### PR TITLE
Refine launcher search ranking

### DIFF
--- a/Menu.qml
+++ b/Menu.qml
@@ -1014,14 +1014,6 @@ Item {
         rows.push(row)
       }
 
-      rows.sort(function(a, b) {
-        return MenuModel.compareSearchRows(a, b, query.length >= 3)
-      })
-      // ListView virtualizes delegates, but ListModel still pays for every
-      // append across the QML/JS boundary. Only retain enough ranked results
-      // for useful navigation; extension rows are added separately below.
-      if (rows.length > root.maxDisplayedResults) rows = rows.slice(0, root.maxDisplayedResults)
-
       var extensionSuggestions = MenuModel.suggestExtensions(root.extensions, query)
       for (var suggestionIndex = extensionSuggestions.length - 1; suggestionIndex >= 0; suggestionIndex--) {
         var suggestion = extensionSuggestions[suggestionIndex]
@@ -1037,7 +1029,9 @@ Item {
           description: suggestionDetail,
           action: suggestedExtension.available ? suggestion.prefix + " " : ""
         })
-        rows.unshift(root.displayRow(suggestionItem, suggestionDetail, -3))
+        var suggestionRow = root.displayRow(suggestionItem, suggestionDetail, -3)
+        suggestionRow.matchPriority = MenuModel.extensionSuggestionPriority(suggestion, query)
+        rows.push(suggestionRow)
       }
 
       var extensionMatches = MenuModel.matchExtensions(root.extensions, query)
@@ -1055,7 +1049,9 @@ Item {
           description: extensionDetail,
           action: extension.available ? root.extensionAction(extension, extensionMatch.prompt) : ""
         })
-        rows.unshift(root.displayRow(extensionItem, extensionDetail, -2))
+        var extensionRow = root.displayRow(extensionItem, extensionDetail, -2)
+        extensionRow.matchPriority = MenuModel.extensionMatchPriority(extension)
+        rows.push(extensionRow)
       }
 
       if (root.unavailableResultExtension) {
@@ -1066,7 +1062,9 @@ Item {
           label: root.unavailableResultExtension.label + " unavailable",
           description: unavailableDetail
         })
-        rows.unshift(root.displayRow(unavailableItem, unavailableDetail, -1))
+        var unavailableRow = root.displayRow(unavailableItem, unavailableDetail, -1)
+        unavailableRow.matchPriority = 0
+        rows.push(unavailableRow)
       }
 
       if (liveResult && root.resultExtension) {
@@ -1077,8 +1075,18 @@ Item {
           description: root.resultExtension.description,
           action: root.shellCommand(root.resultExtension.resultCommand, { result: liveResult, query: query })
         })
-        rows.unshift(root.displayRow(resultItem, root.resultExtension.description, -1))
+        var resultRow = root.displayRow(resultItem, root.resultExtension.description, -1)
+        resultRow.matchPriority = 110
+        rows.push(resultRow)
       }
