### PR TITLE
Add Tab result navigation

### DIFF
--- a/Menu.qml
+++ b/Menu.qml
@@ -2095,6 +2095,10 @@ Item {
             else if (root.fileBrowserActive) root.leaveFileBrowser()
             else root.cancel()
             event.accepted = true
+          } else if ((event.key === Qt.Key_Tab || event.key === Qt.Key_Backtab)
+              && !(event.modifiers & (Qt.ControlModifier | Qt.AltModifier | Qt.MetaModifier))) {
+            root.select(event.key === Qt.Key_Backtab || (event.modifiers & Qt.ShiftModifier) ? -1 : 1)
+            event.accepted = true
           } else if (Util.editsFilter(event, root.filterText)) {
             root.setFilter(Util.editedFilter(event, root.filterText))
             event.accepted = true

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Omalaunch never installs system packages silently. Package installation is offer
 
 ## Usage
 
-Start typing to search commands and applications. Use the arrow keys to move, Enter to activate, and Escape to go back or close the launcher.
+Start typing to search commands and applications. Use the arrow keys or Tab and Shift+Tab to move, Enter to activate, and Escape to go back or close the launcher.
 
 Examples:
 


### PR DESCRIPTION
## Summary
- navigate to the next result with Tab
- navigate to the previous result with Shift+Tab
- leave Ctrl/Alt/Meta modified Tab shortcuts untouched
- document the new navigation keys

## Testing
- `node tests/menu-model-test.js`
- `bash tests/manifest-test.sh`
- `bash tests/qalc-integration-test.sh`
- `bash tests/timezone-integration-test.sh`
- `python tests/file-index-integration-test.py`
- `omarchy plugin validate .worktrees/tab-navigation`
- manually verified Tab and Shift+Tab navigation in Omalaunch