### PR TITLE
Cache recursive file search candidates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,8 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install --yes jq qalc
+          sudo apt-get install --yes fd-find fzf jq qalc
+          if ! command -v fd >/dev/null; then sudo ln -s "$(command -v fdfind)" /usr/local/bin/fd; fi
 
       - name: Validate manifest
         run: bash tests/manifest-test.sh
@@ -29,3 +30,6 @@ jobs:
 
       - name: Run timezone integration tests
         run: bash tests/timezone-integration-test.sh
+
+      - name: Run file index integration tests
+        run: python tests/file-index-integration-test.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .worktrees/
+__pycache__/
+*.py[cod]

--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -75,7 +75,7 @@ File browser extensions provide navigation, recursive search, opening, and path 
 }
 ```
 
-Ctrl+K opens the contextual Action Panel. `command` opens files, `directoryCommand` opens directories in the file manager, `terminalCommand` opens a terminal, `copyCommand` copies the path, and `copyFileCommand` places a file URI on the clipboard. All command fields support `{path}`. The bundled implementation starts at the home directory, uses `fd` traversal and fzf path ranking, omits hidden and ignored paths, and limits each ranked result set to 100 entries.
+Ctrl+K opens the contextual Action Panel. `command` opens files, `directoryCommand` opens directories in the file manager, `terminalCommand` opens a terminal, `copyCommand` copies the path, and `copyFileCommand` places a file URI on the clipboard. All command fields support `{path}`. The bundled implementation starts at the home directory, uses `fd` traversal and fzf path ranking, omits hidden and ignored paths, and limits each ranked result set to 100 entries. Recursive candidates are indexed once per active directory and reused while typing; the index refreshes after 30 seconds or when navigation changes directories.
 
 ## Live-query extension
 

--- a/Menu.qml
+++ b/Menu.qml
@@ -98,6 +98,17 @@ Item {
   property string fileBrowserPath: ""
   property var fileEntries: []
   property int fileScanSerial: 0
+  readonly property string fileIndexHelper: root.pluginPath + "/extensions/files/file-index.py"
+  readonly property string fileIndexInstanceId: Date.now() + "-" + Math.floor(Math.random() * 1000000000)
+  readonly property string fileIndexPathPrefix: Quickshell.env("XDG_RUNTIME_DIR")
+    ? Quickshell.env("XDG_RUNTIME_DIR") + "/omalaunch-file-index-" + root.fileIndexInstanceId
+    : "/tmp/omalaunch-file-index-" + Quickshell.env("USER") + "-" + root.fileIndexInstanceId
+  property string fileIndexPath: ""
+  property string fileIndexRoot: ""
+  property bool fileIndexReady: false
+  property int fileIndexSerial: 0
+  property double fileIndexBuiltAt: 0
+  readonly property int fileIndexTtlMs: 30 * 1000
   property string fileCopyFeedbackPath: ""
   property string fileCopyFeedback: ""
   property bool actionPanelActive: false
@@ -412,6 +423,7 @@ Item {
 
   function enterFileBrowser(extension) {
     if (!extension || !extension.available) return
+    root.resetFileIndex()
     root.fileBrowserActive = true
     root.fileBrowserExtension = extension
     root.fileBrowserPath = extension.root === "~" ? Quickshell.env("HOME") : extension.root
@@ -423,6 +435,7 @@ Item {
   }
 
   function leaveFileBrowser() {
+    root.resetFileIndex()
     root.actionPanelActive = false
     root.actionPanelFile = null
     root.fileBrowserActive = false
@@ -440,10 +453,57 @@ Item {
     return slash <= 0 ? "/" : value.substring(0, slash)
   }
 
-  function scheduleFileScan() {
+  function removeFileIndex(path) {
+    if (path) Quickshell.execDetached(["rm", "-f", "--", path])
+  }
+
+  function resetFileIndex() {
+    root.fileIndexSerial += 1
+    root.removeFileIndex(root.fileIndexPath)
+    root.fileIndexPath = ""
+    root.fileIndexRoot = ""
+    root.fileIndexReady = false
+    root.fileIndexBuiltAt = 0
+    if (fileIndexProc.running && !fileIndexProc.stopping) {
+      fileIndexProc.stopping = true
+      fileIndexProc.running = false
+    }
+  }
+
+  function startFileIndex(path) {
+    // Process command and metadata must stay immutable until onExited. Keep a
+    // build for the requested root alive while typing; only a different root
+    // is allowed to stop it.
+    if (fileIndexProc.running || fileIndexProc.stopping) {
+      if (fileIndexProc.indexRoot === path) return
+      if (fileIndexProc.running && !fileIndexProc.stopping) {
+        fileIndexProc.stopping = true
+        fileIndexProc.running = false
+      }
+      return
+    }
+    root.removeFileIndex(root.fileIndexPath)
+    root.fileIndexSerial += 1
+    root.fileIndexPath = root.fileIndexPathPrefix + "-" + root.fileIndexSerial + ".nul"
+    root.fileIndexRoot = path
+    root.fileIndexReady = false
+    root.fileIndexBuiltAt = 0
+    fileIndexProc.revision = root.fileIndexSerial
+    fileIndexProc.indexRoot = path
+    fileIndexProc.indexPath = root.fileIndexPath
+    fileIndexProc.command = ["python", root.fileIndexHelper, "index", path, fileIndexProc.indexPath]
+    fileIndexProc.running = true
+  }
+
+  function scheduleFileScan(immediate) {
     root.fileScanSerial += 1
+    fileScanTimer.interval = immediate === true ? 0 : 120
     fileScanTimer.restart()
-    if (fileScanProc.running) fileScanProc.running = false
+    if (fileScanProc.running && !fileScanProc.stopping) {
+      fileScanProc.stopping = true
+      fileScanProc.running = false
+    }
+    if (root.fileIndexRoot && root.fileIndexRoot !== root.fileBrowserPath) root.resetFileIndex()
   }
 
   function rebuildFileDisplay() {
@@ -555,6 +615,7 @@ Item {
     var shellAction = root.shellCommand(commandToRun, { path: path })
     root.actionPanelActive = false
     root.fileBrowserActive = false
+    root.resetFileIndex()
     root.opened = false
     root.runAction(shellAction)
   }
@@ -1205,6 +1266,7 @@ Item {
         var openCommand = root.shellCommand(root.fileBrowserExtension.command, { path: row.action })
         root.fileBrowserActive = false
         root.fileBrowserExtension = null
+        root.resetFileIndex()
         root.applySerial = root.requestSerial
         root.opened = false
         root.runAction(openCommand)
@@ -1300,6 +1362,7 @@ Item {
 
   function cancel() {
     if (root.dmenuActive) root.finishRequest(null)
+    root.resetFileIndex()
     root.actionPanelActive = false
     root.actionPanelFile = null
     root.fileBrowserActive = false
@@ -1441,23 +1504,56 @@ Item {
     interval: 120
     repeat: false
     onTriggered: {
-      if (!root.fileBrowserActive || !root.fileBrowserPath) return
+      if (!root.fileBrowserActive || !root.fileBrowserPath || fileScanProc.stopping) return
       var base = root.fileBrowserPath
       var needle = root.filterText.trim()
-      var sourceCommand = needle
-        ? "fd --color never --absolute-path --print0 --type file --type directory . \"$base\" 2>/dev/null | fzf --read0 --print0 --filter=\"$needle\" --scheme=path --tiebreak=begin,length --no-multi-line"
-        : "fd --color never --absolute-path --print0 --type file --type directory --max-depth 1 . \"$base\" 2>/dev/null -X stat --printf '%Y\\t%n\\0' | sort -z -t $'\\t' -k1,1nr"
-      var script = "base=" + root.shellQuote(base) + "; needle=" + root.shellQuote(needle) + "; count=0; "
-        + "while IFS= read -r -d '' entry && (( count < 100 )); do "
-        + "[[ -n $needle ]] || entry=${entry#*$'\\t'}; clean=${entry%/}; [[ -d $clean ]] && type=directory || type=file; name=${clean##*/}; "
-        + "jq -cn --arg path \"$clean\" --arg name \"$name\" --arg type \"$type\" '{path:$path,name:$name,type:$type}'; "
-        + "count=$((count + 1)); done < <(" + sourceCommand + ")"
+
+      if (needle) {
+        var stale = root.fileIndexBuiltAt > 0
+          && Date.now() - root.fileIndexBuiltAt >= root.fileIndexTtlMs
+        if (root.fileIndexRoot !== base || !root.fileIndexReady || stale) {
+          root.startFileIndex(base)
+          return
+        }
+      }
+
       fileScanProc.revision = root.fileScanSerial
       fileScanProc.scanPath = base
       fileScanProc.query = needle
       fileScanProc.collected = ""
-      fileScanProc.command = ["bash", "-lc", script]
+      fileScanProc.outputOverflow = false
+      fileScanProc.command = needle
+        ? ["python", root.fileIndexHelper, "query", root.fileIndexPath, needle]
+        : ["python", root.fileIndexHelper, "browse", base]
       fileScanProc.running = true
+    }
+  }
+
+  Process {
+    id: fileIndexProc
+    property int revision: 0
+    property string indexRoot: ""
+    property string indexPath: ""
+    property bool stopping: false
+    onExited: function(exitCode) {
+      var stale = fileIndexProc.stopping
+        || fileIndexProc.revision !== root.fileIndexSerial
+        || fileIndexProc.indexRoot !== root.fileBrowserPath
+      fileIndexProc.stopping = false
+      if (stale) {
+        root.removeFileIndex(fileIndexProc.indexPath)
+        if (root.fileBrowserActive && root.filterText.trim())
+          Qt.callLater(function() { root.scheduleFileScan(true) })
+        return
+      }
+      root.fileIndexReady = exitCode === 0
+      root.fileIndexBuiltAt = root.fileIndexReady ? Date.now() : 0
+      if (!root.fileIndexReady) {
+        root.removeFileIndex(fileIndexProc.indexPath)
+        if (root.fileIndexPath === fileIndexProc.indexPath) root.fileIndexPath = ""
+      }
+      if (root.fileIndexReady && root.fileBrowserActive && root.filterText.trim())
+        Qt.callLater(function() { root.scheduleFileScan(true) })
     }
   }
 
@@ -1467,12 +1563,23 @@ Item {
     property string scanPath: ""
     property string query: ""
     property string collected: ""
-    stdout: SplitParser { onRead: function(data) { fileScanProc.collected += data + "\n" } }
+    property bool outputOverflow: false
+    property bool stopping: false
+    stdout: SplitParser { onRead: function(data) { root.collectBounded(fileScanProc, data) } }
     onExited: function(exitCode) {
-      if (fileScanProc.revision !== root.fileScanSerial || !root.fileBrowserActive) return
-      if (fileScanProc.scanPath !== root.fileBrowserPath || fileScanProc.query !== root.filterText.trim()) return
+      var stale = fileScanProc.stopping
+        || fileScanProc.revision !== root.fileScanSerial
+        || !root.fileBrowserActive
+        || fileScanProc.scanPath !== root.fileBrowserPath
+        || fileScanProc.query !== root.filterText.trim()
+      fileScanProc.stopping = false
+      if (stale) {
+        if (root.fileBrowserActive)
+          Qt.callLater(function() { root.scheduleFileScan(true) })
+        return
+      }
       var entries = []
-      if (exitCode === 0) {
+      if (exitCode === 0 && !fileScanProc.outputOverflow) {
         var lines = fileScanProc.collected.split("\n")
         for (var i = 0; i < lines.length; i++) {
           if (!lines[i].trim()) continue
@@ -1717,6 +1824,8 @@ Item {
       if (root.guardsPending) Qt.callLater(function() { root.evaluateGuards(root.guardsForcePending) })
     }
   }
+  Component.onDestruction: root.resetFileIndex()
+
   PanelWindow {
     id: panel
     visible: root.opened && root.rowsLoaded

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ time 2026-11-15 8pm new york to london
 
 ## Files
 
-Type `files` and activate the **Files** result to browse from your home directory. Select folders to navigate, type to search recursively within the current folder, and select a file to open it with the default application. Supported image files show thumbnails in the result list and a larger preview pane when selected. Directory contents are ordered by most recently modified, while search uses `fd` with fzf's path-aware relevance ranking. Hidden and ignored files are excluded.
+Type `files` and activate the **Files** result to browse from your home directory. Select folders to navigate, type to search recursively within the current folder, and select a file to open it with the default application. Supported image files show thumbnails in the result list and a larger preview pane when selected. Directory contents are ordered by most recently modified, while search uses `fd` with fzf's path-aware relevance ranking. A short-lived per-directory index is reused while typing so each query does not traverse the filesystem again. Hidden and ignored files are excluded.
 
 Press Ctrl+K on a selected item to open its Action Panel. Directories can be opened in Files or a terminal; files can be opened with their default application. Every item supports copying its path or copying the item to the file clipboard. Ctrl+C remains a shortcut for copying the selected path.
 
@@ -192,6 +192,8 @@ Run the tests with:
 node tests/menu-model-test.js
 bash tests/manifest-test.sh
 bash tests/qalc-integration-test.sh
+bash tests/timezone-integration-test.sh
+python tests/file-index-integration-test.py
 ```
 
 The integration test requires `qalc`.

