### PR TITLE
Add bundled timezone extension

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,3 +26,6 @@ jobs:
 
       - name: Run qalc integration tests
         run: bash tests/qalc-integration-test.sh
+
+      - name: Run timezone integration tests
+        run: bash tests/timezone-integration-test.sh

--- a/Menu.qml
+++ b/Menu.qml
@@ -335,11 +335,11 @@ Item {
     extensionProc.collected = ""
     extensionProc.outputOverflow = false
     var script = "emit_extension() { "
-      + "local file=$1 bundled=$2 raw requirement missing_json; local -a missing=(); "
+      + "local file=$1 bundled=$2 raw requirement missing_json source_dir; local -a missing=(); source_dir=${file%/*}; "
       + "raw=$(jq -c '.' \"$file\" 2>/dev/null) || return; "
       + "while IFS= read -r requirement; do [[ -z $requirement ]] || command -v \"$requirement\" &>/dev/null || missing+=(\"$requirement\"); done < <(jq -r '.requires[]? // empty' <<<\"$raw\"); "
       + "missing_json=$(printf '%s\\n' \"${missing[@]}\" | jq -Rsc 'split(\"\\n\") | map(select(length > 0))'); "
-      + "jq -c --argjson bundled \"$bundled\" --argjson missing \"$missing_json\" '. + {_bundled:$bundled,_missingRequires:$missing}' <<<\"$raw\"; "
+      + "jq -c --argjson bundled \"$bundled\" --argjson missing \"$missing_json\" --arg sourceDir \"$source_dir\" '. + {_bundled:$bundled,_missingRequires:$missing,_sourceDir:$sourceDir}' <<<\"$raw\"; "
       + "}; { shopt -s nullglob; "
       + "for bundled in " + root.shellQuote(root.pluginPath) + "/extensions/*/extension.json; do emit_extension \"$bundled\" true; done; "
       + "declare -A enabled=(); "
@@ -358,7 +358,10 @@ Item {
   }
 
   function isPotentialExtensionQuery(value) {
-    return /^\s*[+-]?(?:\d|\.\d)/.test(String(value || ""))
+    var query = String(value || "")
+    return /^\s*[+-]?(?:\d|\.\d)/.test(query)
+      || MenuModel.queryExtension(root.extensions, query) !== null
+      || MenuModel.unavailableQueryExtension(root.extensions, query) !== null
   }
 
   function scheduleExtensionQuery() {
@@ -1411,7 +1414,7 @@ Item {
       extensionQueryProc.revision = root.extensionQuerySerial
       extensionQueryProc.collected = ""
       extensionQueryProc.outputOverflow = false
-      extensionQueryProc.command = root.commandArguments(extension.command, { query: query })
+      extensionQueryProc.command = root.commandArguments(extension.command, { query: query, extensionDir: extension.sourceDir })
       extensionQueryProc.running = true
       extensionQueryTimeout.restart()
     }

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -356,6 +356,7 @@ function normalizeExtension(raw) {
     command: command,
     priority: Number(raw.priority) || 0,
     bundled: raw._bundled === true,
+    sourceDir: String(raw._sourceDir || ""),
     requires: stringArray(raw.requires),
     missingRequires: stringArray(raw._missingRequires)
   }
@@ -378,6 +379,12 @@ function normalizeExtension(raw) {
       extension.copyFileCommand = stringArray(raw.copyFileCommand)
     }
   } else {
+    extension.prefixes = []
+    var queryPrefixes = Array.isArray(raw.prefixes) ? raw.prefixes : (raw.prefix ? [raw.prefix] : [])
+    for (var p = 0; p < queryPrefixes.length; p++) {
+      var queryPrefix = String(queryPrefixes[p] || "").toLowerCase().trim()
+      if (queryPrefix && extension.prefixes.indexOf(queryPrefix) < 0) extension.prefixes.push(queryPrefix)
+    }
     var match = raw.match || {}
     extension.matchAll = stringArray(match.all)
     extension.matchAny = stringArray(match.any)
@@ -451,7 +458,7 @@ function parseExtensionCatalog(text) {
   var prefixes = ({})
   for (var j = 0; j < resolved.length; j++) {
     var current = resolved[j]
-    if (current.mode !== "prefix") continue
+    if (!current.prefixes || current.prefixes.length === 0) continue
     for (var k = 0; k < current.prefixes.length; k++) {
       var prefix = current.prefixes[k]
       if (prefixes[prefix]) diagnostics.push("Duplicate extension prefix '" + prefix + "': " + prefixes[prefix] + ", " + current.id)
@@ -510,7 +517,7 @@ function suggestExtensions(extensions, query) {
   var values = Array.isArray(extensions) ? extensions : []
   for (var i = 0; i < values.length; i++) {
     var extension = values[i]
-    if (extension.mode !== "prefix" && extension.mode !== "files") continue
+    if (!extension.prefixes || extension.prefixes.length === 0) continue
     for (var j = 0; j < extension.prefixes.length; j++) {
       if (extension.prefixes[j].indexOf(input) !== 0) continue
       suggestions.push({ extension: extension, prefix: extension.prefixes[j] })

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Click the Omalaunch icon to open it. Right-clicking the icon opens a terminal.
 - Run arithmetic, unit conversions, and currency conversions with `qalc`
 - Copy calculation results directly to the clipboard
 - Browse, recursively search, open, and copy paths for local files
+- Look up current times and convert times across DST-aware timezones
 - Accept dmenu-style select and input requests
 - Load extensions contributed by enabled Omarchy plugins
 - Launch agent prompts such as Pi and Codex through optional extensions
@@ -49,6 +50,16 @@ Convert currencies inline using `qalc` exchange-rate data. Press Enter to copy t
 
 ![Currency conversion in Omalaunch](assets/currency-conversion.png)
 
+## Timezones
+
+Type `time` to select the bundled Timezone extension. Look up the current time with queries such as `time seattle` or convert a specific time with `time 9am winnipeg to tokyo`. Dates are optional, city aliases and IANA timezone names are supported, and conversions account for daylight-saving time.
+
+```text
+time seattle
+time 9am winnipeg to tokyo
+time 2026-11-15 8pm new york to london
+```
+
 ## Files
 
 Type `files` and activate the **Files** result to browse from your home directory. Select folders to navigate, type to search recursively within the current folder, and select a file to open it with the default application. Search uses `fd` with fzf's path-aware relevance ranking. Hidden and ignored files are excluded.
@@ -61,7 +72,7 @@ Press Ctrl+K on a selected item to open its Action Panel. Directories can be ope
 
 - A current Omarchy installation with the manifest-based shell plugin system
 - [`libqalculate`](https://qalculate.github.io/) (`qalc`) for calculations and conversions
-- `fd`, `fzf`, `jq`, Bash, and `wl-clipboard` (provided by a standard Omarchy installation)
+- `fd`, `fzf`, `jq`, Python, Bash, and `wl-clipboard` (provided by a standard Omarchy installation)
 
 Install the calculation dependency through Omarchy:
 

--- a/extensions/timezone/aliases.json
+++ b/extensions/timezone/aliases.json
@@ -1,0 +1,22 @@
+{
+  "berlin": "Europe/Berlin",
+  "chicago": "America/Chicago",
+  "denver": "America/Denver",
+  "honolulu": "Pacific/Honolulu",
+  "la": "America/Los_Angeles",
+  "london": "Europe/London",
+  "los angeles": "America/Los_Angeles",
+  "melbourne": "Australia/Melbourne",
+  "new york": "America/New_York",
+  "new-york": "America/New_York",
+  "nyc": "America/New_York",
+  "paris": "Europe/Paris",
+  "phoenix": "America/Phoenix",
+  "seattle": "America/Los_Angeles",
+  "sydney": "Australia/Sydney",
+  "tokyo": "Asia/Tokyo",
+  "toronto": "America/Toronto",
+  "utc": "UTC",
+  "vancouver": "America/Vancouver",
+  "winnipeg": "America/Winnipeg"
+}

--- a/extensions/timezone/convert-timezone.py
+++ b/extensions/timezone/convert-timezone.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import re
+import sys
+from datetime import date, datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError, available_timezones
+
+
+def normalize(value):
+    return re.sub(r"\s+", " ", value.strip().lower().replace("_", " "))
+
+
+def load_aliases():
+    path = Path(__file__).with_name("aliases.json")
+    with path.open(encoding="utf-8") as handle:
+        return {normalize(key): value for key, value in json.load(handle).items()}
+
+
+def local_zone_name():
+    configured = os.environ.get("TZ", "").strip()
+    if configured:
+        return configured
+    try:
+        target = Path("/etc/localtime").resolve()
+        marker = "/usr/share/zoneinfo/"
+        if marker in str(target):
+            return str(target).split(marker, 1)[1]
+    except OSError:
+        pass
+    try:
+        value = Path("/etc/timezone").read_text(encoding="utf-8").strip()
+        if value:
+            return value
+    except OSError:
+        pass
+    return "UTC"
+
+
+def zone_index():
+    zones = sorted(available_timezones())
+    exact = {zone.lower(): zone for zone in zones}
+    cities = {}
+    ambiguous = set()
+    for zone in zones:
+        city = normalize(zone.rsplit("/", 1)[-1])
+        if city in cities and cities[city] != zone:
+            ambiguous.add(city)
+        else:
+            cities[city] = zone
+    for city in ambiguous:
+        cities.pop(city, None)
+    return exact, cities
+
+
+ALIASES = load_aliases()
+EXACT_ZONES, CITY_ZONES = zone_index()
+
+
+def resolve_zone(value):
+    key = normalize(value)
+    zone_name = ALIASES.get(key) or EXACT_ZONES.get(value.strip().lower()) or CITY_ZONES.get(key)
+    if not zone_name:
+        raise ValueError(f"Unknown timezone: {value.strip()}")
+    try:
+        return ZoneInfo(zone_name), zone_name
+    except ZoneInfoNotFoundError:
+        raise ValueError(f"Timezone data unavailable: {zone_name}")
+
+
+def parse_clock(value):
+    compact = re.sub(r"\s+", "", value).upper()
+    formats = ["%I%p", "%I:%M%p"] if compact.endswith(("AM", "PM")) else ["%H:%M", "%H"]
+    for pattern in formats:
+        try:
+            return datetime.strptime(compact, pattern).time()
+        except ValueError:
+            pass
+    raise ValueError(f"Invalid time: {value}")
+
+
+def clock(value):
+    return value.strftime("%I:%M %p %Z").lstrip("0")
+
+
+def day(value):
+    return value.strftime("%a, %b %d").replace(" 0", " ")
+
+
+def current_time(place):
+    zone, zone_name = resolve_zone(place)
+    now = datetime.now(zone)
+    return f"{clock(now)} · {day(now)} · {zone_name}"
+
+
+def convert_time(expression):
+    match = re.fullmatch(
+        r"(?:(?P<date>\d{4}-\d{2}-\d{2})\s+)?"
+        r"(?P<time>\d{1,2}(?::\d{2})?\s*(?:am|pm)?)"
+        r"(?:\s+(?P<source>.+?))?\s+to\s+(?P<destination>.+)",
+        expression,
+        flags=re.IGNORECASE,
+    )
+    if not match:
+        raise ValueError("Try: time 9am winnipeg to seattle")
+
+    source_name = match.group("source") or local_zone_name()
+    source_zone, _ = resolve_zone(source_name)
+    destination_zone, destination_name = resolve_zone(match.group("destination"))
+    source_date = date.fromisoformat(match.group("date")) if match.group("date") else datetime.now(source_zone).date()
+    source = datetime.combine(source_date, parse_clock(match.group("time")), source_zone)
+    destination = source.astimezone(destination_zone)
+    return f"{clock(source)} → {clock(destination)} · {day(destination)} · {destination_name}"
+
+
+def main():
+    query = " ".join(sys.argv[1:]).strip()
+    if not re.match(r"^time\s+", query, flags=re.IGNORECASE):
+        raise ValueError("Query must start with: time")
+    expression = re.sub(r"^time\s+", "", query, count=1, flags=re.IGNORECASE).strip()
+    if not expression:
+        raise ValueError("Try: time seattle")
+    return convert_time(expression) if re.search(r"\s+to\s+", expression, flags=re.IGNORECASE) else current_time(expression)
+
+
+try:
+    print(main())
+except (ValueError, ZoneInfoNotFoundError) as error:
+    print(error)

--- a/extensions/timezone/extension.json
+++ b/extensions/timezone/extension.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 1,
+  "id": "omalaunch.timezone",
+  "capability": "timezone",
+  "mode": "query",
+  "label": "Timezone",
+  "prefixes": ["time"],
+  "icon": "󰥔",
+  "description": "Press Enter to copy",
+  "priority": 15,
+  "requires": ["python", "wl-copy"],
+  "match": {
+    "all": ["^time\\s+\\S"]
+  },
+  "command": ["python", "{extensionDir}/convert-timezone.py", "{query}"],
+  "resultCommand": ["wl-copy", "--", "{result}"]
+}

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -127,6 +127,16 @@ assert(menu.queryExtension(bundledExtensions, '2 + 2').capability === 'calculato
 assert(menu.queryExtension(bundledExtensions, '10 USD to CAD').capability === 'currency', 'bundled currency extension outranks general conversions')
 assert(menu.queryExtension(bundledExtensions, 'hello') === null, 'bundled extensions ignore ordinary searches')
 
+const timezoneExtension = menu.parseExtensions(JSON.stringify([{
+  ...JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'extensions', 'timezone', 'extension.json'), 'utf8')),
+  _bundled: true,
+  _sourceDir: '/tmp/timezone'
+}]))
+assert(menu.suggestExtensions(timezoneExtension, 'tim')[0].prefix === 'time', 'live query extensions can suggest prefixes')
+assert(menu.queryExtension(timezoneExtension, 'time seattle').capability === 'timezone', 'timezone extension matches explicit time queries')
+assert(menu.queryExtension(timezoneExtension, 'timer') === null, 'timezone extension ignores unrelated searches')
+assert(timezoneExtension[0].sourceDir === '/tmp/timezone', 'extension source directories are retained for bundled scripts')
+
 const unavailableCatalog = menu.parseExtensionCatalog(JSON.stringify([
   {
     schemaVersion: 1,

--- a/tests/timezone-integration-test.sh
+++ b/tests/timezone-integration-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+converter="$root/extensions/timezone/convert-timezone.py"
+
+assert_contains() {
+  local query="$1" expected="$2" actual
+  actual=$(python "$converter" "$query")
+  [[ $actual == *"$expected"* ]] || {
+    printf 'not ok - %s\n  expected to contain: %s\n  actual: %s\n' "$query" "$expected" "$actual" >&2
+    exit 1
+  }
+  printf 'ok - %s => %s\n' "$query" "$actual"
+}
+
+assert_contains "time seattle" "America/Los_Angeles"
+assert_contains "time 2026-01-15 9am winnipeg to seattle" "7:00 AM PST"
+assert_contains "time 2026-11-15 8pm new york to london" "Mon, Nov 16"
+assert_contains "time nowhereville" "Unknown timezone: nowhereville"


### PR DESCRIPTION
## Summary
- add a bundled, replaceable timezone extension
- support current-time lookups and DST-aware conversions
- suggest the `time` prefix and support city aliases plus IANA timezone names
- add integration tests and README documentation

## Test plan
- `node tests/menu-model-test.js`
- `bash tests/manifest-test.sh`
- `bash tests/qalc-integration-test.sh`
- `bash tests/timezone-integration-test.sh`