### PR TITLE
Prioritize starred search results

### DIFF
--- a/Menu.qml
+++ b/Menu.qml
@@ -1096,6 +1096,26 @@ Item {
         rows.push(row)
       }
 
+      // File favorites are synthetic starting-view rows rather than members of
+      // the menu tree, so add matching ones explicitly during global search.
+      if (active === "root") {
+        var searchFavoriteIds = Object.keys(favorites.starredIds)
+        var seenSearchFileFavorites = ({})
+        for (var searchFavoriteIndex = 0; searchFavoriteIndex < searchFavoriteIds.length; searchFavoriteIndex++) {
+          var searchFavorite = MenuModel.fileFavorite(searchFavoriteIds[searchFavoriteIndex])
+          var searchFavoriteItem = MenuModel.fileFavoriteItem(searchFavoriteIds[searchFavoriteIndex])
+          if (!searchFavorite || !searchFavoriteItem || seenSearchFileFavorites["$" + searchFavoriteItem.id]) continue
+          seenSearchFileFavorites["$" + searchFavoriteItem.id] = true
+          if (!MenuModel.matchesQuery(searchFavoriteItem, preparedQuery, true)) continue
+          searchFavoriteItem.icon = searchFavorite.type === "directory" ? "󰉋" : "󰈔"
+          var searchFavoriteRow = root.displayRow(searchFavoriteItem, searchFavorite.path, 0)
+          searchFavoriteRow.path = searchFavorite.path
+          searchFavoriteRow.starred = true
+          searchFavoriteRow.matchPriority = MenuModel.searchMatchPriority(searchFavoriteItem, preparedQuery)
+          rows.push(searchFavoriteRow)
+        }
+      }
+
       var extensionSuggestions = MenuModel.suggestExtensions(root.extensions, query)
       for (var suggestionIndex = extensionSuggestions.length - 1; suggestionIndex >= 0; suggestionIndex--) {
         var suggestion = extensionSuggestions[suggestionIndex]
@@ -1186,16 +1206,10 @@ Item {
         var seenFileFavorites = ({})
         for (var favoriteIndex = 0; favoriteIndex < favoriteIds.length; favoriteIndex++) {
           var favorite = MenuModel.fileFavorite(favoriteIds[favoriteIndex])
-          if (!favorite) continue
-          var favoriteId = MenuModel.fileFavoriteId(favorite.path, favorite.type, favorite.capability)
-          if (seenFileFavorites["$" + favoriteId]) continue
-          seenFileFavorites["$" + favoriteId] = true
-          var favoriteItem = root.normalizeItem(favoriteId, {
-            icon: favorite.type === "directory" ? "󰉋" : "󰈔",
-            label: MenuModel.fileFavoriteLabel(favorite.path),
-            description: favorite.path,
-            action: favorite.path
-          })
+          var favoriteItem = MenuModel.fileFavoriteItem(favoriteIds[favoriteIndex])
+          if (!favorite || !favoriteItem || seenFileFavorites["$" + favoriteItem.id]) continue
+          seenFileFavorites["$" + favoriteItem.id] = true
+          favoriteItem.icon = favorite.type === "directory" ? "󰉋" : "󰈔"
           var favoriteRow = root.displayRow(favoriteItem, favorite.path, favoriteItem.order || 0)
           favoriteRow.starred = true
           rows.push(favoriteRow)

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -791,10 +791,10 @@ function searchScore(items, entry, query, metadata) {
 }
 
 function compareSearchRows(a, b, useHistory) {
+  if (a.starred !== b.starred) return a.starred ? -1 : 1
   var aPriority = Math.max(0, Number(a.matchPriority) || 0)
   var bPriority = Math.max(0, Number(b.matchPriority) || 0)
   if (aPriority !== bPriority) return bPriority - aPriority
-  if (a.starred !== b.starred) return a.starred ? -1 : 1
 
   if (useHistory) {
     var aCount = Math.max(0, Number(a.usageCount) || 0)
@@ -914,6 +914,18 @@ function fileFavoriteLabel(path) {
   return value.substring(value.lastIndexOf("/") + 1)
 }
 
+function fileFavoriteItem(itemId) {
+  var favorite = fileFavorite(itemId)
+  if (!favorite) return null
+  var id = fileFavoriteId(favorite.path, favorite.type, favorite.capability)
+  return normalizeItem(id, {
+    label: fileFavoriteLabel(favorite.path),
+    description: favorite.path,
+    // Make each path component searchable without changing the visible path.
+    aliases: [favorite.path.replace(/[\/._-]+/g, " ")],
+    action: favorite.path
+  })
+}
 
 function displayRow(items, itemOrder, checkedResults, entry, detail, score, section, metadata) {
   var target = entry.kind === "link" ? entry.target : entry.id
@@ -1111,6 +1123,7 @@ if (typeof module !== "undefined") {
     fileFavoriteType: fileFavoriteType,
     fileFavoriteCapability: fileFavoriteCapability,
     fileFavoriteLabel: fileFavoriteLabel,
+    fileFavoriteItem: fileFavoriteItem,
     displayRow: displayRow
   }
 }

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This workaround can be removed once Omarchy supports setting a widget’s sectio
 
 ## Starred favorites
 
-Star frequently used applications, commands, files, and directories on the launcher’s starting view.
+Star frequently used applications, commands, files, and directories on the launcher’s starting view. Matching starred items rank above unstarred search results, and starred files and directories are searchable by name or path.
 
 ![Starred favorites in Omalaunch](assets/starred-favorites.png)
 

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -98,6 +98,13 @@ assert(menu.fileFavoriteId('/tmp/notes.txt', 'file', '') === '', 'path favorites
 assert(menu.fileFavorite('file.favorite:not-json') === null, 'malformed path favorites are ignored')
 assert(menu.fileFavoriteLabel('/tmp/Projects/') === 'Projects', 'path favorites use their basename as a label')
 assert(menu.fileFavoriteLabel('/') === '/', 'the filesystem root has a useful favorite label')
+const favoriteSearchItem = menu.fileFavoriteItem('file.favorite.directory:/home/quantumfire/Downloads')
+assert(favoriteSearchItem.id === menu.fileFavoriteId('/home/quantumfire/Downloads', 'directory', 'files'), 'favorite search items canonicalize legacy ids')
+assert(favoriteSearchItem.label === 'Downloads' && favoriteSearchItem.action === '/home/quantumfire/Downloads', 'favorite search items retain their label and path action')
+assert(menu.matchesQuery(favoriteSearchItem, menu.prepareSearchQuery('downloads'), true), 'favorite search items match their visible labels')
+assert(menu.matchesQuery(favoriteSearchItem, menu.prepareSearchQuery('home quantumfire'), true), 'favorite search items match path components')
+assert(!menu.matchesQuery(favoriteSearchItem, menu.prepareSearchQuery('documents'), true), 'nonmatching file favorites remain hidden from search')
+assert(menu.fileFavoriteItem('app.example') === null, 'ordinary starred items do not become synthetic file rows')
 
 const queryExtensions = menu.parseExtensions(JSON.stringify([
   {
@@ -312,25 +319,25 @@ assert(menu.compareSearchRows(
   { matchPriority: 70, starred: false, usageCount: 0, lastUsedAt: 0, score: 20, path: 'Apple Music' },
   { matchPriority: 40, starred: true, usageCount: 10, lastUsedAt: 200, score: 0, path: 'Apps' },
   true
-) < 0, 'label prefixes remain ahead of exact aliases and learned ranking')
+) > 0, 'starred aliases outrank unstarred title prefixes')
 
 assert(menu.compareSearchRows(
   { matchPriority: 95, starred: false, usageCount: 0, lastUsedAt: 0, score: -3, path: 'Exact extension' },
   { matchPriority: 90, starred: true, usageCount: 10, lastUsedAt: 200, score: 0, path: 'Exact app' },
   true
-) < 0, 'exact extension activations outrank exact app titles')
+) > 0, 'starred exact apps outrank exact extension activations')
 
 assert(menu.compareSearchRows(
   { matchPriority: 95, starred: false, usageCount: 0, lastUsedAt: 0, score: -3, path: 'Exact extension' },
   { matchPriority: 70, starred: true, usageCount: 10, lastUsedAt: 200, score: 0, path: 'App prefix' },
   true
-) < 0, 'exact extension activations outrank app title prefixes')
+) > 0, 'starred app title prefixes outrank exact extension activations')
 
 assert(menu.compareSearchRows(
   { matchPriority: 60, starred: false, usageCount: 0, lastUsedAt: 0, score: 0, path: 'App word' },
   { matchPriority: 20, starred: true, usageCount: 10, lastUsedAt: 200, score: -3, path: 'Partial extension' },
   true
-) < 0, 'app title words outrank partial extension suggestions')
+) > 0, 'starred weak matches outrank unstarred app title words')
 
 const crowdedRows = []
 for (let rowIndex = 0; rowIndex < 105; rowIndex++) {
@@ -380,12 +387,13 @@ assert(saturatedRows[0].itemId === 'live-result', 'saturated diagnostics preserv
 assert(saturatedRows.slice(1).every(row => row.itemId.indexOf('diagnostic-') === 0), 'remaining saturated slots are reserved for diagnostics')
 
 const assembledRanking = menu.rankSearchRows([
+  { itemId: 'starred-favorite', matchPriority: 30, starred: true, usageCount: 0, lastUsedAt: 0, score: 10, path: 'Starred favorite' },
   { itemId: 'partial-extension', matchPriority: 20, starred: false, usageCount: 0, lastUsedAt: 0, score: -3, path: 'Partial extension' },
   { itemId: 'exact-app', matchPriority: 90, starred: false, usageCount: 0, lastUsedAt: 0, score: 0, path: 'Exact app' },
   { itemId: 'exact-extension', matchPriority: 95, starred: false, usageCount: 0, lastUsedAt: 0, score: -3, path: 'Exact extension' },
   { itemId: 'live-result', matchPriority: 110, starred: false, usageCount: 0, lastUsedAt: 0, score: -1, path: 'Live result' }
 ], [], true, 100)
-assert(assembledRanking.map(row => row.itemId).join(',') === 'live-result,exact-extension,exact-app,partial-extension', 'assembled rows apply extension and app priority tiers')
+assert(assembledRanking.map(row => row.itemId).join(',') === 'starred-favorite,live-result,exact-extension,exact-app,partial-extension', 'assembled rows rank starred matches before extension and app priority tiers')
 
 assert(menu.compareSearchRows(
   { matchPriority: 0, starred: false, usageCount: 10, lastUsedAt: 200, score: 20, path: 'A' },


### PR DESCRIPTION
## Summary

- rank matching starred items ahead of all unstarred search results
- include starred files and directories in global search
- match file favorites by visible label and path components
- canonicalize and deduplicate legacy file-favorite IDs
- preserve existing capability-aware file and directory activation

## Behavior

Starring is now an explicit persistent ranking override. A matching starred item outranks exact extension prefixes, app-title matches, aliases, usage history, and text relevance.

Synthetic file and directory favorites previously appeared only on the starting view. They now participate in root-level search while remaining hidden when their label and path do not match.

## Tests

- `node tests/menu-model-test.js`
- `bash tests/manifest-test.sh`
- `bash tests/qalc-integration-test.sh`
- `bash tests/timezone-integration-test.sh`
- `python tests/file-index-integration-test.py`

Also manually verified the legacy starred Downloads directory appears first for a `downloads` search in the active Omalaunch instance.