### PR TITLE
Add explicit calculator dependency onboarding

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -133,4 +133,6 @@ Commands are argument arrays. Omalaunch substitutes placeholders and shell-quote
 
 Missing dependencies leave an extension visible but unavailable with a clear message; its command cannot be activated. Omalaunch logs diagnostics for malformed definitions, unsupported schemas, duplicate IDs or prefixes, invalid regular expressions, and missing dependencies.
 
+The `requires` field declares executable requirements only. It does not authorize package installation, and external extensions cannot provide commands for Omalaunch to install system packages. Omalaunch may offer explicit installation only for dependencies in its own trusted allow-list, after showing the exact command and receiving user confirmation.
+
 Malformed extensions are ignored. Omarchy plugins are trusted local software and extension commands run as the current user.

--- a/Menu.qml
+++ b/Menu.qml
@@ -390,6 +390,9 @@ Item {
     root.resultExtension = MenuModel.queryExtension(root.extensions, query)
     root.unavailableResultExtension = MenuModel.unavailableQueryExtension(root.extensions, query)
     if (root.resultExtension) extensionQueryTimer.start()
+    // Available queries rebuild when their process exits. Unavailable queries
+    // start no process, so surface their actionable row immediately.
+    else if (root.unavailableResultExtension) root.rebuildDisplay()
   }
 
   function extensionById(id) {

--- a/Menu.qml
+++ b/Menu.qml
@@ -1007,6 +1007,18 @@ Item {
       }
 
       if (active === "root") {
+        var setupExtension = MenuModel.firstSetupExtension(root.extensions)
+        if (setupExtension) {
+          var dependencySetup = MenuModel.dependencySetup(setupExtension)
+          var setupItem = root.normalizeItem("dependency.setup." + setupExtension.id, {
+            icon: setupExtension.icon,
+            iconFont: setupExtension.iconFont,
+            label: "Enable Calculator & Currency",
+            description: "Install " + dependencySetup.packageName + " · Press Enter to review"
+          })
+          rows.push(root.displayRow(setupItem, setupItem.description, -1))
+        }
+
         rows.sort(function(a, b) {
           if (a.itemId === "omarchy" || b.itemId === "omarchy") return a.itemId === "omarchy" ? -1 : 1
           var aLabel = String(a.label || "").toLowerCase()
@@ -1146,6 +1158,12 @@ Item {
     var row = displayModel.get(index)
     if (root.actionPanelActive && row.itemId.indexOf("file.action.") === 0) {
       root.activateFileAction(row.action)
+      return
+    }
+    if (row.itemId.indexOf("dependency.setup.") === 0) {
+      var setupExtension = root.extensionById(row.itemId.substring("dependency.setup.".length))
+      root.dependencyTarget = MenuModel.dependencySetup(setupExtension)
+      root.dependencyConfirmOpen = root.dependencyTarget !== null
       return
     }
     if (row.itemId.indexOf("extension.unavailable.") === 0) {

--- a/Menu.qml
+++ b/Menu.qml
@@ -109,9 +109,16 @@ Item {
   // removal), owned by the shell and also used by the standalone launcher.
   readonly property var appLibrary: root.shell ? root.shell.appLibrary : null
   property bool deleteConfirmOpen: false
+  property bool dependencyConfirmOpen: false
   property string pendingStarSelectionId: ""
   property var deleteTarget: null
-  onOpenedChanged: if (!opened) { deleteConfirmOpen = false; deleteTarget = null }
+  property var dependencyTarget: null
+  onOpenedChanged: if (!opened) {
+    deleteConfirmOpen = false
+    deleteTarget = null
+    dependencyConfirmOpen = false
+    dependencyTarget = null
+  }
   // Bound to the central [menu] section in shell.toml via Color.qml.
   // Each color already includes its alpha companion (composed in the
   // singleton), so consumers can drop them straight into a Rectangle.
@@ -934,7 +941,7 @@ Item {
         var suggestedExtension = suggestion.extension
         var suggestionDetail = suggestedExtension.available
           ? suggestedExtension.description
-          : "Missing dependency: " + suggestedExtension.missingRequires.join(", ")
+          : MenuModel.unavailableExtensionDetail(suggestedExtension)
         var suggestionId = suggestedExtension.available ? "extension.prepare." : "extension.unavailable."
         var suggestionItem = root.normalizeItem(suggestionId + suggestedExtension.id, {
           icon: suggestedExtension.icon,
@@ -952,7 +959,7 @@ Item {
         var extension = extensionMatch.extension
         var extensionDetail = extension.available
           ? extension.description
-          : "Missing dependency: " + extension.missingRequires.join(", ")
+          : MenuModel.unavailableExtensionDetail(extension)
         var extensionId = extension.available ? "extension." : "extension.unavailable."
         var extensionItem = root.normalizeItem(extensionId + extension.id, {
           icon: extension.icon,
@@ -965,7 +972,7 @@ Item {
       }
 
       if (root.unavailableResultExtension) {
-        var unavailableDetail = "Missing dependency: " + root.unavailableResultExtension.missingRequires.join(", ")
+        var unavailableDetail = MenuModel.unavailableExtensionDetail(root.unavailableResultExtension)
         var unavailableItem = root.normalizeItem("extension.unavailable." + root.unavailableResultExtension.id, {
           icon: root.unavailableResultExtension.icon,
           iconFont: root.unavailableResultExtension.iconFont,
@@ -1141,7 +1148,15 @@ Item {
       root.activateFileAction(row.action)
       return
     }
-    if (row.itemId.indexOf("extension.unavailable.") === 0) return
+    if (row.itemId.indexOf("extension.unavailable.") === 0) {
+      var unavailableExtension = root.extensionById(row.itemId.substring("extension.unavailable.".length))
+      var setup = MenuModel.dependencySetup(unavailableExtension)
+      if (setup) {
+        root.dependencyTarget = setup
+        root.dependencyConfirmOpen = true
+      }
+      return
+    }
     if (row.itemId.indexOf("extension.prepare.") === 0) {
       var preparedExtension = root.extensionById(row.itemId.substring("extension.prepare.".length))
       if (preparedExtension && preparedExtension.mode === "files") root.enterFileBrowser(preparedExtension)
@@ -1179,6 +1194,28 @@ Item {
     } else {
       root.applySelected(row.itemId, row.action)
     }
+  }
+
+  function cancelDependencyInstall() {
+    root.dependencyConfirmOpen = false
+    root.dependencyTarget = null
+    Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+  }
+
+  function confirmDependencyInstall() {
+    var setup = root.dependencyTarget
+    root.dependencyConfirmOpen = false
+    root.dependencyTarget = null
+    if (!setup) return
+
+    // Close the exclusive-focus launcher before opening the visible terminal.
+    // --hold preserves package-manager output after success, failure, or
+    // cancellation. Reopening Omalaunch performs a fresh extension check.
+    root.opened = false
+    root.runAction(root.shellCommand(
+      ["xdg-terminal-exec", "--hold", "--"].concat(setup.installCommand),
+      {}
+    ))
   }
 
   function toggleSelectedStar() {
@@ -1672,13 +1709,17 @@ Item {
       Item {
         id: keyCatcher
         anchors.fill: parent
-        z: root.deleteConfirmOpen ? 20 : 0
+        z: (root.deleteConfirmOpen || root.dependencyConfirmOpen) ? 20 : 0
         focus: true
 
         Keys.priority: Keys.BeforeItem
         Keys.onPressed: function(event) {
           if (root.deleteConfirmOpen) {
             if (deleteConfirm.handleKey(event)) event.accepted = true
+            return
+          }
+          if (root.dependencyConfirmOpen) {
+            if (dependencyConfirm.handleKey(event)) event.accepted = true
             return
           }
 
@@ -1757,6 +1798,30 @@ Item {
           cornerRadius: root.cornerRadius
           onCanceled: root.cancelDelete()
           onConfirmed: root.confirmDelete()
+        }
+
+        ConfirmDialog {
+          id: dependencyConfirm
+
+          anchors.fill: parent
+          opened: root.dependencyConfirmOpen
+          z: 11
+          message: root.dependencyTarget
+            ? ("Install " + root.dependencyTarget.packageName + " for " + root.dependencyTarget.reason
+              + "?\n\nCommand: " + root.dependencyTarget.installCommand.join(" ")
+              + "\n\nThe command will run in a visible terminal. Reopen Omalaunch afterward to recheck.")
+            : ""
+          cancelText: "Not now"
+          confirmText: "Install"
+          background: root.background
+          foreground: root.foreground
+          scrim: root.scrim
+          selectedBackground: root.selectedBackground
+          selectedText: root.selectedText
+          fontFamily: root.fontFamily
+          cornerRadius: root.cornerRadius
+          onCanceled: root.cancelDependencyInstall()
+          onConfirmed: root.confirmDependencyInstall()
         }
       }
 

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -324,6 +324,35 @@ function stringArray(value) {
   return result
 }
 
+// Package installation is deliberately allow-listed here rather than read
+// from extension manifests. External plugins may declare executable
+// requirements, but that never authorizes them to install system packages.
+var DEPENDENCY_SETUPS = {
+  qalc: {
+    executable: "qalc",
+    packageName: "libqalculate",
+    reason: "arithmetic, unit conversion, and currency conversion",
+    installCommand: ["omarchy", "pkg", "add", "libqalculate"]
+  }
+}
+
+function dependencySetup(extension) {
+  if (!extension || !extension.bundled) return null
+  var missing = Array.isArray(extension.missingRequires) ? extension.missingRequires : []
+  for (var i = 0; i < missing.length; i++) {
+    var setup = DEPENDENCY_SETUPS[String(missing[i])]
+    if (setup) return setup
+  }
+  return null
+}
+
+function unavailableExtensionDetail(extension) {
+  if (!extension) return ""
+  var setup = dependencySetup(extension)
+  if (setup) return "Requires " + setup.packageName + " · Press Enter to install"
+  return "Missing dependency: " + extension.missingRequires.join(", ")
+}
+
 // Extension matchers run on the QML UI thread. Reject oversized patterns and
 // the most common nested-quantifier shapes, which can otherwise backtrack for
 // seconds on a short launcher query. This deliberately accepts a conservative
@@ -799,6 +828,8 @@ if (typeof module !== "undefined") {
     nameSearchText: nameSearchText,
     termInSearchWords: termInSearchWords,
     descriptionTextMatches: descriptionTextMatches,
+    dependencySetup: dependencySetup,
+    unavailableExtensionDetail: unavailableExtensionDetail,
     safeExtensionPattern: safeExtensionPattern,
     normalizeExtension: normalizeExtension,
     resolveExtensions: resolveExtensions,

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -353,6 +353,13 @@ function unavailableExtensionDetail(extension) {
   return "Missing dependency: " + extension.missingRequires.join(", ")
 }
 
+function firstSetupExtension(extensions) {
+  var values = Array.isArray(extensions) ? extensions : []
+  for (var i = 0; i < values.length; i++)
+    if (!values[i].available && dependencySetup(values[i])) return values[i]
+  return null
+}
+
 // Extension matchers run on the QML UI thread. Reject oversized patterns and
 // the most common nested-quantifier shapes, which can otherwise backtrack for
 // seconds on a short launcher query. This deliberately accepts a conservative
@@ -830,6 +837,7 @@ if (typeof module !== "undefined") {
     descriptionTextMatches: descriptionTextMatches,
     dependencySetup: dependencySetup,
     unavailableExtensionDetail: unavailableExtensionDetail,
+    firstSetupExtension: firstSetupExtension,
     safeExtensionPattern: safeExtensionPattern,
     normalizeExtension: normalizeExtension,
     resolveExtensions: resolveExtensions,

--- a/README.md
+++ b/README.md
@@ -12,9 +12,15 @@ Omalaunch keeps the familiar Omarchy command tree while adding fast global searc
 omarchy plugin add https://github.com/daniellemky/omalaunch --enable
 ```
 
-Enabling Omalaunch replaces Omarchy’s default clickable launcher icon and routes the existing Super+Space shortcut to Omalaunch. Disabling or removing the plugin restores the default Omarchy launcher.
+Enabling Omalaunch replaces Omarchy’s default clickable launcher icon and routes the existing Super+Space shortcut to Omalaunch. Disabling or removing the plugin restores the default Omarchy launcher. No calculation dependency needs to be installed before adding the plugin; Omalaunch offers explicit setup from its starting view when needed.
 
 Click the launcher icon or press Super+Space to open Omalaunch. Right-clicking the icon opens a terminal.
+
+Current Omarchy versions may append the replacement launcher after other widgets when an interactive installation asks for a bar section. Until Omarchy preserves the replaced widget’s exact position, move Omalaunch before the workspace widget with:
+
+```bash
+omarchy bar move quantumfire.omalaunch --before quantumfire.workspaces
+```
 
 ## Features
 
@@ -67,7 +73,7 @@ Press Ctrl+K on a selected item to open its Action Panel. Directories can be ope
 ## Requirements
 
 - A current Omarchy installation with the manifest-based shell plugin system
-- [`libqalculate`](https://qalculate.github.io/) (`qalc`) for calculations and conversions
+- [`libqalculate`](https://qalculate.github.io/) (`qalc`) to enable calculations and conversions
 - `fd`, `fzf`, `jq`, Python, Bash, and `wl-clipboard` (provided by a standard Omarchy installation)
 
 Install the calculation dependency through Omarchy:
@@ -135,7 +141,9 @@ omarchy restart shell
 
 Restart the shell after updating so the running QML engine does not continue
 using cached plugin code. This works around an upstream Omarchy hot-reload
-issue until plugin rescans reliably load changed QML.
+issue until plugin rescans reliably load changed QML. The restart reloads
+Omalaunch code and is unrelated to calculation dependencies; installing
+`libqalculate` requires only reopening Omalaunch to recheck it.
 
 ## Disabling and removal
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Install the calculation dependency through Omarchy:
 omarchy pkg add libqalculate
 ```
 
-If it is missing, Calculator and Currency results remain visible but unavailable. Press Enter on one of those results to review the exact command and explicitly confirm opening it in a visible terminal. Reopen Omalaunch afterward to recheck the dependency; no shell restart is required. All unrelated launcher features remain usable.
+If it is missing, the launcher’s starting view shows **Enable Calculator & Currency**. Press Enter to review the exact command and explicitly confirm opening it in a visible terminal. The same setup remains available from unavailable calculation results. Reopen Omalaunch afterward to recheck the dependency; no shell restart is required. All unrelated launcher features remain usable.
 
 Omalaunch never installs system packages silently. Package installation is offered only for dependencies allow-listed by Omalaunch itself; external extensions cannot supply installation commands.
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ Install the calculation dependency through Omarchy:
 omarchy pkg add libqalculate
 ```
 
-Omalaunch does not install system packages automatically.
+If it is missing, Calculator and Currency results remain visible but unavailable. Press Enter on one of those results to review the exact command and explicitly confirm opening it in a visible terminal. Reopen Omalaunch afterward to recheck the dependency; no shell restart is required. All unrelated launcher features remain usable.
+
+Omalaunch never installs system packages silently. Package installation is offered only for dependencies allow-listed by Omalaunch itself; external extensions cannot supply installation commands.
 
 ## Usage
 
@@ -135,13 +137,22 @@ Restart the shell after updating so the running QML engine does not continue
 using cached plugin code. This works around an upstream Omarchy hot-reload
 issue until plugin rescans reliably load changed QML.
 
-## Removal
+## Disabling and removal
+
+Disable or re-enable Omalaunch without removing it:
+
+```bash
+omarchy plugin disable quantumfire.omalaunch
+omarchy plugin enable quantumfire.omalaunch
+```
+
+Remove it completely:
 
 ```bash
 omarchy plugin remove quantumfire.omalaunch
 ```
 
-Removing Omalaunch does not remove its optional extension plugins or system dependencies.
+Disabling or removing Omalaunch restores the stock launcher. Removing Omalaunch does not remove its optional extension plugins, saved state, or system dependencies.
 
 ## Security
 

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -175,7 +175,10 @@ const qalcSetup = menu.dependencySetup(bundledMissingQalc)
 assert(qalcSetup.packageName === 'libqalculate', 'bundled qalc requirements map to libqalculate setup')
 assert(qalcSetup.installCommand.join(' ') === 'omarchy pkg add libqalculate', 'dependency setup exposes the exact supported install command')
 assert(menu.unavailableExtensionDetail(bundledMissingQalc).indexOf('Press Enter to install') >= 0, 'known bundled dependencies are actionable')
+assert(menu.firstSetupExtension([bundledMissingQalc]) === bundledMissingQalc, 'missing bundled dependencies produce a root setup extension')
+assert(menu.firstSetupExtension(bundledExtensions) === null, 'available bundled dependencies do not produce root setup')
 assert(menu.dependencySetup(unavailableCatalog.extensions[0]) === null, 'external extensions cannot authorize package installation')
+assert(menu.firstSetupExtension(unavailableCatalog.extensions) === null, 'external dependencies cannot produce root package setup')
 assert(menu.unavailableExtensionDetail(unavailableCatalog.extensions[0]) === 'Missing dependency: missing-tool', 'unknown dependencies retain diagnostic-only messaging')
 
 const searchTree = {

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -166,6 +166,18 @@ assert(!unavailableCatalog.extensions[0].available, 'missing dependencies mark e
 assert(unavailableCatalog.diagnostics.some(message => message.indexOf('missing-tool') >= 0), 'missing dependencies produce diagnostics')
 assert(unavailableCatalog.diagnostics.some(message => message.indexOf('duplicate extension id') >= 0), 'duplicate extension ids produce diagnostics')
 
+const bundledMissingQalc = menu.parseExtensions(JSON.stringify([{
+  ...JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'extensions', 'calculator', 'extension.json'), 'utf8')),
+  _bundled: true,
+  _missingRequires: ['qalc']
+}]))[0]
+const qalcSetup = menu.dependencySetup(bundledMissingQalc)
+assert(qalcSetup.packageName === 'libqalculate', 'bundled qalc requirements map to libqalculate setup')
+assert(qalcSetup.installCommand.join(' ') === 'omarchy pkg add libqalculate', 'dependency setup exposes the exact supported install command')
+assert(menu.unavailableExtensionDetail(bundledMissingQalc).indexOf('Press Enter to install') >= 0, 'known bundled dependencies are actionable')
+assert(menu.dependencySetup(unavailableCatalog.extensions[0]) === null, 'external extensions cannot authorize package installation')
+assert(menu.unavailableExtensionDetail(unavailableCatalog.extensions[0]) === 'Missing dependency: missing-tool', 'unknown dependencies retain diagnostic-only messaging')
+
 const searchTree = {
   setup: { id: 'setup', parent: 'root' },
   'setup.default': { id: 'setup.default', parent: 'setup' },


### PR DESCRIPTION
## Summary

- surface missing Calculator and Currency setup on the launcher starting view and contextual calculation results
- show the exact `omarchy pkg add libqalculate` command and require explicit confirmation before opening it in a visible held terminal
- keep unrelated launcher features available, recheck dependencies on reopen, and prevent external extensions from authorizing package installation
- document installation, update, disable, removal, and the temporary upstream cloned-widget placement workaround

## Security

- package installation is never silent
- install commands are maintained in an Omalaunch-owned allow-list
- external extension `requires` entries remain diagnostic-only

## Testing

- `node tests/menu-model-test.js`
- `bash tests/manifest-test.sh`
- `bash tests/qalc-integration-test.sh`
- `bash tests/timezone-integration-test.sh`
- manually tested clean removal/restoration, missing-qalc starting-view setup, Not now/Escape, contextual calculator recovery, visible terminal installation, dependency recheck without shell restart, calculation, and clipboard copy

## Upstream note

Current Omarchy interactive plugin installation asks cloned bar widgets for a section and can append the replacement instead of preserving the source widget's exact index. The README includes a temporary `omarchy bar move` workaround while an upstream fix is investigated.
