### PR TITLE
Throttle launcher icon refresh scans

### DIFF
--- a/Menu.qml
+++ b/Menu.qml
@@ -124,6 +124,13 @@ Item {
   // Shared application engine (entries, hidden filters, icons, launch,
   // removal), owned by the shell and also used by the standalone launcher.
   readonly property var appLibrary: root.shell ? root.shell.appLibrary : null
+  readonly property int appIconRefreshTtlMs: 30 * 1000
+  property double appIconIndexUpdatedAt: 0
+  property bool appIconRefreshPending: false
+  onAppLibraryChanged: {
+    root.appIconIndexUpdatedAt = 0
+    root.appIconRefreshPending = false
+  }
   property bool deleteConfirmOpen: false
   property bool dependencyConfirmOpen: false
   property string pendingStarSelectionId: ""
@@ -238,6 +245,14 @@ Item {
     if (!command) return
 
     Util.execDetached(command)
+  }
+
+  function refreshAppIconsIfStale() {
+    if (!root.appLibrary || root.appIconRefreshPending) return
+    if (root.appIconIndexUpdatedAt > 0
+        && Date.now() - root.appIconIndexUpdatedAt < root.appIconRefreshTtlMs) return
+    root.appIconRefreshPending = true
+    root.appLibrary.refreshIcons()
   }
 
   // Menu rows only surface their detail while a search is narrowing them;
@@ -1413,8 +1428,9 @@ Item {
     loadProviderForMenu(activeMenu)
     if (activeMenu === "root") root.loadProviderForMenu("apps")
     // The shell may start before first-install packages have finished placing
-    // their icons. Refresh here even when the desktop entry list did not change.
-    if (root.appLibrary) root.appLibrary.refreshIcons()
+    // their icons. Keep the open-time fallback, but avoid rescanning every icon
+    // directory on each rapid launcher invocation.
+    root.refreshAppIconsIfStale()
 
     Qt.callLater(function() { keyCatcher.forceActiveFocus() })
   }
@@ -1715,7 +1731,15 @@ Item {
 
   Connections {
     target: root.appLibrary
+    function onIconIndexChanged() {
+      // iconIndex is swapped only when AppLibrary's asynchronous scan exits.
+      // Start the freshness window from completion, not from the request.
+      root.appIconIndexUpdatedAt = Date.now()
+      root.appIconRefreshPending = false
+    }
     function onAppsChanged() {
+      // AppLibrary owns app-change icon rescans; this signal can also mean only
+      // hidden filters changed, so it must not advance the freshness window.
       if (root.providersLoaded["apps"]) root.mergeAppRows()
     }
   }


### PR DESCRIPTION
## Summary

- coalesce repeated launcher opens while AppLibrary's icon scan is pending
- start a 30-second freshness window only when `iconIndexChanged` confirms the asynchronous scan completed
- preserve AppLibrary-owned desktop-entry rescans without treating unrelated `appsChanged` signals as refresh completion
- reset pending and freshness state if the injected AppLibrary instance changes

## Performance

The icon fallback scan walks application/device icon directories and costs about **100 ms** locally. Previously every launcher open after the preceding scan exited could start the filesystem walk again; repeated opens now reuse the completed index for 30 seconds.

## Validation

- manually deployed and verified against the local shell on top of current `master`
- independent review completed with no remaining blockers
- `node tests/menu-model-test.js`
- `bash tests/manifest-test.sh`
- `bash tests/timezone-integration-test.sh`
- `bash tests/qalc-integration-test.sh`
- `python tests/file-index-integration-test.py`
- `git diff --check`
