### PR TITLE
Coalesce menu source rebuilds

### DIFF
--- a/Menu.qml
+++ b/Menu.qml
@@ -19,8 +19,12 @@ Item {
   // Plugin lifecycle hooks. The host calls open(payloadJson) after
   // `omarchy-shell shell summon quantumfire.omalaunch ...` and close() when hidden.
   property string pendingInitialMenu: "root"
+  property bool routePendingForMenuSources: false
 
   function open(payloadJson) {
+    // Every accepted dmenu request must complete even if another summon
+    // replaces it before the caller has selected a result.
+    if (root.dmenuActive && root.requestActive) root.finishRequest(null)
     root.loadExtensions(false)
     var payload = ({})
     try { payload = JSON.parse(payloadJson || "{}") } catch (e) { payload = ({}) }
@@ -39,8 +43,8 @@ Item {
   }
 
   function refresh() {
-    defaultMenuFile.reload()
-    userMenuFile.reload()
+    root.requestDefaultMenuReload()
+    root.requestUserMenuReload()
     root.loadExtensions(true)
     return "ok"
   }
@@ -55,6 +59,14 @@ Item {
   property string userMenuPath: Quickshell.env("HOME") + "/.config/omarchy/extensions/omarchy-menu.jsonc"
   property var defaultMenuItems: []
   property var userMenuItems: []
+  property bool defaultMenuSettled: false
+  property bool userMenuSettled: false
+  // FileView does not queue reload() while an asynchronous read is active.
+  // Track each read and collapse intervening changes into one trailing reload.
+  property bool defaultMenuLoading: true
+  property bool userMenuLoading: true
+  property bool defaultMenuReloadPending: false
+  property bool userMenuReloadPending: false
   property var extensions: []
   property var extensionDiagnostics: []
   property var unavailableResultExtension: null
@@ -724,6 +736,10 @@ Item {
     return MenuModel.parseMenuJsonc(raw)
   }
 
+  function parseMenuJsoncSnapshot(raw) {
+    return MenuModel.parseMenuJsoncSnapshot(raw)
+  }
+
   // Merge defaults + user extension. Later entries override earlier ones
   // on a per-key basis (so the user can tweak label/icon/action without
   // re-declaring the whole row).
@@ -751,6 +767,12 @@ Item {
     root.rebuildItemMetadata()
     root.rowsLoaded = true
     root.evaluateGuards(true)
+    if (root.routePendingForMenuSources) {
+      var pendingRoute = root.pendingInitialMenu
+      root.routePendingForMenuSources = false
+      root.openRoute(pendingRoute)
+      return
+    }
     if (root.opened) {
       root.rebuildDisplay()
       if (!root.dmenuActive) {
@@ -1535,6 +1557,7 @@ Item {
   }
 
   function cancel() {
+    root.routePendingForMenuSources = false
     if (root.dmenuActive) root.finishRequest(null)
     root.resetFileIndex()
     root.actionPanelActive = false
@@ -1574,6 +1597,7 @@ Item {
   }
 
   function openDmenu(payload) {
+    root.routePendingForMenuSources = false
     requestSerial += 1
     mode = payload.mode === "input" ? "input" : "select"
     dmenuPrompt = String(payload.prompt || (mode === "input" ? "Input" : "Select"))
@@ -1624,6 +1648,15 @@ Item {
   }
 
   function openRoute(initialMenu) {
+    if (!root.rowsLoaded || !root.defaultMenuSettled || !root.userMenuSettled
+        || menuSourceRebuildCoalescer.running) {
+      // Resolve aliases and actions only after both menu snapshots have been
+      // merged. The latest summon wins if several arrive during a reload.
+      root.pendingInitialMenu = initialMenu
+      root.routePendingForMenuSources = true
+      return "ok"
+    }
+    root.routePendingForMenuSources = false
     var id = root.resolveRoute(initialMenu)
     var entry = root.items[id]
     // If the resolved id is an action (i.e. the user invoked an alias for
@@ -1916,13 +1949,88 @@ Item {
   // The JSONC sources are watched so live edits to the default file (or the
   // user extension at ~/.config/omarchy/extensions/omarchy-menu.jsonc) take
   // effect without restarting the shell.
+  // The default and user FileViews settle independently at startup and during
+  // refreshes. A full rebuild resets providers and forces an expensive guard
+  // batch, so wait for both initial snapshots and coalesce later change bursts
+  // into one bounded rebuild window.
+  function scheduleMenuSourceRebuild() {
+    if (!root.defaultMenuSettled || !root.userMenuSettled) return
+    if (!menuSourceRebuildCoalescer.running) menuSourceRebuildCoalescer.start()
+  }
+
+  function requestDefaultMenuReload() {
+    root.defaultMenuSettled = false
+    if (root.defaultMenuLoading) {
+      root.defaultMenuReloadPending = true
+      return
+    }
+    root.defaultMenuLoading = true
+    defaultMenuFile.reload()
+  }
+
+  function requestUserMenuReload() {
+    root.userMenuSettled = false
+    if (root.userMenuLoading) {
+      root.userMenuReloadPending = true
+      return
+    }
+    root.userMenuLoading = true
+    userMenuFile.reload()
+  }
+
+  function finishDefaultMenuReload() {
+    if (root.defaultMenuReloadPending) {
+      root.defaultMenuReloadPending = false
+      // Leave loading set while callLater moves beyond FileView's completion
+      // signal; reload() during that signal can still target the old read.
+      Qt.callLater(function() { defaultMenuFile.reload() })
+      return
+    }
+    root.defaultMenuLoading = false
+    root.defaultMenuSettled = true
+    root.scheduleMenuSourceRebuild()
+  }
+
+  function finishUserMenuReload() {
+    if (root.userMenuReloadPending) {
+      root.userMenuReloadPending = false
+      Qt.callLater(function() { userMenuFile.reload() })
+      return
+    }
+    root.userMenuLoading = false
+    root.userMenuSettled = true
+    root.scheduleMenuSourceRebuild()
+  }
+
+  Timer {
+    id: menuSourceRebuildCoalescer
+    interval: 50
+    repeat: false
+    onTriggered: {
+      // A reload may start while this fixed window is running. Its completion
+      // schedules the next window, so never rebuild from an in-flight snapshot.
+      if (root.defaultMenuSettled && root.userMenuSettled)
+        root.rebuildItemsFromSources()
+    }
+  }
+
   FileView {
     id: defaultMenuFile
     path: root.defaultMenuPath
     watchChanges: true
     printErrors: false
-    onLoaded: { root.defaultMenuItems = root.parseMenuJsonc(text()); root.rebuildItemsFromSources() }
-    onFileChanged: reload()
+    onLoaded: {
+      var snapshot = root.parseMenuJsoncSnapshot(text())
+      // A truncate-and-write save can expose partial JSON through a successful
+      // read. Keep the last valid snapshot until a complete document arrives.
+      if (snapshot.valid) root.defaultMenuItems = snapshot.items
+      root.finishDefaultMenuReload()
+    }
+    onLoadFailed: {
+      // Keep the last valid default snapshot across transient reload failures.
+      root.finishDefaultMenuReload()
+    }
+    onFileChanged: root.requestDefaultMenuReload()
   }
 
   FileView {
@@ -1930,9 +2038,16 @@ Item {
     path: root.userMenuPath
     watchChanges: true
     printErrors: false
-    onLoaded: { root.userMenuItems = root.parseMenuJsonc(text()); root.rebuildItemsFromSources() }
-    onLoadFailed: { root.userMenuItems = []; root.rebuildItemsFromSources() }
-    onFileChanged: reload()
+    onLoaded: {
+      var snapshot = root.parseMenuJsoncSnapshot(text())
+      if (snapshot.valid) root.userMenuItems = snapshot.items
+      root.finishUserMenuReload()
+    }
+    onLoadFailed: {
+      root.userMenuItems = []
+      root.finishUserMenuReload()
+    }
+    onFileChanged: root.requestUserMenuReload()
   }
 
   // ---------------------------------------------------------------- guards

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -38,17 +38,18 @@ function normalizeItem(id, raw) {
   }
 }
 
-function parseMenuJsonc(raw) {
+function parseMenuJsoncSnapshot(raw) {
   var stripped = stripJsonc(raw)
-  if (!stripped.trim()) return []
+  if (!stripped.trim()) return { valid: false, items: [] }
 
   var parsed
   try {
     parsed = JSON.parse(stripped)
   } catch (e) {
-    return []
+    return { valid: false, items: [] }
   }
-  if (typeof parsed !== "object" || parsed === null) return []
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed))
+    return { valid: false, items: [] }
 
   var source = (parsed.items && typeof parsed.items === "object" && !Array.isArray(parsed.items))
     ? parsed.items
@@ -59,7 +60,11 @@ function parseMenuJsonc(raw) {
     if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue
     out.push(normalizeItem(id, entry))
   }
-  return out
+  return { valid: true, items: out }
+}
+
+function parseMenuJsonc(raw) {
+  return parseMenuJsoncSnapshot(raw).items
 }
 
 function mergeMenuSources(defaultItems, userItems) {
@@ -1072,6 +1077,7 @@ if (typeof module !== "undefined") {
     normalizeAliases: normalizeAliases,
     normalizeItem: normalizeItem,
     parseMenuJsonc: parseMenuJsonc,
+    parseMenuJsoncSnapshot: parseMenuJsoncSnapshot,
     mergeMenuSources: mergeMenuSources,
     mergeAppRows: mergeAppRows,
     swapProviderRows: swapProviderRows,

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -14,6 +14,12 @@ const context = { module: { exports: {} } }
 vm.runInNewContext(source, context)
 const menu = context.module.exports
 
+const validMenuSnapshot = menu.parseMenuJsoncSnapshot('{"items":{"root":{"label":"Root"}}}')
+assert(validMenuSnapshot.valid && validMenuSnapshot.items.length === 1, 'valid menu snapshots are identified')
+assert(menu.parseMenuJsoncSnapshot('{}').valid, 'empty menu objects remain valid snapshots')
+assert(!menu.parseMenuJsoncSnapshot('{"items":').valid, 'partial menu JSON is an invalid snapshot')
+assert(!menu.parseMenuJsoncSnapshot('').valid, 'empty menu files are invalid snapshots')
+
 const extensions = menu.parseExtensions(JSON.stringify([{
   schemaVersion: 1,
   id: 'pi-agent',


### PR DESCRIPTION
## Summary

- wait for both default and user menu sources to settle before the initial item rebuild
- coalesce later source-change bursts in a fixed 50 ms window
- preserve the last valid default snapshot across transient reload failures

## Performance

Each source rebuild resets provider state, rebuilds derived metadata and the visible model, and forces a complete guard evaluation. The default and user FileViews previously requested that work independently at startup and during refreshes. On the current 318-item default menu, one 180-expression guard batch takes approximately 570 ms locally; coalescing startup avoids the duplicate batch and associated provider churn.

## Validation

- instrumented local shell startup observed exactly one `rebuildItemsFromSources()` call
- local shell loaded without QML errors
- installed plugin modifications were preserved and restored byte-for-byte after smoke testing
- `node tests/menu-model-test.js`
- `bash tests/manifest-test.sh`
- `bash tests/timezone-integration-test.sh`
- `bash tests/qalc-integration-test.sh`
- `PYTHONDONTWRITEBYTECODE=1 python tests/file-index-integration-test.py`
- `git diff --check`


## Review follow-up

- defer startup routes until source rows exist, preserving the latest submenu, alias, or action summon
- reset source-settled state for explicit refreshes so rebuilding waits for both refreshed snapshots
- queue one trailing source reload when changes arrive during an active FileView read
- suppress timer rebuilds while either source snapshot is in flight
- retain the last valid default menu across transient load failures

- defer route resolution throughout source reload and pre-rebuild windows, not only initial startup
- complete an active dmenu request before a replacement summon
- distinguish valid empty menus from malformed/partial JSON and retain last-good snapshots
