### PR TITLE
Document shell restart after plugin updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,12 @@ Favorites and usage data are stored in the user's state directory. Currency refr
 
 ```bash
 omarchy plugin update quantumfire.omalaunch
+omarchy restart shell
 ```
+
+Restart the shell after updating so the running QML engine does not continue
+using cached plugin code. This works around an upstream Omarchy hot-reload
+issue until plugin rescans reliably load changed QML.
 
 ## Removal
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -73,8 +73,11 @@ After publishing:
 
    ```bash
    omarchy plugin update quantumfire.omalaunch
+   omarchy restart shell
    ```
 
+   The restart ensures the smoke test uses the updated QML rather than a stale
+   component cached by the running shell.
 4. Open Omalaunch and smoke-test the primary launcher and extension flows.
 
 If a release is broken, fix it with a new patch release. Do not move or replace


### PR DESCRIPTION
## Summary

- restart the Omarchy shell after updating Omalaunch
- explain that this avoids stale QML component caching
- include the restart in release verification

## Verification

- `git diff --check`

Upstream context: basecamp/omarchy#6981