### PR TITLE
Add configurable capability providers

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -230,3 +230,18 @@ Missing dependencies leave an extension visible but unavailable with a clear mes
 The `requires` field declares executable requirements only. It does not authorize package installation, and external extensions cannot provide commands for Omalaunch to install system packages. Omalaunch may offer explicit installation only for dependencies in its own trusted allow-list, after showing the exact command and receiving user confirmation.
 
 Malformed extensions are ignored. Omarchy plugins are trusted local software and extension commands run as the current user.
+
+## Configuration
+
+Omalaunch reads its core settings from the dedicated `~/.config/omarchy/omalaunch/config.jsonc` file. JSONC comments and trailing commas are accepted. Invalid, oversized (more than 64 KiB), over-depth, or unsupported configuration is ignored with a diagnostic.
+
+Select a provider by extension `id` in `config.jsonc`. The key is the capability identity. If the requested provider is missing or unavailable, Omalaunch reports it and uses normal priority and replacement resolution.
+
+```jsonc
+{
+  "version": 1,
+  "capabilities": {
+    "files": { "provider": "example.files" },
+  },
+}
+```

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -897,21 +897,35 @@ function lookupKey(value) {
   return "$" + String(value || "")
 }
 
-function resolveExtensions(extensions) {
+function resolveExtensions(extensions, providerPreferences, diagnostics, diagnosticState) {
   var selected = ({})
   var order = []
   var values = Array.isArray(extensions) ? extensions : []
+  var preferences = providerPreferences && typeof providerPreferences === "object" ? providerPreferences : ({})
   for (var i = 0; i < values.length; i++) {
     var extension = values[i]
     var key = lookupKey(extension.capability)
     var current = selected[key]
     if (!current) order.push(key)
-    if (!current
+    var preferredId = typeof preferences[extension.capability] === "string" ? preferences[extension.capability] : ""
+    if (preferredId && extension.id === preferredId && extension.available) selected[key] = extension
+    else if (current && preferredId && current.id === preferredId && current.available) continue
+    else if (!current
         || (extension.available && !current.available)
         || (extension.available === current.available && extension.priority > current.priority)
         || (extension.available === current.available && extension.priority === current.priority
           && current.bundled && !extension.bundled))
       selected[key] = extension
+  }
+  for (var capability in preferences) {
+    if (!Object.prototype.hasOwnProperty.call(preferences, capability)) continue
+    var requested = preferences[capability]
+    var found = null
+    for (var valueIndex = 0; valueIndex < values.length; valueIndex++)
+      if (values[valueIndex].capability === capability && values[valueIndex].id === requested) found = values[valueIndex]
+    if (!found || !found.available) appendExtensionDiagnostic(diagnostics,
+      "Configured provider '" + requested + "' for capability '" + capability + "' is "
+        + (found ? "unavailable" : "missing") + "; normal provider resolution was used", diagnosticState)
   }
   var result = []
   for (var orderIndex = 0; orderIndex < order.length; orderIndex++) result.push(selected[order[orderIndex]])
@@ -957,6 +971,8 @@ function parseExtensionCatalog(text) {
     }
   } else if (!Array.isArray(values)) values = [values]
 
+  var providerPreferences = parsed && typeof parsed.providerPreferences === "object" && !Array.isArray(parsed.providerPreferences)
+    ? parsed.providerPreferences : ({})
   var extensions = []
   var ids = ({})
   if (values.length > MAX_EXTENSION_CATALOG_VALUES)
@@ -980,7 +996,7 @@ function parseExtensionCatalog(text) {
       appendExtensionDiagnostic(diagnostics, extension.id + " is missing: " + extension.missingRequires.join(", "), diagnosticState)
   }
 
-  var resolved = resolveExtensions(extensions)
+  var resolved = resolveExtensions(extensions, providerPreferences, diagnostics, diagnosticState)
   var prefixes = ({})
   for (var j = 0; j < resolved.length; j++) {
     var current = resolved[j]

--- a/README.md
+++ b/README.md
@@ -150,6 +150,19 @@ Omalaunch reads the stock Omarchy menu and the standard user menu override:
 
 Favorites and usage data are stored in the user's state directory. Currency refreshes use `qalc` and respect a persistent cooldown to avoid unnecessary network requests.
 
+Omalaunch core settings live in the dedicated `~/.config/omarchy/omalaunch/config.jsonc` file. Select a preferred extension provider by capability:
+
+```jsonc
+{
+  "version": 1,
+  "capabilities": {
+    "files": { "provider": "omalaunch.files" },
+  },
+}
+```
+
+If a preferred provider is missing or unavailable, Omalaunch reports a diagnostic and uses its normal provider selection rules.
+
 ## Updating
 
 ```bash

--- a/libexec/load-extensions.py
+++ b/libexec/load-extensions.py
@@ -37,6 +37,8 @@ MAX_DIAGNOSTICS = 256
 MAX_DIAGNOSTIC_CHARS = 1024
 MAX_SAFE_JSON_INTEGER = 9007199254740991
 AGGREGATE_PROVIDER_SECONDS = 15.0
+MAX_CONFIG_INPUT_BYTES = 64 * 1024
+MAX_CONFIG_CAPABILITIES = 128
 
 
 @dataclass(frozen=True)
@@ -71,6 +73,11 @@ class CatalogBuilder:
         self.definition_limit_reported = False
         self.byte_limit_reported = False
         self.diagnostic_limit_reported = False
+        self.provider_preferences: dict[str, str] = {}
+        # This normalized object is the stable loader-to-host envelope for
+        # current and future Omalaunch core settings. Only validated settings
+        # are copied from the user-owned config file.
+        self.omalaunch_config: dict[str, Any] = {}
         # Reserve room for useful diagnostics. The final envelope still uses
         # the exact public catalog limit and trims diagnostics linearly.
         reserve = min(64 * 1024, max(64, limits.catalog_output_bytes // 4))
@@ -135,7 +142,13 @@ class CatalogBuilder:
         """Return a bounded envelope even if defensive final encoding fails."""
         try:
             validate_json_depth(self.catalog, self.limits.json_nesting_depth + 1)
-            result = {"extensions": self.catalog, "diagnostics": [], "complete": complete}
+            result = {
+                "extensions": self.catalog,
+                "diagnostics": [],
+                "complete": complete,
+                "providerPreferences": self.provider_preferences,
+                "omalaunchConfig": self.omalaunch_config,
+            }
             base_size = len(self.encoded(result))
             used = base_size
             omitted = False
@@ -303,6 +316,75 @@ def parse_json(value: str | bytes, *, maximum_depth: int = MAX_JSON_NESTING_DEPT
     return parsed
 
 
+def strip_jsonc(value: bytes) -> str:
+    """Remove JSONC comments and trailing commas without changing strings."""
+    text = value.decode("utf-8")
+    output: list[str] = []
+    index = 0
+    in_string = False
+    escaped = False
+    while index < len(text):
+        char = text[index]
+        if in_string:
+            output.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            index += 1
+            continue
+        if char == '"':
+            in_string = True
+            output.append(char)
+            index += 1
+        elif text.startswith("//", index):
+            end = text.find("\n", index + 2)
+            index = len(text) if end < 0 else end
+        elif text.startswith("/*", index):
+            end = text.find("*/", index + 2)
+            if end < 0:
+                raise ValueError("unterminated block comment")
+            output.append(" ")
+            output.extend("\n" for item in text[index:end + 2] if item == "\n")
+            index = end + 2
+        else:
+            output.append(char)
+            index += 1
+    # A second string-aware pass removes only commas followed by ] or }.
+    text = "".join(output)
+    output = []
+    index = 0
+    in_string = escaped = False
+    while index < len(text):
+        char = text[index]
+        if in_string:
+            output.append(char)
+            if escaped: escaped = False
+            elif char == "\\": escaped = True
+            elif char == '"': in_string = False
+        elif char == '"':
+            in_string = True
+            output.append(char)
+        elif char == ',':
+            lookahead = index + 1
+            while lookahead < len(text) and text[lookahead].isspace(): lookahead += 1
+            if lookahead >= len(text) or text[lookahead] not in "]}": output.append(char)
+        else:
+            output.append(char)
+        index += 1
+    return "".join(output)
+
+
+def read_jsonc(path: Path, *, size_limit: int = MAX_CONFIG_INPUT_BYTES,
+               maximum_depth: int = MAX_JSON_NESTING_DEPTH) -> Any:
+    size = path.stat().st_size
+    if size > size_limit:
+        raise ValueError(f"file is {size} bytes; limit is {size_limit} bytes")
+    return parse_json(strip_jsonc(path.read_bytes()), maximum_depth=maximum_depth)
+
+
 def read_json(path: Path, *, size_limit: int | None = None,
               maximum_depth: int = MAX_JSON_NESTING_DEPTH) -> Any:
     if size_limit is not None:
@@ -359,6 +441,38 @@ def provider_failure(source: str, status: str, stderr: bytes, output_limit: int)
         reason = f"could not start ({status.split(':', 1)[-1]})"
     detail = stderr.decode("utf-8", "replace").strip()[:DIAGNOSTIC_STDERR_BYTES]
     return f"Extension provider {source} {reason}" + (f": {detail}" if detail else "")
+
+
+def load_user_configuration(home: Path, builder: CatalogBuilder, limits: Limits) -> None:
+    config_root = home / ".config" / "omarchy" / "omalaunch"
+    main_path = config_root / "config.jsonc"
+    if main_path.exists():
+        try:
+            value = read_jsonc(main_path, maximum_depth=limits.json_nesting_depth)
+            if not isinstance(value, dict) or value.get("version") != 1:
+                raise ValueError("expected an object with version 1")
+            capabilities = value.get("capabilities", {})
+            if not isinstance(capabilities, dict):
+                raise ValueError("capabilities must be an object")
+            if len(capabilities) > MAX_CONFIG_CAPABILITIES:
+                builder.diagnostic(f"Configuration {main_path} has more than {MAX_CONFIG_CAPABILITIES} capabilities; trailing entries were ignored")
+            normalized_capabilities: dict[str, dict[str, str]] = {}
+            for capability, setting in list(capabilities.items())[:MAX_CONFIG_CAPABILITIES]:
+                if not isinstance(capability, str) or not capability or not isinstance(setting, dict):
+                    builder.diagnostic(f"Ignored invalid capability selection in {main_path}: {capability!r}")
+                    continue
+                provider = setting.get("provider")
+                if not isinstance(provider, str) or not provider:
+                    builder.diagnostic(f"Ignored invalid provider for capability {capability!r} in {main_path}")
+                    continue
+                builder.provider_preferences[capability] = provider
+                normalized_capabilities[capability] = {"provider": provider}
+            builder.omalaunch_config = {
+                "version": 1,
+                "capabilities": normalized_capabilities,
+            }
+        except (OSError, UnicodeDecodeError, ValueError) as error:
+            builder.diagnostic(f"Could not load configuration {main_path}: {error}")
 
 
 def load_catalog(plugin_path: Path, omarchy_path: Path, home: Path, limits: Limits) -> dict[str, Any]:
@@ -561,6 +675,7 @@ def load_catalog(plugin_path: Path, omarchy_path: Path, home: Path, limits: Limi
                 continue
             builder.append(definitions, bundled=False, source_dir=plugin_dir, source=source)
 
+    load_user_configuration(home, builder, limits)
     return builder.finish(complete=complete)
 
 

--- a/tests/extension-loader-test.py
+++ b/tests/extension-loader-test.py
@@ -147,7 +147,17 @@ elif mode == 'integer-overflow':
     omarchy_root = base / "omarchy"
     omarchy_root.mkdir()
 
+    config_root = home / ".config" / "omarchy" / "omalaunch"
+    config_root.mkdir(parents=True)
+    (config_root / "config.jsonc").write_text('{\n// selection\n"version": 1, "capabilities": {"files": {"provider": "chosen",},},\n}')
+
     catalog = run_loader(plugin_root, omarchy_root, home, env)
+    check(catalog["providerPreferences"] == {"files": "chosen"}
+          and catalog["omalaunchConfig"] == {
+              "version": 1,
+              "capabilities": {"files": {"provider": "chosen"}},
+          },
+          "bounded JSONC loads provider selection into the stable core configuration envelope")
     ids = [item.get("id") for item in catalog["extensions"]]
     messages = "\n".join(catalog["diagnostics"])
     check(ids == ["bundled", "static", "dynamic", "argument"],

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -625,3 +625,18 @@ const guardRun = childProcess.spawnSync('bash', ['-c', menu.guardScript({
 assert(guardRun.status === 0, 'guard scripts remain valid for shell metacharacters in ids')
 assert(guardRun.stdout.trim() === `${hostileId}:w:1`, 'guard ids round-trip without shell interpretation')
 assert(!fs.existsSync(marker), 'guard ids cannot inject shell commands')
+
+const configuredProviderCatalog = menu.parseExtensionCatalog(JSON.stringify({
+  extensions: [
+    { schemaVersion: 1, id: 'default-files', capability: 'files', mode: 'files', label: 'Default', prefixes: ['default'], command: ['true'], _bundled: true },
+    { schemaVersion: 1, id: 'chosen-files', capability: 'files', mode: 'files', label: 'Chosen', prefixes: ['chosen'], command: ['true'], priority: -10 }
+  ], providerPreferences: { files: 'chosen-files' }
+}))
+assert(configuredProviderCatalog.extensions[0].id === 'chosen-files',
+  'provider configuration selects an available id')
+const missingProviderCatalog = menu.parseExtensionCatalog(JSON.stringify({
+  extensions: [{ schemaVersion: 1, id: 'fallback', capability: 'files', mode: 'files', label: 'Fallback', prefixes: ['fallback'], command: ['true'] }],
+  providerPreferences: { files: 'missing' }
+}))
+assert(missingProviderCatalog.extensions[0].id === 'fallback' && missingProviderCatalog.diagnostics.some(value => value.indexOf("is missing; normal provider resolution was used") >= 0),
+  'a missing configured provider falls back with a diagnostic')


### PR DESCRIPTION
## Summary

- load bounded JSONC settings from `~/.config/omarchy/omalaunch/config.jsonc`
- let users select an extension provider by capability and extension ID
- fall back to normal provider resolution with a diagnostic when the preferred provider is missing or unavailable
- document the provider configuration format

## Example

```jsonc
{
  "version": 1,
  "capabilities": {
    "files": { "provider": "omalaunch.files" }
  }
}
```

## Validation

- `python tests/extension-loader-test.py`
- `bash tests/manifest-test.sh`
- `python -m py_compile libexec/load-extensions.py`
- `git diff --check`

The Node.js menu-model test was not run locally because Node.js is not installed in the test environment.