--- a/extensions/files/file-index.py
+++ b/extensions/files/file-index.py
@@ -161,7 +161,6 @@ def query(index_path: str, needle: str) -> int:
                 f"--filter={needle}",
                 "--scheme=path",
                 "--tiebreak=begin,length",
-                "--no-multi-line",
             ],
             stdin=index,
             stdout=subprocess.PIPE,

--- a/extensions/files/file-index.py
+++ b/extensions/files/file-index.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Build and query the temporary file index used by Omalaunch."""
+
+from __future__ import annotations
+
+import heapq
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+from typing import BinaryIO
+
+MAX_RESULTS = 100
+_child: subprocess.Popen[bytes] | None = None
+
+
+def _stop_child(_signum: int, _frame: object) -> None:
+    if _child is not None and _child.poll() is None:
+        _child.terminate()
+    raise SystemExit(130)
+
+
+signal.signal(signal.SIGTERM, _stop_child)
+signal.signal(signal.SIGINT, _stop_child)
+
+
+def _nul_records(stream: BinaryIO) -> Iterator[bytes]:
+    pending = b""
+    while True:
+        chunk = stream.read(64 * 1024)
+        if not chunk:
+            break
+        parts = (pending + chunk).split(b"\0")
+        pending = parts.pop()
+        yield from parts
+    if pending:
+        yield pending
+
+
+def _entry(raw_path: bytes) -> dict[str, str] | None:
+    path = os.fsdecode(raw_path).rstrip("/")
+    if not path:
+        return None
+    return {
+        "path": path,
+        "name": os.path.basename(path),
+        "type": "directory" if os.path.isdir(path) else "file",
+    }
+
+
+def _emit(raw_paths: Iterator[bytes]) -> None:
+    emitted = 0
+    for raw_path in raw_paths:
+        entry = _entry(raw_path)
+        if entry is None:
+            continue
+        # ensure_ascii keeps arbitrary Linux filenames representable as one
+        # UTF-8-safe JSON line, including names containing literal newlines.
+        print(json.dumps(entry, ensure_ascii=True, separators=(",", ":")))
+        emitted += 1
+        if emitted >= MAX_RESULTS:
+            break
+
+
+def _fd_command(root: str, *, max_depth: int | None = None) -> list[str]:
+    command = [
+        "fd",
+        "--color",
+        "never",
+        "--absolute-path",
+        "--print0",
+        "--type",
+        "file",
+        "--type",
+        "directory",
+    ]
+    if max_depth is not None:
+        command.extend(["--max-depth", str(max_depth)])
+    command.extend([".", root])
+    return command
+
+
+def build_index(root: str, output_path: str) -> int:
+    global _child
+
+    output = Path(output_path)
+    output.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f"{output.name}.tmp-",
+        dir=output.parent,
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as destination:
+            _child = subprocess.Popen(
+                _fd_command(root),
+                stdout=destination,
+                stderr=subprocess.DEVNULL,
+            )
+            exit_code = _child.wait()
+        _child = None
+        if exit_code != 0:
+            return exit_code
+        os.replace(temporary, output)
+        return 0
+    finally:
+        _child = None
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def browse(root: str) -> int:
+    global _child
+
+    _child = subprocess.Popen(
+        _fd_command(root, max_depth=1),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    assert _child.stdout is not None
+    rows: list[tuple[float, bytes]] = []
+    for raw_path in _nul_records(_child.stdout):
+        try:
+            modified_at = os.stat(raw_path.rstrip(b"/"), follow_symlinks=False).st_mtime
+        except OSError:
+            continue
+        row = (modified_at, raw_path)
+        if len(rows) < MAX_RESULTS:
+            heapq.heappush(rows, row)
+        elif row > rows[0]:
+            heapq.heapreplace(rows, row)
+    exit_code = _child.wait()
+    _child = None
+    if exit_code != 0:
+        return exit_code
+    rows.sort(reverse=True)
+    _emit(iter(raw_path for _, raw_path in rows))
+    return 0
+
+
+def query(index_path: str, needle: str) -> int:
+    global _child
+
+    try:
+        index = open(index_path, "rb")
+    except OSError:
+        return 2
+
+    with index:
+        _child = subprocess.Popen(
+            [
+                "fzf",
+                "--read0",
+                "--print0",
+                f"--filter={needle}",
+                "--scheme=path",
+                "--tiebreak=begin,length",
+                "--no-multi-line",
+            ],
+            stdin=index,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+        assert _child.stdout is not None
+        _emit(_nul_records(_child.stdout))
+        # fzf may still be writing matches after the first 100. Closing its
+        # pipe lets it stop without forcing Python to materialize every match.
+        _child.stdout.close()
+        if _child.poll() is None:
+            _child.terminate()
+        exit_code = _child.wait()
+    _child = None
+    # fzf uses 1 for a valid query with no matches. Once the display limit is
+    # reached it exits through either our SIGTERM or SIGPIPE from the closed
+    # output pipe; both are successful query outcomes.
+    return 0 if exit_code in (0, 1, -signal.SIGTERM, -signal.SIGPIPE) else exit_code
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        print("usage: file-index.py <index|browse|query> ...", file=sys.stderr)
+        return 2
+
+    mode = argv[1]
+    if mode == "index" and len(argv) == 4:
+        return build_index(argv[2], argv[3])
+    if mode == "browse" and len(argv) == 3:
+        return browse(argv[2])
+    if mode == "query" and len(argv) == 4:
+        return query(argv[2], argv[3])
+
+    print(f"invalid arguments for {mode}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/file-index-integration-test.py
+++ b/tests/file-index-integration-test.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+HELPER = ROOT / "extensions" / "files" / "file-index.py"
+
+
+def run(*arguments: str) -> list[dict[str, str]]:
+    result = subprocess.run(
+        ["python", str(HELPER), *arguments],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [json.loads(line) for line in result.stdout.splitlines() if line]
+
+
+with tempfile.TemporaryDirectory() as temporary:
+    workspace = Path(temporary)
+    files = workspace / "files"
+    files.mkdir()
+    alpha = files / "Alpha"
+    beta = files / "Beta"
+    alpha.mkdir()
+    beta.mkdir()
+    (alpha / "report final.txt").write_text("report", encoding="utf-8")
+    (beta / "notes.txt").write_text("notes", encoding="utf-8")
+    (files / ".hidden.txt").write_text("hidden", encoding="utf-8")
+    strange = alpha / "strange\nname.txt"
+    strange.write_text("newline", encoding="utf-8")
+    os.utime(alpha, (100, 100))
+    os.utime(beta, (200, 200))
+
+    browsed = run("browse", str(files))
+    assert [row["name"] for row in browsed[:2]] == ["Beta", "Alpha"]
+    assert all(row["name"] != ".hidden.txt" for row in browsed)
+    print("ok - browsing is modification-sorted and excludes hidden entries")
+
+    index = workspace / "index.nul"
+    run("index", str(files), str(index))
+    assert index.stat().st_mode & 0o777 == 0o600
+    reports = run("query", str(index), "report")
+    assert [row["name"] for row in reports] == ["report final.txt"]
+    print("ok - indexed queries use a private cache and return recursively ranked paths")
+
+    unusual = run("query", str(index), "strange")
+    assert unusual[0]["name"] == "strange\nname.txt"
+    print("ok - indexed queries preserve filenames containing newlines")
+
+    added_later = files / "added-after-index.txt"
+    added_later.write_text("new", encoding="utf-8")
+    assert run("query", str(index), "added-after-index") == []
+    run("index", str(files), str(index))
+    assert run("query", str(index), "added-after-index")[0]["path"] == str(added_later)
+    print("ok - rebuilding refreshes the index snapshot")
+
+    newest_base = time.time() + 1000
+    for number in range(110):
+        nested = beta / f"limit-match-{number:03}.txt"
+        nested.write_text("", encoding="utf-8")
+        direct = files / f"direct-{number:03}.txt"
+        direct.write_text("", encoding="utf-8")
+        os.utime(direct, (newest_base + number, newest_base + number))
+    limited_browse = run("browse", str(files))
+    assert len(limited_browse) == 100
+    assert limited_browse[0]["name"] == "direct-109.txt"
+    run("index", str(files), str(index))
+    assert len(run("query", str(index), "limit-match")) == 100
+    print("ok - browse and indexed query output are capped at 100 rows")


### PR DESCRIPTION
## Summary

- build a short-lived recursive `fd` index once per active file-browser directory and reuse it for debounced `fzf` queries
- replace the shell loop and per-result `jq` processes with a bounded Python helper for browsing, indexing, and querying
- guard Quickshell process cancellation so stale scans cannot publish results and typing cannot repeatedly cancel an in-progress index build
- use private per-instance cache generations with secure temporary files and lifecycle cleanup
- add file-index integration coverage and CI dependencies

## Performance

Measured locally:

- repeated recursive search: about **102 ms → 39 ms** average
- browsing a 100-entry directory: about **301 ms → 26 ms**

## Validation

- manually tested the installed plugin with rapid query changes, navigation, closing, and reopening
- `python tests/file-index-integration-test.py`
- `node tests/menu-model-test.js`
- `bash tests/manifest-test.sh`
- `bash tests/timezone-integration-test.sh`
- `bash tests/qalc-integration-test.sh`
- `git diff --check origin/master...HEAD`
