### PR TITLE
Precompute launcher search metadata

### DIFF
--- a/Menu.qml
+++ b/Menu.qml
@@ -84,6 +84,7 @@ Item {
   readonly property int maxProcessOutputBytes: 1024 * 1024
   property var items: ({})
   property var itemOrder: []
+  property var itemMetadata: ({})
   property var searchExcludedRoots: ["setup.default"]
   property var navStack: []
   property var providersLoaded: ({})
@@ -620,6 +621,14 @@ Item {
     return MenuModel.normalizeItem(id, raw)
   }
 
+  function rebuildItemMetadata() {
+    root.itemMetadata = MenuModel.buildItemMetadata(root.items, root.itemOrder, root.whenResults)
+  }
+
+  function metadataFor(id) {
+    return root.itemMetadata[id] || null
+  }
+
   function parseMenuJsonc(raw) {
     return MenuModel.parseMenuJsonc(raw)
   }
@@ -648,6 +657,7 @@ Item {
     nextOrder.splice(rootIndex >= 0 ? rootIndex + 1 : 0, 0, "omarchy")
     root.items = nextItems
     root.itemOrder = nextOrder
+    root.rebuildItemMetadata()
     root.rowsLoaded = true
     root.evaluateGuards(true)
     if (root.opened) {
@@ -722,6 +732,7 @@ Item {
     var merged = MenuModel.mergeAppRows(root.items, root.itemOrder, appRows)
     root.items = merged.items
     root.itemOrder = merged.itemOrder
+    root.rebuildItemMetadata()
     if (root.opened) root.rebuildDisplay()
   }
 
@@ -787,6 +798,7 @@ Item {
     var merged = MenuModel.swapProviderRows(root.items, root.itemOrder, menuId, providerRows)
     root.items = merged.items
     root.itemOrder = merged.itemOrder
+    root.rebuildItemMetadata()
     if (root.opened) root.rebuildDisplay()
   }
 
@@ -843,30 +855,34 @@ Item {
   }
 
   function depthFor(id) {
-    return MenuModel.depthFor(root.items, id)
+    var metadata = root.metadataFor(id)
+    return metadata ? metadata.depth : MenuModel.depthFor(root.items, id)
   }
 
   function pathFor(id) {
-    return MenuModel.pathFor(root.items, id)
+    var metadata = root.metadataFor(id)
+    return metadata ? metadata.path : MenuModel.pathFor(root.items, id)
   }
 
   function parentPathFor(id) {
-    return MenuModel.parentPathFor(root.items, id)
+    return MenuModel.parentPathFor(root.items, id, root.itemMetadata)
   }
 
   function isDescendantOf(id, ancestorId) {
-    return MenuModel.isDescendantOf(root.items, id, ancestorId)
+    return MenuModel.isDescendantOf(root.items, id, ancestorId, root.itemMetadata)
   }
 
   function childCount(id) {
-    return MenuModel.childCount(root.items, root.itemOrder, id)
+    var metadata = root.metadataFor(id)
+    return metadata ? metadata.childCount : MenuModel.childCount(root.items, root.itemOrder, id)
   }
 
   // Guarded items are hidden when their `when:` evaluates false. Static
   // submenus are also hidden when none of their descendants are visible;
   // provider-backed menus stay visible because their rows load on demand.
   function isVisible(entry) {
-    return MenuModel.isVisible(root.items, root.itemOrder, root.whenResults, entry)
+    var metadata = entry ? root.metadataFor(entry.id) : null
+    return metadata ? metadata.visible : MenuModel.isVisible(root.items, root.itemOrder, root.whenResults, entry)
   }
 
   // Label with the ✓ marker baked in when `checked:` evaluated truthy.
@@ -895,15 +911,17 @@ Item {
   }
 
   function matchesQuery(entry, query) {
-    return MenuModel.matchesQuery(entry, query, root.isVisible(entry))
+    var metadata = entry ? root.metadataFor(entry.id) : null
+    return MenuModel.matchesQuery(entry, query, metadata ? metadata.visible : root.isVisible(entry), metadata)
   }
 
   function searchScore(entry, query) {
-    return MenuModel.searchScore(root.items, entry, query)
+    return MenuModel.searchScore(root.items, entry, query, root.metadataFor(entry.id))
   }
 
   function displayRow(entry, detail, score, section) {
-    return MenuModel.displayRow(root.items, root.itemOrder, root.checkedResults, entry, detail, score, section)
+    return MenuModel.displayRow(root.items, root.itemOrder, root.checkedResults,
+      entry, detail, score, section, root.metadataFor(entry.id))
   }
 
   function rebuildDmenuDisplay() {
@@ -977,18 +995,20 @@ Item {
     root.searchDivider = false
 
     if (query) {
+      var preparedQuery = MenuModel.prepareSearchQuery(query)
       var liveResult = root.extensionQuery === query ? root.extensionResult : ""
       for (var i = 0; i < root.itemOrder.length; i++) {
         var entry = root.item(root.itemOrder[i])
         if (!entry || entry.id === "root") continue
-        if (MenuModel.isSearchExcluded(root.items, entry.id, root.searchExcludedRoots)) continue
+        if (MenuModel.isSearchExcluded(root.items, entry.id, root.searchExcludedRoots, root.itemMetadata)) continue
         if (!root.isDescendantOf(entry.id, active)) continue
-        if (!root.matchesQuery(entry, query)) continue
+        if (!root.matchesQuery(entry, preparedQuery)) continue
 
         var detail = root.parentPathFor(entry.id)
-        var row = root.displayRow(entry, detail, root.searchScore(entry, query))
+        var metadata = root.metadataFor(entry.id)
+        var row = root.displayRow(entry, detail, root.searchScore(entry, preparedQuery))
         row.starred = favorites.isStarred(row.itemId)
-        row.matchPriority = MenuModel.searchMatchPriority(entry, query)
+        row.matchPriority = MenuModel.searchMatchPriority(entry, preparedQuery, metadata)
         row.usageCount = usage.count(row.itemId)
         row.lastUsedAt = usage.lastUsedAt(row.itemId)
         rows.push(row)
@@ -1769,6 +1789,7 @@ Item {
     if (!script) {
       root.whenResults = ({})
       root.checkedResults = ({})
+      root.rebuildItemMetadata()
       return
     }
     guardProc.collected = ""
@@ -1811,6 +1832,7 @@ Item {
       }
       root.whenResults = nextWhen
       root.checkedResults = nextChecked
+      root.rebuildItemMetadata()
       root.guardsEvaluatedAt = Date.now()
       if (root.opened) root.rebuildDisplay()
       // Run the evaluation that had to stand aside. Deferred by a turn so the

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -167,6 +167,13 @@ function item(items, id) {
   return items && items[id] ? items[id] : null
 }
 
+// Structural IDs are supplied by menu authors. Prefix them before using plain
+// objects as maps so names such as constructor, toString, and __proto__ cannot
+// collide with Object.prototype.
+function structuralKey(value) {
+  return "$" + String(value || "")
+}
+
 // Routes may name a real id (`system`, `setup.power`) or an alias declared in
 // JSONC (`power-menu`, `settings`). An exact id beats any alias, and app rows
 // are never routable: their aliases carry .desktop Keywords and GenericName
@@ -232,7 +239,7 @@ function parentPathFor(items, id, metadata) {
 function isDescendantOf(items, id, ancestorId, metadata) {
   if (ancestorId === "root") return id !== "root"
   var cached = metadata && metadata[id]
-  if (cached) return cached.ancestorSet[ancestorId] === true
+  if (cached) return cached.ancestorSet[structuralKey(ancestorId)] === true
 
   var current = item(items, id)
   var guard = 0
@@ -330,27 +337,29 @@ function buildItemMetadata(items, itemOrder, whenResults) {
   for (var i = 0; i < order.length; i++) {
     var entry = item(source, order[i])
     if (!entry || !entry.parent) continue
-    if (!children[entry.parent]) children[entry.parent] = []
-    children[entry.parent].push(entry.id)
+    var parentKey = structuralKey(entry.parent)
+    if (!children[parentKey]) children[parentKey] = []
+    children[parentKey].push(entry.id)
   }
 
   function visible(id, depth, visiting) {
     var entry = item(source, id)
-    if (!entry || visiting[id]) return false
+    var visitKey = structuralKey(id)
+    if (!entry || visiting[visitKey]) return false
     if (entry.when && whenResults && whenResults[id] === false) return false
     // Match isVisible's ordering: leaves and provider-backed menus remain
     // visible even when reached at the recursion guard boundary.
     if ((entry.kind !== "menu" && entry.kind !== "link") || entry.provider) return true
     if (depth >= 32) return false
 
-    visiting[id] = true
+    visiting[visitKey] = true
     var target = entry.kind === "link" ? entry.target : id
-    var childIds = children[target] || []
+    var childIds = children[structuralKey(target)] || []
     var result = false
     for (var childIndex = 0; childIndex < childIds.length; childIndex++) {
       if (visible(childIds[childIndex], depth + 1, visiting)) { result = true; break }
     }
-    delete visiting[id]
+    delete visiting[visitKey]
     return result
   }
 
@@ -364,7 +373,7 @@ function buildItemMetadata(items, itemOrder, whenResults) {
     var depth = 0
     while (cursor && cursor.id !== "root" && guard < 32) {
       labels.unshift(cursor.label)
-      if (cursor.parent) ancestorSet[cursor.parent] = true
+      if (cursor.parent) ancestorSet[structuralKey(cursor.parent)] = true
       if (cursor.parent && cursor.parent !== "root") depth += 1
       cursor = item(source, cursor.parent)
       guard += 1
@@ -382,7 +391,7 @@ function buildItemMetadata(items, itemOrder, whenResults) {
       parentPath: current.parent && current.parent !== "root" && metadata[current.parent]
         ? metadata[current.parent].path
         : (current.parent && current.parent !== "root" ? pathFor(source, current.parent) : ""),
-      childCount: (children[target] || []).length,
+      childCount: (children[structuralKey(target)] || []).length,
       ancestorSet: ancestorSet,
       visible: visible(current.id, 0, ({})),
       nameText: nameSearchText(current),

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -221,14 +221,18 @@ function pathFor(items, id) {
   return labels.join(" › ")
 }
 
-function parentPathFor(items, id) {
+function parentPathFor(items, id, metadata) {
+  var cached = metadata && metadata[id]
+  if (cached) return cached.parentPath
   var entry = item(items, id)
   if (!entry || !entry.parent || entry.parent === "root") return ""
   return pathFor(items, entry.parent)
 }
 
-function isDescendantOf(items, id, ancestorId) {
+function isDescendantOf(items, id, ancestorId, metadata) {
   if (ancestorId === "root") return id !== "root"
+  var cached = metadata && metadata[id]
+  if (cached) return cached.ancestorSet[ancestorId] === true
 
   var current = item(items, id)
   var guard = 0
@@ -241,10 +245,10 @@ function isDescendantOf(items, id, ancestorId) {
   return false
 }
 
-function isSearchExcluded(items, id, excludedRoots) {
+function isSearchExcluded(items, id, excludedRoots, metadata) {
   var roots = Array.isArray(excludedRoots) ? excludedRoots : []
   for (var i = 0; i < roots.length; i++) {
-    if (id === roots[i] || isDescendantOf(items, id, roots[i])) return true
+    if (id === roots[i] || isDescendantOf(items, id, roots[i], metadata)) return true
   }
   return false
 }
@@ -301,6 +305,103 @@ function nameSearchText(entry) {
   return [entry.label, searchableToken(leafIdFor(entry.id)), aliases.join(" ")].join(" ").toLowerCase()
 }
 
+function wordSet(text) {
+  var result = ({})
+  var words = String(text || "").toLowerCase().split(/\s+/)
+  // Prefix keys so special object properties such as __proto__ remain ordinary
+  // searchable words in QML's plain JavaScript objects.
+  for (var i = 0; i < words.length; i++) if (words[i]) result["$" + words[i]] = true
+  return result
+}
+
+function hasWord(words, value) {
+  return words["$" + value] === true
+}
+
+// Menu structure and searchable strings change only when a source/provider or
+// application list changes. Precompute them there instead of rebuilding paths,
+// walking descendants, and normalizing the same strings on every keystroke.
+function buildItemMetadata(items, itemOrder, whenResults) {
+  var source = items || ({})
+  var order = Array.isArray(itemOrder) ? itemOrder : []
+  var children = ({})
+  var metadata = ({})
+
+  for (var i = 0; i < order.length; i++) {
+    var entry = item(source, order[i])
+    if (!entry || !entry.parent) continue
+    if (!children[entry.parent]) children[entry.parent] = []
+    children[entry.parent].push(entry.id)
+  }
+
+  function visible(id, depth, visiting) {
+    var entry = item(source, id)
+    if (!entry || visiting[id]) return false
+    if (entry.when && whenResults && whenResults[id] === false) return false
+    // Match isVisible's ordering: leaves and provider-backed menus remain
+    // visible even when reached at the recursion guard boundary.
+    if ((entry.kind !== "menu" && entry.kind !== "link") || entry.provider) return true
+    if (depth >= 32) return false
+
+    visiting[id] = true
+    var target = entry.kind === "link" ? entry.target : id
+    var childIds = children[target] || []
+    var result = false
+    for (var childIndex = 0; childIndex < childIds.length; childIndex++) {
+      if (visible(childIds[childIndex], depth + 1, visiting)) { result = true; break }
+    }
+    delete visiting[id]
+    return result
+  }
+
+  for (var j = 0; j < order.length; j++) {
+    var current = item(source, order[j])
+    if (!current) continue
+    var labels = []
+    var ancestorSet = ({})
+    var cursor = current
+    var guard = 0
+    var depth = 0
+    while (cursor && cursor.id !== "root" && guard < 32) {
+      labels.unshift(cursor.label)
+      if (cursor.parent) ancestorSet[cursor.parent] = true
+      if (cursor.parent && cursor.parent !== "root") depth += 1
+      cursor = item(source, cursor.parent)
+      guard += 1
+    }
+
+    var aliasesLower = []
+    var aliases = Array.isArray(current.aliases) ? current.aliases : []
+    for (var aliasIndex = 0; aliasIndex < aliases.length; aliasIndex++)
+      aliasesLower.push(String(aliases[aliasIndex] || "").toLowerCase().trim())
+    var descriptionText = String(current.description || "").toLowerCase()
+    var target = current.kind === "link" ? current.target : current.id
+    metadata[current.id] = {
+      depth: depth,
+      path: labels.join(" › "),
+      parentPath: current.parent && current.parent !== "root" && metadata[current.parent]
+        ? metadata[current.parent].path
+        : (current.parent && current.parent !== "root" ? pathFor(source, current.parent) : ""),
+      childCount: (children[target] || []).length,
+      ancestorSet: ancestorSet,
+      visible: visible(current.id, 0, ({})),
+      nameText: nameSearchText(current),
+      descriptionText: descriptionText,
+      descriptionWords: wordSet(descriptionText),
+      labelLower: String(current.label || "").toLowerCase(),
+      labelWords: wordSet(current.label),
+      aliasesLower: aliasesLower
+    }
+  }
+
+  return metadata
+}
+
+function prepareSearchQuery(query) {
+  var needle = String(query || "").toLowerCase().trim()
+  return { needle: needle, terms: needle ? needle.split(/\s+/) : [] }
+}
+
 function termInSearchWords(term, text) {
   var words = String(text || "").toLowerCase().split(/\s+/)
   for (var i = 0; i < words.length; i++) {
@@ -314,6 +415,12 @@ function descriptionTextMatches(query, text) {
   for (var i = 0; i < terms.length; i++) {
     if (terms[i] && !termInSearchWords(terms[i], text)) return false
   }
+  return true
+}
+
+function termsInWordSet(terms, words) {
+  for (var i = 0; i < terms.length; i++)
+    if (terms[i] && !hasWord(words, terms[i])) return false
   return true
 }
 
@@ -588,63 +695,74 @@ function matchExtensions(extensions, query) {
   return matches
 }
 
-function matchesQuery(entry, query, visible) {
+function matchesQuery(entry, query, visible, metadata) {
   if (!entry || entry.id === "root") return false
   if (!visible) return false
 
-  var nameText = nameSearchText(entry)
-  var descriptionText = String(entry.description || "").toLowerCase()
-  var terms = String(query || "").toLowerCase().trim().split(/\s+/)
+  var prepared = query && typeof query === "object" ? query : prepareSearchQuery(query)
+  var nameText = metadata ? metadata.nameText : nameSearchText(entry)
+  var descriptionText = metadata ? metadata.descriptionText : String(entry.description || "").toLowerCase()
+  var descriptionWords = metadata ? metadata.descriptionWords : null
 
-  for (var i = 0; i < terms.length; i++) {
-    if (!terms[i]) continue
-    if (nameText.indexOf(terms[i]) >= 0) continue
-    if (termInSearchWords(terms[i], descriptionText)) continue
+  for (var i = 0; i < prepared.terms.length; i++) {
+    var term = prepared.terms[i]
+    if (!term) continue
+    if (nameText.indexOf(term) >= 0) continue
+    if (descriptionWords ? hasWord(descriptionWords, term) : termInSearchWords(term, descriptionText)) continue
     return false
   }
 
   return true
 }
 
-function searchMatchPriority(entry, query) {
-  var needle = String(query || "").toLowerCase().trim()
+function searchMatchPriority(entry, query, metadata) {
+  var prepared = query && typeof query === "object" ? query : prepareSearchQuery(query)
+  var needle = prepared.needle
   if (!entry || !needle) return 0
-  var label = String(entry.label || "").toLowerCase()
+  var label = metadata ? metadata.labelLower : String(entry.label || "").toLowerCase()
   if (label === needle) return 4
 
-  var aliases = Array.isArray(entry.aliases) ? entry.aliases : []
+  var aliases = metadata ? metadata.aliasesLower : []
+  if (!metadata) {
+    var sourceAliases = Array.isArray(entry.aliases) ? entry.aliases : []
+    for (var sourceIndex = 0; sourceIndex < sourceAliases.length; sourceIndex++)
+      aliases.push(String(sourceAliases[sourceIndex] || "").toLowerCase().trim())
+  }
   for (var i = 0; i < aliases.length; i++) {
-    if (String(aliases[i] || "").toLowerCase().trim() === needle) return 3
+    if (aliases[i] === needle) return 3
   }
   for (var j = 0; j < aliases.length; j++) {
-    if (String(aliases[j] || "").toLowerCase().trim().indexOf(needle) === 0) return 2
+    if (aliases[j].indexOf(needle) === 0) return 2
   }
   if (label.indexOf(needle) === 0) return 1
   return 0
 }
 
-function searchScore(items, entry, query) {
-  var needle = String(query || "").toLowerCase().trim()
-  var label = entry.label.toLowerCase()
-  var nameText = nameSearchText(entry)
-  var descriptionText = String(entry.description || "").toLowerCase()
+function searchScore(items, entry, query, metadata) {
+  var prepared = query && typeof query === "object" ? query : prepareSearchQuery(query)
+  var needle = prepared.needle
+  var label = metadata ? metadata.labelLower : entry.label.toLowerCase()
+  var nameText = metadata ? metadata.nameText : nameSearchText(entry)
+  var descriptionText = metadata ? metadata.descriptionText : String(entry.description || "").toLowerCase()
   var score = 80
 
   if (label === needle) score = entry.parent === "root" ? 2 : 0
   // An installed app whose name contains the query as a whole word ("zen"
   // for Zen Browser) beats exact-labeled menu entries like Install > Zen.
-  else if (entry.kind === "app" && label.split(/\s+/).indexOf(needle) >= 0) score = 0
+  else if (entry.kind === "app" && (metadata ? hasWord(metadata.labelWords, needle) : label.split(/\s+/).indexOf(needle) >= 0)) score = 0
   else if (label.indexOf(needle) === 0) score = 10
   else if (label.indexOf(needle) >= 0) score = 30
   else if (nameText.indexOf(needle) >= 0) score = 40
-  else if (descriptionTextMatches(needle, descriptionText)) score = 60
+  else if (metadata
+    ? termsInWordSet(prepared.terms, metadata.descriptionWords)
+    : descriptionTextMatches(needle, descriptionText)) score = 60
 
   if (entry.kind === "menu" || entry.kind === "link") score -= 2
   // App rows sort after all menu items, so they lose the tiebreak below to an
   // equal match. Outrank those, but stay inside the tier so better ones win.
   if (entry.kind === "app") score -= 5
 
-  return score * 1000 + depthFor(items, entry.id) * 25 + entry.order
+  return score * 1000 + (metadata ? metadata.depth : depthFor(items, entry.id)) * 25 + entry.order
 }
 
 function compareSearchRows(a, b, useHistory) {
@@ -678,7 +796,7 @@ function localFileUrl(path) {
   }).join("/")
 }
 
-function displayRow(items, itemOrder, checkedResults, entry, detail, score, section) {
+function displayRow(items, itemOrder, checkedResults, entry, detail, score, section, metadata) {
   var target = entry.kind === "link" ? entry.target : entry.id
   return {
     itemId: entry.id,
@@ -690,8 +808,9 @@ function displayRow(items, itemOrder, checkedResults, entry, detail, score, sect
     label: labelFor(entry, checkedResults),
     target: target,
     detail: detail || "",
-    path: pathFor(items, entry.id),
-    childCount: (entry.kind === "menu" || entry.kind === "link") ? childCount(items, itemOrder, target) : 0,
+    path: metadata ? metadata.path : pathFor(items, entry.id),
+    childCount: (entry.kind === "menu" || entry.kind === "link")
+      ? (metadata ? metadata.childCount : childCount(items, itemOrder, target)) : 0,
     action: entry.action || "",
     provider: entry.provider || "",
     score: score || 0,
@@ -832,6 +951,8 @@ if (typeof module !== "undefined") {
     pathFor: pathFor,
     parentPathFor: parentPathFor,
     isDescendantOf: isDescendantOf,
+    buildItemMetadata: buildItemMetadata,
+    prepareSearchQuery: prepareSearchQuery,
     isSearchExcluded: isSearchExcluded,
     childCount: childCount,
     isVisible: isVisible,

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -244,6 +244,18 @@ deepOrder.push('deep.leaf')
 const deepMetadata = menu.buildItemMetadata(deepItems, deepOrder, {})
 assert(deepOrder.every(id => deepMetadata[id].visible === menu.isVisible(deepItems, deepOrder, {}, deepItems[id])), 'cached visibility preserves recursion-boundary behavior')
 
+const specialParentItems = { root: menu.normalizeItem('root', { label: 'Go' }) }
+specialParentItems.constructor = menu.normalizeItem('constructor', { label: 'Constructor' })
+specialParentItems['constructor.child'] = menu.normalizeItem('constructor.child', { label: 'Child', parent: 'constructor', action: 'child' })
+specialParentItems['toString.child'] = menu.normalizeItem('toString.child', { label: 'String Child', parent: 'toString', action: 'child' })
+specialParentItems['__proto__.child'] = menu.normalizeItem('__proto__.child', { label: 'Proto Child', parent: '__proto__', action: 'child' })
+const specialParentOrder = ['root', 'constructor', 'constructor.child', 'toString.child', '__proto__.child']
+specialParentOrder.forEach((id, index) => { specialParentItems[id].order = index })
+const specialParentMetadata = menu.buildItemMetadata(specialParentItems, specialParentOrder, {})
+assert(specialParentMetadata.constructor.childCount === 1, 'derived child maps accept inherited object-property names')
+assert(specialParentMetadata['constructor.child'].ancestorSet.$constructor, 'derived ancestry accepts inherited object-property names')
+assert(specialParentMetadata['toString.child'].visible && specialParentMetadata['__proto__.child'].visible, 'special parent ids do not prevent metadata construction')
+
 assert(menu.searchMatchPriority({ label: 'Apps', aliases: ['app', 'applications'] }, 'apps') === 4, 'exact labels have highest priority')
 assert(menu.searchMatchPriority({ label: 'Apps', aliases: ['app', 'applications'] }, 'app') === 3, 'exact aliases outrank prefixes')
 assert(menu.searchMatchPriority({ label: 'Apps', aliases: ['app', 'applications'] }, 'ap') === 2, 'alias prefixes outrank label prefixes')

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -192,6 +192,58 @@ assert(menu.isSearchExcluded(searchTree, 'setup.default', ['setup.default']), 'e
 assert(menu.isSearchExcluded(searchTree, 'setup.default.agent', ['setup.default']), 'descendants of excluded search roots are hidden')
 assert(!menu.isSearchExcluded(searchTree, 'setup.security', ['setup.default']), 'sibling menu results remain searchable')
 
+const metadataItems = {
+  root: menu.normalizeItem('root', { label: 'Go' }),
+  tools: menu.normalizeItem('tools', { label: 'Tools' }),
+  'tools.editor': menu.normalizeItem('tools.editor', {
+    label: 'Text Editor',
+    action: 'editor',
+    aliases: ['Edit'],
+    description: 'Open text files'
+  }),
+  hidden: menu.normalizeItem('hidden', { label: 'Hidden' }),
+  'hidden.child': menu.normalizeItem('hidden.child', { label: 'Guarded', action: 'guarded', when: 'false' }),
+  provider: menu.normalizeItem('provider', { label: 'Dynamic', provider: 'apps' })
+}
+const metadataOrder = ['root', 'tools', 'tools.editor', 'hidden', 'hidden.child', 'provider']
+metadataOrder.forEach((id, index) => { metadataItems[id].order = index })
+const itemMetadata = menu.buildItemMetadata(metadataItems, metadataOrder, { 'hidden.child': false })
+assert(itemMetadata['tools.editor'].path === 'Tools › Text Editor', 'derived metadata caches item paths')
+assert(itemMetadata['tools.editor'].parentPath === 'Tools', 'derived metadata caches parent paths')
+assert(itemMetadata['tools.editor'].depth === menu.depthFor(metadataItems, 'tools.editor'), 'derived metadata caches item depth')
+assert(itemMetadata.tools.childCount === 1, 'derived metadata caches direct child counts')
+assert(itemMetadata.tools.visible, 'derived metadata caches visible menu descendants')
+assert(!itemMetadata.hidden.visible, 'derived metadata propagates guarded descendant visibility')
+assert(itemMetadata.provider.visible, 'provider-backed menus remain visible in derived metadata')
+assert(menu.isDescendantOf(metadataItems, 'tools.editor', 'tools', itemMetadata), 'derived ancestry answers descendant checks')
+const preparedEditorQuery = menu.prepareSearchQuery('EDIT text')
+assert(menu.matchesQuery(metadataItems['tools.editor'], preparedEditorQuery, true, itemMetadata['tools.editor']), 'prepared queries use cached aliases and description words')
+assert(
+  menu.searchScore(metadataItems, metadataItems['tools.editor'], preparedEditorQuery, itemMetadata['tools.editor'])
+    === menu.searchScore(metadataItems, metadataItems['tools.editor'], 'EDIT text'),
+  'cached metadata preserves search scoring'
+)
+const specialWordItem = menu.normalizeItem('special', { label: 'Special', action: 'special', description: '__proto__' })
+specialWordItem.order = 0
+const specialWordMetadata = menu.buildItemMetadata({ special: specialWordItem }, ['special'], {}).special
+assert(menu.matchesQuery(specialWordItem, menu.prepareSearchQuery('__proto__'), true, specialWordMetadata), 'cached word sets retain special object-property names')
+
+const deepItems = { root: menu.normalizeItem('root', { label: 'Go' }) }
+const deepOrder = ['root']
+let deepParent = 'root'
+for (let depth = 0; depth < 34; depth++) {
+  const id = `deep.${depth}`
+  deepItems[id] = menu.normalizeItem(id, { label: `Depth ${depth}`, parent: deepParent })
+  deepItems[id].order = deepOrder.length
+  deepOrder.push(id)
+  deepParent = id
+}
+deepItems['deep.leaf'] = menu.normalizeItem('deep.leaf', { label: 'Leaf', parent: deepParent, action: 'leaf' })
+deepItems['deep.leaf'].order = deepOrder.length
+deepOrder.push('deep.leaf')
+const deepMetadata = menu.buildItemMetadata(deepItems, deepOrder, {})
+assert(deepOrder.every(id => deepMetadata[id].visible === menu.isVisible(deepItems, deepOrder, {}, deepItems[id])), 'cached visibility preserves recursion-boundary behavior')
+
 assert(menu.searchMatchPriority({ label: 'Apps', aliases: ['app', 'applications'] }, 'apps') === 4, 'exact labels have highest priority')
 assert(menu.searchMatchPriority({ label: 'Apps', aliases: ['app', 'applications'] }, 'app') === 3, 'exact aliases outrank prefixes')
 assert(menu.searchMatchPriority({ label: 'Apps', aliases: ['app', 'applications'] }, 'ap') === 2, 'alias prefixes outrank label prefixes')


### PR DESCRIPTION
## Summary

- precompute normalized labels, aliases, descriptions, paths, ancestry, depth, child counts, and guard-dependent visibility whenever launcher items change
- prepare query terms once per display rebuild and reuse cached metadata during matching, scoring, exclusion checks, and row construction
- rebuild metadata when menu sources, applications, dynamic providers, or guard results change
- add semantic-parity regressions for guarded visibility, recursion boundaries, providers, paths, ranking, and special object-property names

## Performance

Synthetic 819-item benchmark:

- metadata build: about **4.8 ms** when items change
- search pass: about **1.13 ms → 0.11 ms** per query
- roughly **10× faster** filtering/ranking hot path

## Validation

- independent review completed with no remaining blockers
- `node tests/menu-model-test.js`
- `bash tests/manifest-test.sh`
- `bash tests/timezone-integration-test.sh`
- `bash tests/qalc-integration-test.sh`
- `python tests/file-index-integration-test.py`
- `git diff --check origin/master...HEAD`
