### PR TITLE
Sort file browser entries by recency

### DIFF
--- a/Menu.qml
+++ b/Menu.qml
@@ -1366,10 +1366,10 @@ Item {
       var needle = root.filterText.trim()
       var sourceCommand = needle
         ? "fd --color never --absolute-path --print0 --type file --type directory . \"$base\" 2>/dev/null | fzf --read0 --print0 --filter=\"$needle\" --scheme=path --tiebreak=begin,length --no-multi-line"
-        : "fd --color never --absolute-path --print0 --type file --type directory --max-depth 1 . \"$base\" 2>/dev/null"
+        : "fd --color never --absolute-path --print0 --type file --type directory --max-depth 1 . \"$base\" 2>/dev/null -X stat --printf '%Y\\t%n\\0' | sort -z -t $'\\t' -k1,1nr"
       var script = "base=" + root.shellQuote(base) + "; needle=" + root.shellQuote(needle) + "; count=0; "
         + "while IFS= read -r -d '' entry && (( count < 100 )); do "
-        + "clean=${entry%/}; [[ -d $clean ]] && type=directory || type=file; name=${clean##*/}; "
+        + "[[ -n $needle ]] || entry=${entry#*$'\\t'}; clean=${entry%/}; [[ -d $clean ]] && type=directory || type=file; name=${clean##*/}; "
         + "jq -cn --arg path \"$clean\" --arg name \"$name\" --arg type \"$type\" '{path:$path,name:$name,type:$type}'; "
         + "count=$((count + 1)); done < <(" + sourceCommand + ")"
       fileScanProc.revision = root.fileScanSerial
@@ -1399,10 +1399,6 @@ Item {
           try { entries.push(JSON.parse(lines[i])) } catch (e) {}
         }
       }
-      if (!fileScanProc.query) entries.sort(function(a, b) {
-        if (a.type !== b.type) return a.type === "directory" ? -1 : 1
-        return a.name.toLowerCase().localeCompare(b.name.toLowerCase())
-      })
       root.fileEntries = entries
       root.rebuildFileDisplay()
     }

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ time 2026-11-15 8pm new york to london
 
 ## Files
 
-Type `files` and activate the **Files** result to browse from your home directory. Select folders to navigate, type to search recursively within the current folder, and select a file to open it with the default application. Supported image files show thumbnails in the result list and a larger preview pane when selected. Search uses `fd` with fzf's path-aware relevance ranking. Hidden and ignored files are excluded.
+Type `files` and activate the **Files** result to browse from your home directory. Select folders to navigate, type to search recursively within the current folder, and select a file to open it with the default application. Supported image files show thumbnails in the result list and a larger preview pane when selected. Directory contents are ordered by most recently modified, while search uses `fd` with fzf's path-aware relevance ranking. Hidden and ignored files are excluded.
 
 Press Ctrl+K on a selected item to open its Action Panel. Directories can be opened in Files or a terminal; files can be opened with their default application. Every item supports copying its path or copying the item to the file clipboard. Ctrl+C remains a shortcut for copying the selected path.
 


### PR DESCRIPTION
## Summary
- sort directory contents by modification time with newest entries first
- preserve fzf path-relevance ordering while searching
- document the default file ordering

## Testing
- `node tests/menu-model-test.js`
- `bash tests/manifest-test.sh`
- manually tested in Omarchy Shell