+
+      rows.sort(function(a, b) {
+        return MenuModel.compareSearchRows(a, b, query.length >= 3)
+      })
+      // ListView virtualizes delegates, but ListModel still pays for every
+      // append across the QML/JS boundary. Rank all item and extension rows
+      // together, then retain only the useful leading results.
+      if (rows.length > root.maxDisplayedResults) rows = rows.slice(0, root.maxDisplayedResults)
     } else {
       for (var j = 0; j < root.itemOrder.length; j++) {
         var child = root.item(root.itemOrder[j])

--- a/Menu.qml
+++ b/Menu.qml
@@ -995,6 +995,7 @@ Item {
     root.searchDivider = false
 
     if (query) {
+      var diagnosticRows = []
       var preparedQuery = MenuModel.prepareSearchQuery(query)
       var liveResult = root.extensionQuery === query ? root.extensionResult : ""
       for (var i = 0; i < root.itemOrder.length; i++) {
@@ -1031,7 +1032,8 @@ Item {
         })
         var suggestionRow = root.displayRow(suggestionItem, suggestionDetail, -3)
         suggestionRow.matchPriority = MenuModel.extensionSuggestionPriority(suggestion, query)
-        rows.push(suggestionRow)
+        if (suggestedExtension.available) rows.push(suggestionRow)
+        else diagnosticRows.push(suggestionRow)
       }
 
       var extensionMatches = MenuModel.matchExtensions(root.extensions, query)
@@ -1051,7 +1053,8 @@ Item {
         })
         var extensionRow = root.displayRow(extensionItem, extensionDetail, -2)
         extensionRow.matchPriority = MenuModel.extensionMatchPriority(extension)
-        rows.push(extensionRow)
+        if (extension.available) rows.push(extensionRow)
+        else diagnosticRows.push(extensionRow)
       }
 
       if (root.unavailableResultExtension) {
@@ -1064,7 +1067,7 @@ Item {
         })
         var unavailableRow = root.displayRow(unavailableItem, unavailableDetail, -1)
         unavailableRow.matchPriority = 0
-        rows.push(unavailableRow)
+        diagnosticRows.push(unavailableRow)
       }
 
       if (liveResult && root.resultExtension) {
@@ -1080,13 +1083,9 @@ Item {
         rows.push(resultRow)
       }
 
-      rows.sort(function(a, b) {
-        return MenuModel.compareSearchRows(a, b, query.length >= 3)
-      })
-      // ListView virtualizes delegates, but ListModel still pays for every
-      // append across the QML/JS boundary. Rank all item and extension rows
-      // together, then retain only the useful leading results.
-      if (rows.length > root.maxDisplayedResults) rows = rows.slice(0, root.maxDisplayedResults)
+      // Rank normal item and extension rows together. Diagnostic rows reserve
+      // space at the bottom so dependency/setup guidance survives the cap.
+      rows = MenuModel.rankSearchRows(rows, diagnosticRows, query.length >= 3, root.maxDisplayedResults)
     } else {
       for (var j = 0; j < root.itemOrder.length; j++) {
         var child = root.item(root.itemOrder[j])

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -817,7 +817,12 @@ function rankSearchRows(rows, diagnosticRows, useHistory, maxRows) {
 
   var limit = Math.max(0, Number(maxRows) || 0)
   if (!limit) return []
-  if (diagnostics.length >= limit) return diagnostics.slice(0, limit)
+  // Even a saturated diagnostic set must not hide the best actionable result,
+  // such as a live extension result. Reserve one slot when one is available.
+  if (diagnostics.length >= limit) {
+    if (ranked.length === 0) return diagnostics.slice(0, limit)
+    return ranked.slice(0, 1).concat(diagnostics.slice(0, limit - 1))
+  }
   return ranked.slice(0, limit - diagnostics.length).concat(diagnostics)
 }
 

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -739,13 +739,13 @@ function searchMatchPriority(entry, query, metadata) {
   var needle = prepared.needle
   if (!entry || !needle) return 0
   var label = metadata ? metadata.labelLower : String(entry.label || "").toLowerCase()
-  var isApp = entry.kind === "app" || entry.parent === "apps"
+  var isApp = entry.kind === "app" || (entry.kind === "action" && entry.parent === "apps")
   if (label === needle) return isApp ? 90 : 50
   if (isApp && label.indexOf(needle) === 0) return 70
   if (isApp && (metadata ? hasWord(metadata.labelWords, needle) : label.split(/\s+/).indexOf(needle) >= 0)) return 60
-  // Any remaining match from the Apps menu came from app metadata such as
-  // GenericName or Keywords. Launchable apps still outrank management routes.
-  if (isApp) return 55
+  // Any remaining launchable-app match came from searchable metadata such as
+  // GenericName, Keywords, the generated id, or description text.
+  if (isApp && matchesQuery(entry, prepared, true, metadata)) return 55
 
   var aliases = metadata ? metadata.aliasesLower : []
   if (!metadata) {
@@ -807,6 +807,18 @@ function compareSearchRows(a, b, useHistory) {
 
   if (a.score !== b.score) return a.score - b.score
   return String(a.path || "").localeCompare(String(b.path || ""))
+}
+
+function rankSearchRows(rows, diagnosticRows, useHistory, maxRows) {
+  var ranked = Array.isArray(rows) ? rows.slice() : []
+  var diagnostics = Array.isArray(diagnosticRows) ? diagnosticRows.slice() : []
+  ranked.sort(function(a, b) { return compareSearchRows(a, b, useHistory) })
+  diagnostics.sort(function(a, b) { return compareSearchRows(a, b, false) })
+
+  var limit = Math.max(0, Number(maxRows) || 0)
+  if (!limit) return []
+  if (diagnostics.length >= limit) return diagnostics.slice(0, limit)
+  return ranked.slice(0, limit - diagnostics.length).concat(diagnostics)
 }
 
 function isImagePath(path) {
@@ -1006,6 +1018,7 @@ if (typeof module !== "undefined") {
     searchMatchPriority: searchMatchPriority,
     searchScore: searchScore,
     compareSearchRows: compareSearchRows,
+    rankSearchRows: rankSearchRows,
     isImagePath: isImagePath,
     localFileUrl: localFileUrl,
     displayRow: displayRow

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -667,6 +667,16 @@ function unavailableQueryExtension(extensions, query) {
   return matches.length > 0 && !matches[0].available ? matches[0] : null
 }
 
+function extensionSuggestionPriority(suggestion, query) {
+  if (!suggestion || !suggestion.extension || !suggestion.extension.available) return 0
+  var input = String(query || "").toLowerCase().trim()
+  return suggestion.prefix === input ? 95 : 20
+}
+
+function extensionMatchPriority(extension) {
+  return extension && extension.available ? 100 : 0
+}
+
 function suggestExtensions(extensions, query) {
   var input = String(query || "").toLowerCase().trim()
   if (!input || /\s/.test(input)) return []
@@ -729,7 +739,13 @@ function searchMatchPriority(entry, query, metadata) {
   var needle = prepared.needle
   if (!entry || !needle) return 0
   var label = metadata ? metadata.labelLower : String(entry.label || "").toLowerCase()
-  if (label === needle) return 4
+  var isApp = entry.kind === "app" || entry.parent === "apps"
+  if (label === needle) return isApp ? 90 : 50
+  if (isApp && label.indexOf(needle) === 0) return 70
+  if (isApp && (metadata ? hasWord(metadata.labelWords, needle) : label.split(/\s+/).indexOf(needle) >= 0)) return 60
+  // Any remaining match from the Apps menu came from app metadata such as
+  // GenericName or Keywords. Launchable apps still outrank management routes.
+  if (isApp) return 55
 
   var aliases = metadata ? metadata.aliasesLower : []
   if (!metadata) {
@@ -738,12 +754,12 @@ function searchMatchPriority(entry, query, metadata) {
       aliases.push(String(sourceAliases[sourceIndex] || "").toLowerCase().trim())
   }
   for (var i = 0; i < aliases.length; i++) {
-    if (aliases[i] === needle) return 3
+    if (aliases[i] === needle) return 40
   }
+  if (label.indexOf(needle) === 0) return 30
   for (var j = 0; j < aliases.length; j++) {
-    if (aliases[j].indexOf(needle) === 0) return 2
+    if (aliases[j].indexOf(needle) === 0) return 10
   }
-  if (label.indexOf(needle) === 0) return 1
   return 0
 }
 
@@ -982,6 +998,8 @@ if (typeof module !== "undefined") {
     matchesRules: matchesRules,
     queryExtension: queryExtension,
     unavailableQueryExtension: unavailableQueryExtension,
+    extensionSuggestionPriority: extensionSuggestionPriority,
+    extensionMatchPriority: extensionMatchPriority,
     suggestExtensions: suggestExtensions,
     matchExtensions: matchExtensions,
     matchesQuery: matchesQuery,

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -267,6 +267,9 @@ assert(menu.searchMatchPriority({ kind: 'app', label: 'Apps', aliases: ['app', '
 assert(menu.searchMatchPriority({ kind: 'app', label: 'Apple Music', aliases: [] }, 'app') === 70, 'app title prefixes outrank menu shortcuts')
 assert(menu.searchMatchPriority({ kind: 'action', parent: 'apps', label: 'Work Browser', aliases: [] }, 'browser') === 60, 'whole-word titles in the Apps menu outrank exact menu shortcuts')
 assert(menu.searchMatchPriority({ kind: 'app', parent: 'apps', label: 'Chromium', aliases: ['Web Browser'] }, 'browser') === 55, 'apps matched through metadata outrank management shortcuts')
+assert(menu.searchMatchPriority({ kind: 'app', parent: 'tools', label: 'Chromium', aliases: ['Web Browser'] }, 'browser') === 55, 'desktop apps retain app ranking outside the Apps menu')
+assert(menu.searchMatchPriority({ kind: 'app', parent: 'apps', label: 'Chromium', aliases: ['Web Browser'] }, 'calculator') === 0, 'unmatched apps receive no metadata fallback priority')
+assert(menu.searchMatchPriority({ kind: 'menu', parent: 'apps', label: 'Other', aliases: ['Browser'] }, 'browser') === 40, 'submenus under Apps do not receive app ranking')
 assert(menu.searchMatchPriority({ kind: 'menu', label: 'Browser', aliases: [] }, 'browser') === 50, 'exact menu titles rank below matching apps')
 assert(menu.searchMatchPriority({ label: 'Utilities', aliases: ['app', 'applications'] }, 'app') === 40, 'exact aliases outrank menu title prefixes')
 assert(menu.searchMatchPriority({ label: 'Apps', aliases: ['app', 'applications'] }, 'ap') === 30, 'menu title prefixes outrank alias prefixes')
@@ -307,6 +310,41 @@ assert(menu.compareSearchRows(
   { matchPriority: 20, starred: true, usageCount: 10, lastUsedAt: 200, score: -3, path: 'Partial extension' },
   true
 ) < 0, 'app title words outrank partial extension suggestions')
+
+const crowdedRows = []
+for (let rowIndex = 0; rowIndex < 105; rowIndex++) {
+  crowdedRows.push({
+    itemId: `row-${rowIndex}`,
+    matchPriority: 0,
+    starred: false,
+    usageCount: 0,
+    lastUsedAt: 0,
+    score: rowIndex,
+    path: `Row ${rowIndex}`
+  })
+}
+const diagnosticRow = {
+  itemId: 'extension.unavailable.test',
+  matchPriority: 0,
+  starred: false,
+  usageCount: 0,
+  lastUsedAt: 0,
+  score: -3,
+  path: 'Unavailable extension'
+}
+const cappedRows = menu.rankSearchRows(crowdedRows, [diagnosticRow], true, 100)
+assert(cappedRows.length === 100, 'ranked search rows respect the result cap')
+assert(cappedRows[0].itemId === 'row-0', 'highest ordinary result remains first after capping')
+assert(cappedRows[98].itemId === 'row-98', 'diagnostics reserve space inside the result cap')
+assert(cappedRows[99].itemId === diagnosticRow.itemId, 'unavailable extension diagnostics remain visible at the bottom')
+
+const assembledRanking = menu.rankSearchRows([
+  { itemId: 'partial-extension', matchPriority: 20, starred: false, usageCount: 0, lastUsedAt: 0, score: -3, path: 'Partial extension' },
+  { itemId: 'exact-app', matchPriority: 90, starred: false, usageCount: 0, lastUsedAt: 0, score: 0, path: 'Exact app' },
+  { itemId: 'exact-extension', matchPriority: 95, starred: false, usageCount: 0, lastUsedAt: 0, score: -3, path: 'Exact extension' },
+  { itemId: 'live-result', matchPriority: 110, starred: false, usageCount: 0, lastUsedAt: 0, score: -1, path: 'Live result' }
+], [], true, 100)
+assert(assembledRanking.map(row => row.itemId).join(',') === 'live-result,exact-extension,exact-app,partial-extension', 'assembled rows apply extension and app priority tiers')
 
 assert(menu.compareSearchRows(
   { matchPriority: 0, starred: false, usageCount: 10, lastUsedAt: 200, score: 20, path: 'A' },

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -338,6 +338,26 @@ assert(cappedRows[0].itemId === 'row-0', 'highest ordinary result remains first 
 assert(cappedRows[98].itemId === 'row-98', 'diagnostics reserve space inside the result cap')
 assert(cappedRows[99].itemId === diagnosticRow.itemId, 'unavailable extension diagnostics remain visible at the bottom')
 
+const saturatedDiagnostics = []
+for (let diagnosticIndex = 0; diagnosticIndex < 4; diagnosticIndex++) {
+  saturatedDiagnostics.push({
+    itemId: `diagnostic-${diagnosticIndex}`,
+    matchPriority: 0,
+    starred: false,
+    usageCount: 0,
+    lastUsedAt: 0,
+    score: diagnosticIndex,
+    path: `Diagnostic ${diagnosticIndex}`
+  })
+}
+const saturatedRows = menu.rankSearchRows([
+  { itemId: 'live-result', matchPriority: 110, starred: false, usageCount: 0, lastUsedAt: 0, score: -1, path: 'Live result' },
+  { itemId: 'ordinary-result', matchPriority: 0, starred: false, usageCount: 0, lastUsedAt: 0, score: 0, path: 'Ordinary result' }
+], saturatedDiagnostics, true, 3)
+assert(saturatedRows.length === 3, 'saturated diagnostics still respect the result cap')
+assert(saturatedRows[0].itemId === 'live-result', 'saturated diagnostics preserve the highest-ranked actionable result')
+assert(saturatedRows.slice(1).every(row => row.itemId.indexOf('diagnostic-') === 0), 'remaining saturated slots are reserved for diagnostics')
+
 const assembledRanking = menu.rankSearchRows([
   { itemId: 'partial-extension', matchPriority: 20, starred: false, usageCount: 0, lastUsedAt: 0, score: -3, path: 'Partial extension' },
   { itemId: 'exact-app', matchPriority: 90, starred: false, usageCount: 0, lastUsedAt: 0, score: 0, path: 'Exact app' },

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -61,7 +61,14 @@ const filesExtension = menu.parseExtensions(JSON.stringify([{
   copyFileCommand: ['copy-file', '{path}']
 }]))
 assert(filesExtension.length === 1 && filesExtension[0].mode === 'files', 'file browser extensions are parsed')
-assert(menu.suggestExtensions(filesExtension, 'fil')[0].extension.id === 'files', 'file browser extensions appear in prefix suggestions')
+const partialFilesSuggestion = menu.suggestExtensions(filesExtension, 'fil')[0]
+const exactFilesSuggestion = menu.suggestExtensions(filesExtension, 'files')[0]
+assert(partialFilesSuggestion.extension.id === 'files', 'file browser extensions appear in prefix suggestions')
+assert(menu.extensionSuggestionPriority(partialFilesSuggestion, 'fil') === 20, 'partial extension suggestions receive low priority')
+assert(menu.extensionSuggestionPriority(exactFilesSuggestion, ' FILES ') === 95, 'exact extension prefixes outrank exact app titles')
+assert(menu.extensionSuggestionPriority({ extension: { available: false }, prefix: 'files' }, 'files') === 0, 'unavailable extension suggestions receive no priority boost')
+assert(menu.extensionMatchPriority(filesExtension[0]) === 100, 'explicit available extension invocations receive top priority')
+assert(menu.extensionMatchPriority({ available: false }) === 0, 'unavailable extension invocations receive no priority boost')
 assert(filesExtension[0].copyCommand[2] === '{path}', 'file browser copy path commands are retained')
 assert(filesExtension[0].copyFileCommand[1] === '{path}', 'file browser copy file commands are retained')
 assert(filesExtension[0].terminalCommand[1] === '--dir={path}', 'file browser terminal commands are retained')
@@ -256,10 +263,14 @@ assert(specialParentMetadata.constructor.childCount === 1, 'derived child maps a
 assert(specialParentMetadata['constructor.child'].ancestorSet.$constructor, 'derived ancestry accepts inherited object-property names')
 assert(specialParentMetadata['toString.child'].visible && specialParentMetadata['__proto__.child'].visible, 'special parent ids do not prevent metadata construction')
 
-assert(menu.searchMatchPriority({ label: 'Apps', aliases: ['app', 'applications'] }, 'apps') === 4, 'exact labels have highest priority')
-assert(menu.searchMatchPriority({ label: 'Apps', aliases: ['app', 'applications'] }, 'app') === 3, 'exact aliases outrank prefixes')
-assert(menu.searchMatchPriority({ label: 'Apps', aliases: ['app', 'applications'] }, 'ap') === 2, 'alias prefixes outrank label prefixes')
-assert(menu.searchMatchPriority({ label: 'Apple Music', aliases: [] }, 'ap') === 1, 'label prefixes are recognized')
+assert(menu.searchMatchPriority({ kind: 'app', label: 'Apps', aliases: ['app', 'applications'] }, 'apps') === 90, 'exact app titles have highest item priority')
+assert(menu.searchMatchPriority({ kind: 'app', label: 'Apple Music', aliases: [] }, 'app') === 70, 'app title prefixes outrank menu shortcuts')
+assert(menu.searchMatchPriority({ kind: 'action', parent: 'apps', label: 'Work Browser', aliases: [] }, 'browser') === 60, 'whole-word titles in the Apps menu outrank exact menu shortcuts')
+assert(menu.searchMatchPriority({ kind: 'app', parent: 'apps', label: 'Chromium', aliases: ['Web Browser'] }, 'browser') === 55, 'apps matched through metadata outrank management shortcuts')
+assert(menu.searchMatchPriority({ kind: 'menu', label: 'Browser', aliases: [] }, 'browser') === 50, 'exact menu titles rank below matching apps')
+assert(menu.searchMatchPriority({ label: 'Utilities', aliases: ['app', 'applications'] }, 'app') === 40, 'exact aliases outrank menu title prefixes')
+assert(menu.searchMatchPriority({ label: 'Apps', aliases: ['app', 'applications'] }, 'ap') === 30, 'menu title prefixes outrank alias prefixes')
+assert(menu.searchMatchPriority({ label: 'Utilities', aliases: ['applications'] }, 'ap') === 10, 'alias prefixes are recognized')
 
 assert(menu.compareSearchRows(
   { matchPriority: 0, starred: false, usageCount: 2, lastUsedAt: 100, score: 20, path: 'A' },
@@ -274,10 +285,28 @@ assert(menu.compareSearchRows(
 ) < 0, 'recency breaks equal frequency ties')
 
 assert(menu.compareSearchRows(
-  { matchPriority: 3, starred: false, usageCount: 0, lastUsedAt: 0, score: 20, path: 'Apps' },
-  { matchPriority: 1, starred: true, usageCount: 10, lastUsedAt: 200, score: 0, path: 'Apple Music' },
+  { matchPriority: 70, starred: false, usageCount: 0, lastUsedAt: 0, score: 20, path: 'Apple Music' },
+  { matchPriority: 40, starred: true, usageCount: 10, lastUsedAt: 200, score: 0, path: 'Apps' },
   true
-) < 0, 'exact aliases remain ahead of learned prefix matches')
+) < 0, 'label prefixes remain ahead of exact aliases and learned ranking')
+
+assert(menu.compareSearchRows(
+  { matchPriority: 95, starred: false, usageCount: 0, lastUsedAt: 0, score: -3, path: 'Exact extension' },
+  { matchPriority: 90, starred: true, usageCount: 10, lastUsedAt: 200, score: 0, path: 'Exact app' },
+  true
+) < 0, 'exact extension activations outrank exact app titles')
+
+assert(menu.compareSearchRows(
+  { matchPriority: 95, starred: false, usageCount: 0, lastUsedAt: 0, score: -3, path: 'Exact extension' },
+  { matchPriority: 70, starred: true, usageCount: 10, lastUsedAt: 200, score: 0, path: 'App prefix' },
+  true
+) < 0, 'exact extension activations outrank app title prefixes')
+
+assert(menu.compareSearchRows(
+  { matchPriority: 60, starred: false, usageCount: 0, lastUsedAt: 0, score: 0, path: 'App word' },
+  { matchPriority: 20, starred: true, usageCount: 10, lastUsedAt: 200, score: -3, path: 'Partial extension' },
+  true
+) < 0, 'app title words outrank partial extension suggestions')
 
 assert(menu.compareSearchRows(
   { matchPriority: 0, starred: false, usageCount: 10, lastUsedAt: 200, score: 20, path: 'A' },


### PR DESCRIPTION
## Summary

- prioritize launchable apps over matching install/remove management routes
- rank exact extension prefixes above exact app titles while keeping partial extension suggestions below app matches
- rank extension results, app titles, aliases, and menu shortcuts through one consistent search order
- preserve unavailable-extension setup diagnostics at the bottom of capped result sets
- keep direct launchable actions under Apps, such as Work Browser and Personal Browser, on the app ranking path without treating Apps submenus as apps

## Ranking behavior

- explicit extension result
- explicit extension invocation
- exact extension prefix
- exact app title
- app title prefix
- app title whole-word or metadata match
- exact menu title
- exact alias
- menu title prefix
- partial extension suggestion
- alias prefix and other matches

## Tested examples

- `browser` ranks Work Browser, Personal Browser, Brave Origin, and Chromium ahead of Install/Remove Browser
- `image` ranks Image Viewer ahead of the Disks `image` keyword
- `files` ranks the exact Files extension above the Files app
- partial extension prefixes remain below matching apps
- unavailable extension diagnostics remain visible with more than 100 matching rows

## Tests

- `node tests/menu-model-test.js`
- `bash tests/manifest-test.sh`
- `bash tests/qalc-integration-test.sh`
- `bash tests/timezone-integration-test.sh`
- `python tests/file-index-integration-test.py`