### PR TITLE
Ignore favorite metadata in search

### DIFF
--- a/Menu.qml
+++ b/Menu.qml
@@ -1143,7 +1143,7 @@ Item {
           var searchFavoriteItem = MenuModel.fileFavoriteItem(searchFavoriteIds[searchFavoriteIndex])
           if (!searchFavorite || !searchFavoriteItem || seenSearchFileFavorites["$" + searchFavoriteItem.id]) continue
           seenSearchFileFavorites["$" + searchFavoriteItem.id] = true
-          if (!MenuModel.matchesQuery(searchFavoriteItem, preparedQuery, true)) continue
+          if (!MenuModel.matchesFileFavoriteQuery(searchFavoriteItem, preparedQuery)) continue
           searchFavoriteItem.icon = searchFavorite.type === "directory" ? "󰉋" : "󰈔"
           var searchFavoriteRow = root.displayRow(searchFavoriteItem, searchFavorite.path, 0)
           searchFavoriteRow.path = searchFavorite.path

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -932,6 +932,19 @@ function fileFavoriteItem(itemId) {
   })
 }
 
+function matchesFileFavoriteQuery(entry, query) {
+  if (!entry) return false
+  var prepared = query && typeof query === "object" ? query : prepareSearchQuery(query)
+  var aliases = Array.isArray(entry.aliases) ? entry.aliases : []
+  // Deliberately exclude the canonical id: it contains implementation details
+  // such as the extension capability (`files`) and path type (`directory`).
+  var searchText = [entry.label].concat(aliases).join(" ").toLowerCase()
+  for (var i = 0; i < prepared.terms.length; i++) {
+    if (prepared.terms[i] && searchText.indexOf(prepared.terms[i]) < 0) return false
+  }
+  return prepared.terms.length > 0
+}
+
 function displayRow(items, itemOrder, checkedResults, entry, detail, score, section, metadata) {
   var target = entry.kind === "link" ? entry.target : entry.id
   return {
@@ -1130,6 +1143,7 @@ if (typeof module !== "undefined") {
     fileFavoriteCapability: fileFavoriteCapability,
     fileFavoriteLabel: fileFavoriteLabel,
     fileFavoriteItem: fileFavoriteItem,
+    matchesFileFavoriteQuery: matchesFileFavoriteQuery,
     displayRow: displayRow
   }
 }

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -107,9 +107,13 @@ assert(menu.fileFavoriteLabel('/') === '/', 'the filesystem root has a useful fa
 const favoriteSearchItem = menu.fileFavoriteItem('file.favorite.directory:/home/quantumfire/Downloads')
 assert(favoriteSearchItem.id === menu.fileFavoriteId('/home/quantumfire/Downloads', 'directory', 'files'), 'favorite search items canonicalize legacy ids')
 assert(favoriteSearchItem.label === 'Downloads' && favoriteSearchItem.action === '/home/quantumfire/Downloads', 'favorite search items retain their label and path action')
-assert(menu.matchesQuery(favoriteSearchItem, menu.prepareSearchQuery('downloads'), true), 'favorite search items match their visible labels')
-assert(menu.matchesQuery(favoriteSearchItem, menu.prepareSearchQuery('home quantumfire'), true), 'favorite search items match path components')
-assert(!menu.matchesQuery(favoriteSearchItem, menu.prepareSearchQuery('documents'), true), 'nonmatching file favorites remain hidden from search')
+assert(menu.matchesFileFavoriteQuery(favoriteSearchItem, menu.prepareSearchQuery('downloads')), 'favorite search items match their visible labels')
+assert(menu.matchesFileFavoriteQuery(favoriteSearchItem, menu.prepareSearchQuery('home quantumfire')), 'favorite search items match path components')
+assert(!menu.matchesFileFavoriteQuery(favoriteSearchItem, menu.prepareSearchQuery('documents')), 'nonmatching file favorites remain hidden from search')
+assert(!menu.matchesFileFavoriteQuery(favoriteSearchItem, menu.prepareSearchQuery('files')), 'favorite search ignores the hidden extension capability in canonical ids')
+assert(!menu.matchesFileFavoriteQuery(favoriteSearchItem, menu.prepareSearchQuery('directory')), 'favorite search ignores the hidden path type in canonical ids')
+const filesPathFavorite = menu.fileFavoriteItem(menu.fileFavoriteId('/home/quantumfire/files/Downloads', 'directory', 'files'))
+assert(menu.matchesFileFavoriteQuery(filesPathFavorite, menu.prepareSearchQuery('files')), 'favorite search still matches capability-like words when they occur in the visible path')
 assert(menu.fileFavoriteItem('app.example') === null, 'ordinary starred items do not become synthetic file rows')
 
 const queryExtensions = menu.parseExtensions(JSON.stringify([


### PR DESCRIPTION
## Summary

- match starred files and directories using only their visible label and path components
- exclude canonical favorite IDs from search matching
- prevent hidden extension capabilities such as `files` and path types such as `directory` from producing false matches
- continue matching capability-like words when they genuinely occur in a visible path

## Example

For `/home/quantumfire/Downloads`:

- `downloads` matches
- `home quantumfire` matches
- `files` does not match
- `directory` does not match

## Tests

- `node tests/menu-model-test.js`
- `bash tests/manifest-test.sh`
- `bash tests/qalc-integration-test.sh`
- `bash tests/timezone-integration-test.sh`
- `python tests/file-index-integration-test.py`

Manually verified in the active Omalaunch instance that a starred Downloads directory no longer appears for `files`.