### PR TITLE
Add a contextual launcher action bar

### DIFF
--- a/Menu.qml
+++ b/Menu.qml
@@ -3330,19 +3330,20 @@ Item {
         }
 
         Item {
-          width: parent.width
+          x: -card.contentLeftInset
+          width: parent.width + card.contentLeftInset + card.contentRightInset
           height: root.actionBarHeight
           clip: true
 
           Rectangle {
-            x: -card.contentLeftInset
-            width: parent.width + card.contentLeftInset + card.contentRightInset
+            width: parent.width
             height: parent.height + root.actionBarBottomPadding
             color: Util.alpha(root.foreground, 0.035)
           }
 
           Row {
             anchors.right: parent.right
+            anchors.rightMargin: card.contentRightInset
             anchors.verticalCenter: parent.verticalCenter
             spacing: Style.space(18)
 

--- a/Menu.qml
+++ b/Menu.qml
@@ -3374,7 +3374,7 @@ Item {
                   anchors.verticalCenter: parent.verticalCenter
 
                   Repeater {
-                    model: modelData.shortcut === "Enter" ? ["↵"] : String(modelData.shortcut).split(" ")
+                    model: [modelData.shortcut === "Enter" ? "↵" : String(modelData.shortcut)]
 
                     Item {
                       required property string modelData

--- a/Menu.qml
+++ b/Menu.qml
@@ -214,6 +214,7 @@ Item {
   readonly property int cornerRadius: Style.cornerRadius
   property int contentMargin: Style.spacing.panelPadding
   property int headerHeight: Math.max(Style.space(34), Style.font.title + Style.spacing.controlPaddingY * 2)
+  property int actionBarHeight: Math.max(Style.space(36), Style.font.bodySmall + Style.spacing.controlPaddingY * 2)
   property int contentSpacing: Style.spacing.md
   property int baseRowHeight: Math.max(Style.space(50), Style.font.body + Style.spacing.rowPaddingX * 2)
   property int detailRowHeight: Math.max(Style.space(58), Style.font.body + Style.font.caption + Style.spacing.rowPaddingX * 2)
@@ -229,9 +230,29 @@ Item {
     : Style.space(root.imagePreviewActive ? 900 : 600), panel.width - Style.gapsOut * 2)
   readonly property bool emptyRoot: !root.dmenuActive && root.activeMenu === "root" && !root.filterText && displayModel.count === 0
   property int visibleRowsHeight: root.emptyRoot || root.workflowInputActive ? 0 : (root.dmenuActive ? dmenuRowListHeight(layoutSerial, displayModel.count, filterText) : rowListHeight(layoutSerial, displayModel.count, filterText, searchDivider))
-  property int cardHeight: root.dmenuActive
-    ? Math.min(contentMargin * 2 + headerHeight + (mode === "input" ? 0 : contentSpacing + visibleRowsHeight), panel.height - Style.gapsOut * 2)
-    : Math.min(contentMargin * 2 + headerHeight + (visibleRowsHeight > 0 ? contentSpacing + visibleRowsHeight : 0), panel.height - Style.gapsOut * 2)
+  property int cardHeight: Math.min(contentMargin * 2 + headerHeight + actionBarHeight + contentSpacing
+    + (visibleRowsHeight > 0 ? contentSpacing + visibleRowsHeight : 0), panel.height - Style.gapsOut * 2)
+
+  readonly property var actionBarHints: MenuModel.actionBarHints({
+    dmenuActive: root.dmenuActive,
+    dmenuInput: root.dmenuActive && root.mode === "input",
+    workflowActive: root.workflowActive,
+    workflowInputActive: root.workflowInputActive,
+    fileBrowserActive: root.fileBrowserActive,
+    directoryPickerActive: root.directoryPickerActive,
+    actionPanelActive: root.actionPanelActive,
+    focusedExtension: !!root.focusedExtension,
+    hasSelection: displayModel.count > 0 && root.cursorActive,
+    canStar: !root.dmenuActive && !root.workflowActive && !root.actionPanelActive
+      && displayModel.count > 0 && root.cursorActive && root.selectedIndex >= 0
+      && root.selectedIndex < displayModel.count
+      && (root.fileBrowserActive || (displayModel.get(root.selectedIndex).itemId !== "omarchy"
+        && displayModel.get(root.selectedIndex).itemId !== "extensions"
+        && displayModel.get(root.selectedIndex).itemId !== "extension.result"
+        && displayModel.get(root.selectedIndex).itemId !== "extension.result.pending")),
+    starred: displayModel.count > 0 && root.cursorActive && root.selectedIndex >= 0
+      && root.selectedIndex < displayModel.count && displayModel.get(root.selectedIndex).starred
+  })
 
   function finishRequest(selection) {
     if (!root.requestActive || !root.doneFile) {
@@ -305,7 +326,8 @@ Item {
 
   // Height the card can devote to rows below its pinned top edge.
   function availableRowsHeight() {
-    var available = panel.height - panel.pinnedTop - Style.gapsOut - root.contentMargin * 2 - root.headerHeight - root.contentSpacing
+    var available = panel.height - panel.pinnedTop - Style.gapsOut - root.contentMargin * 2
+      - root.headerHeight - root.actionBarHeight - root.contentSpacing * 2
     // A card that swallows the whole screen reads as a page, not a menu.
     return Math.min(available, Math.round(panel.height * 0.5))
   }
@@ -2951,8 +2973,7 @@ Item {
           Text {
             visible: !root.focusedExtension
             anchors.left: parent.left
-            anchors.right: starHint.left
-            anchors.rightMargin: Style.space(8)
+            anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
             text: root.actionPanelActive
               ? ("Actions for " + ((root.actionPanelFile && root.actionPanelFile.name) || "file"))
@@ -2981,20 +3002,6 @@ Item {
             font.family: root.fontFamily
             font.pixelSize: Style.font.heading
             elide: Text.ElideRight
-          }
-
-          Text {
-            id: starHint
-            visible: !root.actionPanelActive && !root.dmenuActive && !root.workflowActive && displayModel.count > 0 && root.cursorActive && root.selectedIndex >= 0 && root.selectedIndex < displayModel.count && (root.fileBrowserActive || (displayModel.get(root.selectedIndex).itemId !== "omarchy" && displayModel.get(root.selectedIndex).itemId !== "extensions" && displayModel.get(root.selectedIndex).itemId !== "extension.result" && displayModel.get(root.selectedIndex).itemId !== "extension.result.pending"))
-            anchors.right: parent.right
-            anchors.verticalCenter: parent.verticalCenter
-            text: root.fileBrowserActive
-              ? (!root.selectedFileRow ? "" : (root.selectedFileRow.starred ? "Ctrl+S  Unstar · Ctrl+K  Actions" : "Ctrl+S  Star · Ctrl+K  Actions"))
-              : (root.cursorActive && root.selectedIndex >= 0 && root.selectedIndex < displayModel.count && displayModel.get(root.selectedIndex).starred ? "Ctrl+S  Unstar" : "Ctrl+S  Star")
-            color: root.foreground
-            opacity: 0.45
-            font.family: root.fontFamily
-            font.pixelSize: Style.font.bodySmall
           }
 
         }
@@ -3321,7 +3328,61 @@ Item {
 
         Item {
           width: parent.width
-          height: 0
+          height: root.actionBarHeight
+
+          Rectangle {
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            height: Style.spacing.hairline
+            color: Util.alpha(root.foreground, 0.16)
+          }
+
+          Row {
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            spacing: Style.space(14)
+
+            Repeater {
+              model: root.actionBarHints
+
+              Row {
+                required property var modelData
+                spacing: Style.space(6)
+                anchors.verticalCenter: parent.verticalCenter
+
+                Text {
+                  text: modelData.label
+                  color: root.foreground
+                  opacity: 0.68
+                  font.family: root.fontFamily
+                  font.pixelSize: Style.font.bodySmall
+                  anchors.verticalCenter: parent.verticalCenter
+                }
+
+                Rectangle {
+                  width: shortcutText.implicitWidth + Style.space(10)
+                  height: Math.max(Style.space(22), shortcutText.implicitHeight + Style.space(6))
+                  radius: Math.min(root.cornerRadius, Style.space(5))
+                  color: Util.alpha(root.foreground, 0.09)
+                  border.width: Style.spacing.hairline
+                  border.color: Util.alpha(root.foreground, 0.16)
+                  anchors.verticalCenter: parent.verticalCenter
+
+                  Text {
+                    id: shortcutText
+                    anchors.centerIn: parent
+                    text: modelData.shortcut
+                    color: root.foreground
+                    opacity: 0.82
+                    font.family: root.fontFamily
+                    font.pixelSize: Style.font.caption
+                    font.weight: Font.Medium
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/Menu.qml
+++ b/Menu.qml
@@ -3331,25 +3331,33 @@ Item {
           height: root.actionBarHeight
 
           Rectangle {
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.top: parent.top
-            height: Style.spacing.hairline
-            color: Util.alpha(root.foreground, 0.16)
+            x: -card.contentLeftInset
+            width: parent.width + card.contentLeftInset + card.contentRightInset
+            height: parent.height + card.contentBottomInset
+            color: Util.alpha(root.foreground, 0.035)
           }
 
           Row {
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
-            spacing: Style.space(14)
+            spacing: Style.space(18)
 
             Repeater {
               model: root.actionBarHints
 
               Row {
+                required property int index
                 required property var modelData
-                spacing: Style.space(6)
+                spacing: Style.space(5)
                 anchors.verticalCenter: parent.verticalCenter
+
+                Rectangle {
+                  visible: index > 0
+                  width: Style.spacing.hairline
+                  height: Style.space(15)
+                  color: Util.alpha(root.foreground, 0.14)
+                  anchors.verticalCenter: parent.verticalCenter
+                }
 
                 Text {
                   text: modelData.label
@@ -3360,24 +3368,45 @@ Item {
                   anchors.verticalCenter: parent.verticalCenter
                 }
 
-                Rectangle {
-                  width: shortcutText.implicitWidth + Style.space(10)
-                  height: Math.max(Style.space(22), shortcutText.implicitHeight + Style.space(6))
-                  radius: Math.min(root.cornerRadius, Style.space(5))
-                  color: Util.alpha(root.foreground, 0.09)
-                  border.width: Style.spacing.hairline
-                  border.color: Util.alpha(root.foreground, 0.16)
+                Row {
+                  spacing: Style.space(3)
                   anchors.verticalCenter: parent.verticalCenter
 
-                  Text {
-                    id: shortcutText
-                    anchors.centerIn: parent
-                    text: modelData.shortcut
-                    color: root.foreground
-                    opacity: 0.82
-                    font.family: root.fontFamily
-                    font.pixelSize: Style.font.caption
-                    font.weight: Font.Medium
+                  Repeater {
+                    model: modelData.shortcut === "Enter" ? ["↵"] : String(modelData.shortcut).split(" ")
+
+                    Item {
+                      required property string modelData
+                      width: shortcutText.implicitWidth + Style.space(10)
+                      height: Math.max(Style.space(22), shortcutText.implicitHeight + Style.space(6))
+
+                      Rectangle {
+                        anchors.fill: parent
+                        anchors.topMargin: Style.space(2)
+                        radius: Math.min(root.cornerRadius, Style.space(5))
+                        color: Util.alpha(root.foreground, 0.1)
+                      }
+
+                      Rectangle {
+                        anchors.fill: parent
+                        anchors.bottomMargin: Style.space(2)
+                        radius: Math.min(root.cornerRadius, Style.space(5))
+                        color: Util.alpha(root.foreground, 0.065)
+                        border.width: Style.spacing.hairline
+                        border.color: Util.alpha(root.foreground, 0.13)
+
+                        Text {
+                          id: shortcutText
+                          anchors.centerIn: parent
+                          text: modelData
+                          color: root.foreground
+                          opacity: 0.82
+                          font.family: root.fontFamily
+                          font.pixelSize: Style.font.caption
+                          font.weight: Font.Medium
+                        }
+                      }
+                    }
                   }
                 }
               }

--- a/Menu.qml
+++ b/Menu.qml
@@ -215,6 +215,7 @@ Item {
   property int contentMargin: Style.spacing.panelPadding
   property int headerHeight: Math.max(Style.space(34), Style.font.title + Style.spacing.controlPaddingY * 2)
   property int actionBarHeight: Math.max(Style.space(36), Style.font.bodySmall + Style.spacing.controlPaddingY * 2)
+  property int actionBarBottomPadding: Style.space(6)
   property int contentSpacing: Style.spacing.md
   property int baseRowHeight: Math.max(Style.space(50), Style.font.body + Style.spacing.rowPaddingX * 2)
   property int detailRowHeight: Math.max(Style.space(58), Style.font.body + Style.font.caption + Style.spacing.rowPaddingX * 2)
@@ -230,7 +231,7 @@ Item {
     : Style.space(root.imagePreviewActive ? 900 : 600), panel.width - Style.gapsOut * 2)
   readonly property bool emptyRoot: !root.dmenuActive && root.activeMenu === "root" && !root.filterText && displayModel.count === 0
   property int visibleRowsHeight: root.emptyRoot || root.workflowInputActive ? 0 : (root.dmenuActive ? dmenuRowListHeight(layoutSerial, displayModel.count, filterText) : rowListHeight(layoutSerial, displayModel.count, filterText, searchDivider))
-  property int cardHeight: Math.min(contentMargin * 2 + headerHeight + actionBarHeight + contentSpacing
+  property int cardHeight: Math.min(contentMargin + actionBarBottomPadding + headerHeight + actionBarHeight + contentSpacing
     + (visibleRowsHeight > 0 ? contentSpacing + visibleRowsHeight : 0), panel.height - Style.gapsOut * 2)
 
   readonly property var actionBarHints: MenuModel.actionBarHints({
@@ -326,7 +327,7 @@ Item {
 
   // Height the card can devote to rows below its pinned top edge.
   function availableRowsHeight() {
-    var available = panel.height - panel.pinnedTop - Style.gapsOut - root.contentMargin * 2
+    var available = panel.height - panel.pinnedTop - Style.gapsOut - root.contentMargin - root.actionBarBottomPadding
       - root.headerHeight - root.actionBarHeight - root.contentSpacing * 2
     // A card that swallows the whole screen reads as a page, not a menu.
     return Math.min(available, Math.round(panel.height * 0.5))
@@ -2960,7 +2961,7 @@ Item {
         anchors.fill: parent
         anchors.topMargin: card.contentTopInset
         anchors.rightMargin: card.contentRightInset
-        anchors.bottomMargin: card.contentBottomInset
+        anchors.bottomMargin: root.actionBarBottomPadding
         anchors.leftMargin: card.contentLeftInset
         spacing: root.contentSpacing
 
@@ -3333,7 +3334,7 @@ Item {
           Rectangle {
             x: -card.contentLeftInset
             width: parent.width + card.contentLeftInset + card.contentRightInset
-            height: parent.height + card.contentBottomInset
+            height: parent.height + root.actionBarBottomPadding
             color: Util.alpha(root.foreground, 0.035)
           }
 
@@ -3382,16 +3383,8 @@ Item {
 
                       Rectangle {
                         anchors.fill: parent
-                        anchors.topMargin: Style.space(2)
                         radius: Math.min(root.cornerRadius, Style.space(5))
-                        color: Util.alpha(root.foreground, 0.1)
-                      }
-
-                      Rectangle {
-                        anchors.fill: parent
-                        anchors.bottomMargin: Style.space(2)
-                        radius: Math.min(root.cornerRadius, Style.space(5))
-                        color: Util.alpha(root.foreground, 0.065)
+                        color: "transparent"
                         border.width: Style.spacing.hairline
                         border.color: Util.alpha(root.foreground, 0.13)
 

--- a/Menu.qml
+++ b/Menu.qml
@@ -3378,7 +3378,7 @@ Item {
 
                     Item {
                       required property string modelData
-                      width: shortcutText.implicitWidth + Style.space(10)
+                      width: Math.max(height, shortcutText.implicitWidth + Style.space(10))
                       height: Math.max(Style.space(22), shortcutText.implicitHeight + Style.space(6))
 
                       Rectangle {

--- a/Menu.qml
+++ b/Menu.qml
@@ -254,6 +254,8 @@ Item {
     starred: displayModel.count > 0 && root.cursorActive && root.selectedIndex >= 0
       && root.selectedIndex < displayModel.count && displayModel.get(root.selectedIndex).starred
   })
+  readonly property var displayedActionBarHints: root.cardWidth < Style.space(560)
+    ? MenuModel.compactActionBarHints(root.actionBarHints) : root.actionBarHints
 
   function finishRequest(selection) {
     if (!root.requestActive || !root.doneFile) {
@@ -3330,6 +3332,7 @@ Item {
         Item {
           width: parent.width
           height: root.actionBarHeight
+          clip: true
 
           Rectangle {
             x: -card.contentLeftInset
@@ -3344,7 +3347,7 @@ Item {
             spacing: Style.space(18)
 
             Repeater {
-              model: root.actionBarHints
+              model: root.displayedActionBarHints
 
               Row {
                 required property int index

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -1478,6 +1478,34 @@ function guardScript(items) {
   return guards ? guardPrelude(guards) + guards : ""
 }
 
+// Keep the footer limited to actions that the current launcher state accepts.
+// The same labels are used in QML and unit tests, so shortcut help does not
+// drift away from the keyboard handler.
+function actionBarHints(state) {
+  var value = state || ({})
+  var hints = []
+
+  if (value.dmenuInput) hints.push({ label: "Submit", shortcut: "Enter" })
+  else if (value.workflowInputActive) hints.push({ label: "Continue", shortcut: "Enter" })
+  else if (value.hasSelection) {
+    var primary = value.actionPanelActive ? "Run"
+      : (value.directoryPickerActive || value.dmenuActive ? "Select"
+        : (value.workflowActive ? "Continue" : "Open"))
+    hints.push({ label: primary, shortcut: "Enter" })
+  }
+
+  if (value.fileBrowserActive && value.hasSelection && !value.directoryPickerActive && !value.actionPanelActive) {
+    hints.push({ label: "Actions", shortcut: "Ctrl K" })
+    hints.push({ label: "Copy Path", shortcut: "Ctrl C" })
+  }
+  if (value.canStar) hints.push({ label: value.starred ? "Unstar" : "Star", shortcut: "Ctrl S" })
+
+  var back = value.actionPanelActive || value.workflowActive || value.fileBrowserActive
+    || value.focusedExtension ? "Back" : "Close"
+  hints.push({ label: back, shortcut: "Esc" })
+  return hints
+}
+
 if (typeof module !== "undefined") {
   module.exports = {
     guardReaders: GUARD_READERS,
@@ -1559,6 +1587,7 @@ if (typeof module !== "undefined") {
     fileFavoriteLabel: fileFavoriteLabel,
     fileFavoriteItem: fileFavoriteItem,
     matchesFileFavoriteQuery: matchesFileFavoriteQuery,
-    displayRow: displayRow
+    displayRow: displayRow,
+    actionBarHints: actionBarHints
   }
 }

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -1500,10 +1500,23 @@ function actionBarHints(state) {
   }
   if (value.canStar) hints.push({ label: value.starred ? "Unstar" : "Star", shortcut: "Ctrl S" })
 
-  var back = value.actionPanelActive || value.workflowActive || value.fileBrowserActive
-    || value.focusedExtension ? "Back" : "Close"
-  hints.push({ label: back, shortcut: "Esc" })
   return hints
+}
+
+// On narrow cards, retain the primary action and the action-panel shortcut.
+// Hidden hints remain active keyboard commands; this function only controls
+// footer help text.
+function compactActionBarHints(hints) {
+  var values = Array.isArray(hints) ? hints : []
+  if (values.length <= 2) return values.slice()
+  var compact = values.length > 0 ? [values[0]] : []
+  for (var i = 1; i < values.length; i++) {
+    if (values[i].label === "Actions") {
+      compact.push(values[i])
+      break
+    }
+  }
+  return compact
 }
 
 if (typeof module !== "undefined") {
@@ -1588,6 +1601,7 @@ if (typeof module !== "undefined") {
     fileFavoriteItem: fileFavoriteItem,
     matchesFileFavoriteQuery: matchesFileFavoriteQuery,
     displayRow: displayRow,
-    actionBarHints: actionBarHints
+    actionBarHints: actionBarHints,
+    compactActionBarHints: compactActionBarHints
   }
 }

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -420,17 +420,21 @@ const fileActionHints = menu.actionBarHints({
   starred: false
 })
 assert(fileActionHints.map(hint => `${hint.label}:${hint.shortcut}`).join(',')
-  === 'Open:Enter,Actions:Ctrl K,Copy Path:Ctrl C,Star:Ctrl S,Back:Esc',
+  === 'Open:Enter,Actions:Ctrl K,Copy Path:Ctrl C,Star:Ctrl S',
   'the action bar lists every available file shortcut')
 const starredActionHints = menu.actionBarHints({ hasSelection: true, canStar: true, starred: true })
 assert(starredActionHints.some(hint => hint.label === 'Unstar' && hint.shortcut === 'Ctrl S'),
   'the action bar reflects the selected favorite state')
 const inputActionHints = menu.actionBarHints({ dmenuActive: true, dmenuInput: true })
-assert(inputActionHints.map(hint => hint.label).join(',') === 'Submit,Close',
-  'input requests only advertise submit and close actions')
+assert(inputActionHints.map(hint => hint.label).join(',') === 'Submit',
+  'input requests only advertise their submit action')
 const panelActionHints = menu.actionBarHints({ fileBrowserActive: true, actionPanelActive: true, hasSelection: true })
-assert(panelActionHints.map(hint => hint.label).join(',') === 'Run,Back',
+assert(panelActionHints.map(hint => hint.label).join(',') === 'Run',
   'action panels hide file-browser shortcuts that they do not accept')
+assert(menu.compactActionBarHints(fileActionHints).map(hint => hint.label).join(',') === 'Open,Actions',
+  'narrow action bars retain the primary action and action-panel shortcut')
+assert(menu.compactActionBarHints(starredActionHints).map(hint => hint.label).join(',') === 'Open,Unstar',
+  'action bars with only two hints do not compact further')
 
 const resetOpenState = menu.openStateReset({ workflowActive: true, fileBrowserActive: true })
 assert(resetOpenState.workflowActive === false && resetOpenState.workflowNode === null && resetOpenState.workflowStack.length === 0, 'new opens reset workflow state')

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -413,6 +413,25 @@ assert(boundedQmlDiagnostics.extensions.length === 0 && boundedQmlDiagnostics.di
 assert(boundedQmlDiagnostics.diagnostics[0].length <= 1024
   && boundedQmlDiagnostics.diagnostics.some(message => message.indexOf('Further extension diagnostics were omitted') >= 0),
   'QML catalog validation bounds diagnostic text and reports omissions')
+const fileActionHints = menu.actionBarHints({
+  fileBrowserActive: true,
+  hasSelection: true,
+  canStar: true,
+  starred: false
+})
+assert(fileActionHints.map(hint => `${hint.label}:${hint.shortcut}`).join(',')
+  === 'Open:Enter,Actions:Ctrl K,Copy Path:Ctrl C,Star:Ctrl S,Back:Esc',
+  'the action bar lists every available file shortcut')
+const starredActionHints = menu.actionBarHints({ hasSelection: true, canStar: true, starred: true })
+assert(starredActionHints.some(hint => hint.label === 'Unstar' && hint.shortcut === 'Ctrl S'),
+  'the action bar reflects the selected favorite state')
+const inputActionHints = menu.actionBarHints({ dmenuActive: true, dmenuInput: true })
+assert(inputActionHints.map(hint => hint.label).join(',') === 'Submit,Close',
+  'input requests only advertise submit and close actions')
+const panelActionHints = menu.actionBarHints({ fileBrowserActive: true, actionPanelActive: true, hasSelection: true })
+assert(panelActionHints.map(hint => hint.label).join(',') === 'Run,Back',
+  'action panels hide file-browser shortcuts that they do not accept')
+
 const resetOpenState = menu.openStateReset({ workflowActive: true, fileBrowserActive: true })
 assert(resetOpenState.workflowActive === false && resetOpenState.workflowNode === null && resetOpenState.workflowStack.length === 0, 'new opens reset workflow state')
 assert(resetOpenState.fileBrowserActive === false && resetOpenState.directoryPickerActive === false && resetOpenState.fileBrowserExtension === null, 'new opens reset file browser and directory picker state')


### PR DESCRIPTION
## Summary

- add a Raycast-style footer that shows keyboard actions for the current launcher state
- show contextual file, workflow, dmenu, favorite, and action-panel shortcuts
- compact hints on narrow cards while keeping the primary action and action-panel shortcut
- add polished full-width footer styling and grouped shortcut keycaps

## Tests

- `node tests/menu-model-test.js`
- `bash tests/manifest-test.sh`
- `bash tests/qalc-integration-test.sh`
- `bash tests/timezone-integration-test.sh`
- `python tests/file-index-integration-test.py`
- `node tests/qml-extension-path-test.js`