### PR TITLE
Add Files Git ignore configuration

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -245,3 +245,15 @@ Select a provider by extension `id` in `config.jsonc`. The key is the capability
   },
 }
 ```
+
+Capability settings are independent of the selected provider and have one file per capability. The first supported file is `extensions/files.jsonc`:
+
+```jsonc
+{
+  "version": 1,
+  // Include paths ignored by Git, but continue to honor other fd ignore rules.
+  "includeGitIgnored": true,
+}
+```
+
+`includeGitIgnored` defaults to `false`. When true, both directory browsing and the recursive Files index use `fd --no-ignore-vcs`.

--- a/Menu.qml
+++ b/Menu.qml
@@ -868,6 +868,11 @@ Item {
     }
   }
 
+  function includeGitIgnoredFiles() {
+    var extension = root.extensionByCapability("files")
+    return !!(extension && extension.config && extension.config.includeGitIgnored === true)
+  }
+
   function startFileIndex(path) {
     // Process command and metadata must stay immutable until onExited. Keep a
     // build for the requested root alive while typing; only a different root
@@ -890,6 +895,7 @@ Item {
     fileIndexProc.indexRoot = path
     fileIndexProc.indexPath = root.fileIndexPath
     fileIndexProc.command = ["python", root.fileIndexHelper, root.directoryPickerActive ? "index-dirs" : "index", path, fileIndexProc.indexPath]
+      .concat(root.includeGitIgnoredFiles() ? ["--include-git-ignored"] : [])
     fileIndexProc.running = true
   }
 
@@ -2224,6 +2230,7 @@ Item {
       fileScanProc.command = needle
         ? ["python", root.fileIndexHelper, "query", root.fileIndexPath, needle]
         : ["python", root.fileIndexHelper, root.directoryPickerActive ? "browse-dirs" : "browse", base]
+          .concat(root.includeGitIgnoredFiles() ? ["--include-git-ignored"] : [])
       fileScanProc.running = true
     }
   }

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -973,6 +973,8 @@ function parseExtensionCatalog(text) {
 
   var providerPreferences = parsed && typeof parsed.providerPreferences === "object" && !Array.isArray(parsed.providerPreferences)
     ? parsed.providerPreferences : ({})
+  var capabilityConfig = parsed && typeof parsed.capabilityConfig === "object" && !Array.isArray(parsed.capabilityConfig)
+    ? parsed.capabilityConfig : ({})
   var extensions = []
   var ids = ({})
   if (values.length > MAX_EXTENSION_CATALOG_VALUES)
@@ -991,6 +993,8 @@ function parseExtensionCatalog(text) {
       continue
     }
     ids[idKey] = extensionSource(values[i], i)
+    extension.config = capabilityConfig[extension.capability] && typeof capabilityConfig[extension.capability] === "object"
+      ? capabilityConfig[extension.capability] : ({})
     extensions.push(extension)
     if (!extension.available)
       appendExtensionDiagnostic(diagnostics, extension.id + " is missing: " + extension.missingRequires.join(", "), diagnosticState)

--- a/README.md
+++ b/README.md
@@ -161,6 +161,15 @@ Omalaunch core settings live in the dedicated `~/.config/omarchy/omalaunch/confi
 }
 ```
 
+Each capability has an independent configuration file. For example, include files ignored by Git in Files browsing and search with `extensions/files.jsonc`:
+
+```jsonc
+{
+  "version": 1,
+  "includeGitIgnored": true,
+}
+```
+
 If a preferred provider is missing or unavailable, Omalaunch reports a diagnostic and uses its normal provider selection rules.
 
 ## Updating

--- a/extensions/files/file-index.py
+++ b/extensions/files/file-index.py
@@ -52,9 +52,13 @@ def _entry(raw_path: bytes) -> dict[str, str] | None:
     }
 
 
-def _emit(raw_paths: Iterator[bytes]) -> None:
+def _emit(raw_paths: Iterator[bytes], *, limit: int = MAX_RESULTS,
+          excluded: set[bytes] | None = None) -> int:
     emitted = 0
+    skipped = excluded or set()
     for raw_path in raw_paths:
+        if raw_path.rstrip(b"/") in skipped:
+            continue
         entry = _entry(raw_path)
         if entry is None:
             continue
@@ -62,12 +66,14 @@ def _emit(raw_paths: Iterator[bytes]) -> None:
         # UTF-8-safe JSON line, including names containing literal newlines.
         print(json.dumps(entry, ensure_ascii=True, separators=(",", ":")))
         emitted += 1
-        if emitted >= MAX_RESULTS:
+        if emitted >= limit:
             break
+    return emitted
 
 
 def _fd_command(
-    root: str, *, max_depth: int | None = None, directories_only: bool = False
+    root: str, *, max_depth: int | None = None, directories_only: bool = False,
+    include_git_ignored: bool = False,
 ) -> list[str]:
     command = [
         "fd",
@@ -76,6 +82,8 @@ def _fd_command(
         "--absolute-path",
         "--print0",
     ]
+    if include_git_ignored:
+        command.append("--no-ignore-vcs")
     if not directories_only:
         command.extend(["--type", "file"])
     command.extend(["--type", "directory"])
@@ -85,7 +93,8 @@ def _fd_command(
     return command
 
 
-def build_index(root: str, output_path: str, *, directories_only: bool = False) -> int:
+def build_index(root: str, output_path: str, *, directories_only: bool = False,
+                include_git_ignored: bool = False) -> int:
     global _child
 
     output = Path(output_path)
@@ -98,7 +107,7 @@ def build_index(root: str, output_path: str, *, directories_only: bool = False) 
     try:
         with os.fdopen(descriptor, "wb") as destination:
             _child = subprocess.Popen(
-                _fd_command(root, directories_only=directories_only),
+                _fd_command(root, directories_only=directories_only, include_git_ignored=include_git_ignored),
                 stdout=destination,
                 stderr=subprocess.DEVNULL,
             )
@@ -116,11 +125,12 @@ def build_index(root: str, output_path: str, *, directories_only: bool = False) 
             pass
 
 
-def browse(root: str, *, directories_only: bool = False) -> int:
+def browse(root: str, *, directories_only: bool = False,
+           include_git_ignored: bool = False) -> int:
     global _child
 
     _child = subprocess.Popen(
-        _fd_command(root, max_depth=1, directories_only=directories_only),
+        _fd_command(root, max_depth=1, directories_only=directories_only, include_git_ignored=include_git_ignored),
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
     )
@@ -154,6 +164,22 @@ def query(index_path: str, needle: str) -> int:
         return 2
 
     with index:
+        # Exact basename matches must not be displaced by many descendants
+        # whose parent path contains the query. Find only this small priority
+        # set before asking fzf to rank all path matches.
+        exact: list[bytes] = []
+        exact_key = needle.casefold()
+        for raw_path in _nul_records(index):
+            name = os.path.basename(os.fsdecode(raw_path).rstrip("/"))
+            if name.casefold() == exact_key:
+                exact.append(raw_path)
+                if len(exact) >= MAX_RESULTS:
+                    break
+        emitted = _emit(iter(exact))
+        if emitted >= MAX_RESULTS:
+            return 0
+
+        index.seek(0)
         _child = subprocess.Popen(
             [
                 "fzf",
@@ -168,8 +194,9 @@ def query(index_path: str, needle: str) -> int:
             stderr=subprocess.DEVNULL,
         )
         assert _child.stdout is not None
-        _emit(_nul_records(_child.stdout))
-        # fzf may still be writing matches after the first 100. Closing its
+        exact_paths = {raw_path.rstrip(b"/") for raw_path in exact}
+        _emit(_nul_records(_child.stdout), limit=MAX_RESULTS - emitted, excluded=exact_paths)
+        # fzf may still be writing matches after the display limit. Closing its
         # pipe lets it stop without forcing Python to materialize every match.
         _child.stdout.close()
         if _child.poll() is None:
@@ -188,10 +215,14 @@ def main(argv: list[str]) -> int:
         return 2
 
     mode = argv[1]
-    if mode in ("index", "index-dirs") and len(argv) == 4:
-        return build_index(argv[2], argv[3], directories_only=mode == "index-dirs")
-    if mode in ("browse", "browse-dirs") and len(argv) == 3:
-        return browse(argv[2], directories_only=mode == "browse-dirs")
+    include_git_ignored = argv[-1] == "--include-git-ignored"
+    positional = argv[:-1] if include_git_ignored else argv
+    if mode in ("index", "index-dirs") and len(positional) == 4:
+        return build_index(positional[2], positional[3], directories_only=mode == "index-dirs",
+                           include_git_ignored=include_git_ignored)
+    if mode in ("browse", "browse-dirs") and len(positional) == 3:
+        return browse(positional[2], directories_only=mode == "browse-dirs",
+                      include_git_ignored=include_git_ignored)
     if mode == "query" and len(argv) == 4:
         return query(argv[2], argv[3])
 

--- a/libexec/load-extensions.py
+++ b/libexec/load-extensions.py
@@ -78,6 +78,7 @@ class CatalogBuilder:
         # current and future Omalaunch core settings. Only validated settings
         # are copied from the user-owned config file.
         self.omalaunch_config: dict[str, Any] = {}
+        self.capability_config: dict[str, dict[str, Any]] = {}
         # Reserve room for useful diagnostics. The final envelope still uses
         # the exact public catalog limit and trims diagnostics linearly.
         reserve = min(64 * 1024, max(64, limits.catalog_output_bytes // 4))
@@ -148,6 +149,7 @@ class CatalogBuilder:
                 "complete": complete,
                 "providerPreferences": self.provider_preferences,
                 "omalaunchConfig": self.omalaunch_config,
+                "capabilityConfig": self.capability_config,
             }
             base_size = len(self.encoded(result))
             used = base_size
@@ -473,6 +475,21 @@ def load_user_configuration(home: Path, builder: CatalogBuilder, limits: Limits)
             }
         except (OSError, UnicodeDecodeError, ValueError) as error:
             builder.diagnostic(f"Could not load configuration {main_path}: {error}")
+
+    # Capability configuration is independent of provider identity. Load only
+    # host-supported capability schemas, so files cannot select arbitrary paths.
+    files_path = config_root / "extensions" / "files.jsonc"
+    if files_path.exists():
+        try:
+            value = read_jsonc(files_path, maximum_depth=limits.json_nesting_depth)
+            if not isinstance(value, dict) or value.get("version") != 1:
+                raise ValueError("expected an object with version 1")
+            include = value.get("includeGitIgnored", False)
+            if not isinstance(include, bool):
+                raise ValueError("includeGitIgnored must be a boolean")
+            builder.capability_config["files"] = {"includeGitIgnored": include}
+        except (OSError, UnicodeDecodeError, ValueError) as error:
+            builder.diagnostic(f"Could not load configuration {files_path}: {error}")
 
 
 def load_catalog(plugin_path: Path, omarchy_path: Path, home: Path, limits: Limits) -> dict[str, Any]:

--- a/tests/extension-loader-test.py
+++ b/tests/extension-loader-test.py
@@ -148,16 +148,18 @@ elif mode == 'integer-overflow':
     omarchy_root.mkdir()
 
     config_root = home / ".config" / "omarchy" / "omalaunch"
-    config_root.mkdir(parents=True)
+    (config_root / "extensions").mkdir(parents=True)
     (config_root / "config.jsonc").write_text('{\n// selection\n"version": 1, "capabilities": {"files": {"provider": "chosen",},},\n}')
+    (config_root / "extensions" / "files.jsonc").write_text('{"version": 1, "includeGitIgnored": true,}')
 
     catalog = run_loader(plugin_root, omarchy_root, home, env)
     check(catalog["providerPreferences"] == {"files": "chosen"}
           and catalog["omalaunchConfig"] == {
               "version": 1,
               "capabilities": {"files": {"provider": "chosen"}},
-          },
-          "bounded JSONC loads provider selection into the stable core configuration envelope")
+          }
+          and catalog["capabilityConfig"] == {"files": {"includeGitIgnored": True}},
+          "bounded JSONC loads core and capability configuration")
     ids = [item.get("id") for item in catalog["extensions"]]
     messages = "\n".join(catalog["diagnostics"])
     check(ids == ["bundled", "static", "dynamic", "argument"],

--- a/tests/file-index-integration-test.py
+++ b/tests/file-index-integration-test.py
@@ -4,6 +4,7 @@ import json
 import os
 import subprocess
 import tempfile
+import runpy
 import time
 from pathlib import Path
 
@@ -62,6 +63,18 @@ with tempfile.TemporaryDirectory() as temporary:
     assert unusual[0]["name"] == "strange\nname.txt"
     print("ok - indexed queries preserve filenames containing newlines")
 
+    subprocess.run(["git", "init", "-q", str(files)], check=True)
+    (files / ".gitignore").write_text("git-ignored.txt\n", encoding="utf-8")
+    ignored = files / "git-ignored.txt"
+    ignored.write_text("ignored", encoding="utf-8")
+    run("index", str(files), str(index))
+    assert run("query", str(index), "git-ignored") == []
+    run("index", str(files), str(index), "--include-git-ignored")
+    assert run("query", str(index), "git-ignored")[0]["path"] == str(ignored)
+    assert all(row["name"] != "git-ignored.txt" for row in run("browse", str(files)))
+    assert any(row["name"] == "git-ignored.txt" for row in run("browse", str(files), "--include-git-ignored"))
+    print("ok - includeGitIgnored controls Git ignore rules in browsing and recursive search")
+
     added_later = files / "added-after-index.txt"
     added_later.write_text("new", encoding="utf-8")
     assert run("query", str(index), "added-after-index") == []
@@ -82,3 +95,22 @@ with tempfile.TemporaryDirectory() as temporary:
     run("index", str(files), str(index))
     assert len(run("query", str(index), "limit-match")) == 100
     print("ok - browse and indexed query output are capped at 100 rows")
+
+    first_exact = files / "first" / "local-spotlights"
+    second_exact = files / "second" / "local-spotlights"
+    first_exact.mkdir(parents=True)
+    second_exact.mkdir(parents=True)
+    for number in range(110):
+        (first_exact / f"descendant-{number:03}.txt").write_text("", encoding="utf-8")
+    run("index", str(files), str(index))
+    exact_ranked = run("query", str(index), "local-spotlights")
+    assert {row["path"] for row in exact_ranked[:2]} == {str(first_exact), str(second_exact)}
+    assert len(exact_ranked) == 100
+    print("ok - exact basename matches rank before descendants and remain within the result limit")
+
+# Configuration uses one explicit helper flag for both fd traversal modes.
+module = runpy.run_path(str(HELPER))
+assert "--no-ignore-vcs" in module["_fd_command"]("/tmp", include_git_ignored=True)
+print("ok - includeGitIgnored adds fd --no-ignore-vcs")
+assert "--no-ignore-vcs" not in module["_fd_command"]("/tmp")
+print("ok - Git-ignored paths remain excluded by default")

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -630,10 +630,10 @@ const configuredProviderCatalog = menu.parseExtensionCatalog(JSON.stringify({
   extensions: [
     { schemaVersion: 1, id: 'default-files', capability: 'files', mode: 'files', label: 'Default', prefixes: ['default'], command: ['true'], _bundled: true },
     { schemaVersion: 1, id: 'chosen-files', capability: 'files', mode: 'files', label: 'Chosen', prefixes: ['chosen'], command: ['true'], priority: -10 }
-  ], providerPreferences: { files: 'chosen-files' }
+  ], providerPreferences: { files: 'chosen-files' }, capabilityConfig: { files: { includeGitIgnored: true } }
 }))
-assert(configuredProviderCatalog.extensions[0].id === 'chosen-files',
-  'provider configuration selects an available id')
+assert(configuredProviderCatalog.extensions[0].id === 'chosen-files' && configuredProviderCatalog.extensions[0].config.includeGitIgnored === true,
+  'provider configuration selects an available id and capability configuration follows capability identity')
 const missingProviderCatalog = menu.parseExtensionCatalog(JSON.stringify({
   extensions: [{ schemaVersion: 1, id: 'fallback', capability: 'files', mode: 'files', label: 'Fallback', prefixes: ['fallback'], command: ['true'] }],
   providerPreferences: { files: 'missing' }


### PR DESCRIPTION
## Summary

- load Files settings from `~/.config/omarchy/omalaunch/extensions/files.jsonc`
- add `includeGitIgnored`, which defaults to `false`
- use `fd --no-ignore-vcs` for browsing and recursive search when enabled
- rank exact basename matches before descendants so result limits do not hide matching directories

## Example

```jsonc
{
  "version": 1,
  "includeGitIgnored": true
}
```

## Validation

- `python tests/extension-loader-test.py`
- `python tests/file-index-integration-test.py`
- `bash tests/manifest-test.sh`
- `bash tests/qalc-integration-test.sh`
- `bash tests/timezone-integration-test.sh`
- `python -m py_compile libexec/load-extensions.py extensions/files/file-index.py`
- `git diff --check`

The Node.js menu-model test was not run locally because Node.js is not installed in the test environment.
