### PR TITLE
Add the actionable dynamic menu contract

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -19,6 +19,7 @@ Activating a shortcut enters the interface appropriate to its mode:
 - A prefixed `query` or `prefix` extension focuses input with its prefix prepared.
 - A query-only extension focuses an empty, extension-specific input (for example Calculator and Currency conversion).
 - `workflow` opens its first host-rendered workflow stage.
+- `menu` runs its provider and opens the returned host-rendered action menu.
 
 Unavailable extensions remain listed with their missing dependency detail. Only dependencies in Omalaunch's own trusted setup allow-list offer an installation confirmation; other unavailable shortcuts cannot dispatch a command.
 
@@ -170,11 +171,84 @@ Workflow extensions contribute a launcher entry and a bounded tree of host-rende
 }
 ```
 
-Supported node kinds are `menu`, `directoryPicker`, and `input`. Menus contain `items`; a directory picker requires a `next` node; an input may run `command` and then enter `next`. Directory selection supplies `{path}` and `{basename}`. Input supplies `{input}`. `{extensionDir}` is the contributing extension's source directory. A node's bounded string-only `context` is inherited by its descendants. `default` initializes an input, `maxLength` bounds it, and `allowEmpty` permits submission without text. `emptyCommand` selects a distinct argument array for empty input. `refreshExtensions` reloads dynamic catalogs after a successful action. `nextBackSteps` can collapse transient input/picker history after a successful save.
+Supported node kinds are `menu`, `directoryPicker`, `input`, `action`, and `confirm`. Menus contain `items`; a directory picker requires a `next` node; an input may run `command` and then enter `next`. Action and confirmation nodes run a direct command; confirmation nodes use `confirm` and optional `confirmLabel` text. Directory selection supplies `{path}` and `{basename}`. Input supplies `{input}`. `{extensionDir}` is the contributing extension's source directory. A node's bounded string-only `context` is inherited by its descendants. `default` initializes an input, `maxLength` bounds it, and `allowEmpty` permits submission without text. `emptyCommand` selects a distinct argument array for empty input. `refreshExtensions` reloads dynamic catalogs after a successful action. `nextBackSteps` can collapse transient input/picker history after a successful save.
 
 Commands are executed directly as argument arrays. Placeholder substitution never invokes a shell, so paths, names, and prompts remain literal arguments. Workflow trees are capped at 256 nodes and eight levels. Extensions cannot contribute QML. Escape returns through workflow stages. The directory picker reuses the Files index/browse implementation but selects directories instead of opening them. Contextual workflow Ctrl+K actions are intentionally left as a future extension point; workflow definitions do not opt into the global Files Action Panel.
 
 A validated terminal leaf command whose executable is `xdg-terminal-exec` or `omarchy-launch-terminal` is dispatched detached, then Omalaunch closes and resets immediately; the launcher does not wait for a terminal wrapper to exit. Empty-input and other pre-dispatch validation failures leave the workflow open. Non-terminal commands and commands with a following stage wait for successful completion before navigating or closing. After 30 seconds, or when their workflow/session/catalog is left or replaced, Omalaunch sends SIGTERM to the tracked direct child; if it has not exited after a one-second grace period, Omalaunch sends that same generation's direct child SIGKILL. This guarantees release of the reusable Quickshell `Process` even when the direct child ignores SIGTERM. Quickshell's `Process.signal()` targets the direct process, not a process group, so independently surviving descendants are not guaranteed to be terminated. Generation checks prevent a stale process exit or kill timer from changing a later launcher session.
+
+## Actionable dynamic-menu extension
+
+Dynamic-menu extensions let a trusted external plugin calculate a short menu when the user opens its shortcut. The provider is a direct argument-array command:
+
+```json
+{
+  "schemaVersion": 1,
+  "id": "example.quicklinks",
+  "capability": "quicklinks",
+  "mode": "menu",
+  "label": "Quicklinks",
+  "prefixes": ["links"],
+  "requires": ["quicklinks"],
+  "command": ["quicklinks", "menu", "--json"]
+}
+```
+
+The provider receives no stdin. It writes one JSON object with an `items` array, or writes the array directly. A result can contain at most 100 rows. The process has a five-second timeout and a 256 KiB stdout limit. Invalid JSON, a nonzero exit, excessive output, duplicate row IDs, an invalid row, or an excessive row count rejects the complete snapshot. Omalaunch does not run a partial menu. Leaving the menu or closing the launcher makes the old generation stale, so its result cannot replace a later menu. Providers must be fast and should only read state.
+
+A basic row runs `command` directly:
+
+```json
+{
+  "items": [{
+    "id": "docs",
+    "label": "Project documentation",
+    "description": "example.test/docs",
+    "icon": "󰈙",
+    "command": ["xdg-open", "https://example.test/docs"]
+  }]
+}
+```
+
+Every row requires a unique, nonempty `id`, a nonempty `label`, and a nonempty argument-array `command`. Presentation strings and command arguments are bounded. Omalaunch does not invoke a shell and does not expand command text. `{extensionDir}` and form `{input}` values are substituted as complete literal arguments. Set `closeOnSuccess: true` for launch/open rows that should close Omalaunch after the command exits successfully. Other successful menu commands reload the provider so mutations appear immediately.
+
+A row can ask for confirmation before dispatch:
+
+```json
+{
+  "id": "remove",
+  "label": "Remove link",
+  "confirm": "Remove this saved link?",
+  "confirmLabel": "Remove",
+  "command": ["quicklinks", "remove", "docs"],
+  "refreshExtensions": true
+}
+```
+
+A row can open a host-rendered text input form. The input object supports the workflow input fields `prompt`, `default`, `maxLength`, `allowEmpty`, `emptyCommand`, `command`, and `next`. An input with `capture` stores its literal value under that named context key for interpolation by the next stage. This permits multi-step forms without temporary plugin state; backing out cancels the unfinished flow.
+
+```json
+{
+  "id": "add",
+  "label": "Add link",
+  "input": {
+    "prompt": "URL",
+    "maxLength": 2048,
+    "command": ["quicklinks", "add", "{input}"]
+  },
+  "refreshExtensions": true
+}
+```
+
+A row can include up to 16 `actions`. Press Ctrl+K on that row to open its contextual action list. Each contextual action has the same direct command, confirmation, input, and refresh fields as a row, but actions cannot contain more nested actions. A row can set `starAction` to the ID of one direct contextual action; Ctrl+S then runs that action through the normal tracked lifecycle. Providers should update the row's `starred` value and the action label/command in the next snapshot.
+
+Menu and action commands use the workflow action lifecycle. A non-terminal direct child runs for at most 30 seconds. Cancellation sends SIGTERM and then sends SIGKILL to the same direct child after one second. Stale generation checks prevent old exits from changing a new session. A successful menu mutation reloads the provider so the visible rows show current state. `refreshExtensions: true` also reloads the extension catalog after success. Failed commands leave the current menu open and do not refresh it.
+
+Set the extension field `globalSearch: true` to include its current top-level actionable rows in Omalaunch general search. The default is `false`, so omitted and false values keep the current shortcut-only behavior. Omalaunch preloads opted-in, available providers and searches each row by `label`, `description`, and optional string or string-array `aliases`. A row with `starred: true` also appears on the launcher's top-level starting view; non-starred rows remain search-only. The extension root remains visible as a separate search result. Activating a cached row runs the same primary command, including confirmation or input handling, and honors `closeOnSuccess`. Ctrl+K opens the row's cached contextual actions.
+
+The preload is one atomic cached snapshot. Omalaunch keeps the last complete snapshot if one provider fails, times out, returns invalid or excessive output, or exceeds an aggregate safeguard. At most 16 opted-in providers, 1,000 searchable rows, 1 MiB of output, and ten seconds of aggregate preload time are accepted; the existing five-second, 256 KiB, and 100-row limits still apply to each provider. Catalog changes and successful menu mutations invalidate and reload the snapshot. Generation checks reject stale provider exits. Providers must return all searchable state in the normal bounded menu response; Omalaunch does not run providers for each keystroke.
+
+Dynamic menus are for small actionable collections, not unbounded search results or a persistent RPC protocol. The plugin remains trusted local software; argument arrays prevent accidental shell parsing but do not sandbox it.
 
 ## Live-query extension
 
@@ -224,12 +298,12 @@ The highest-priority matching live-query extension runs. Live queries debounce f
 - `schemaVersion`: Extension format version; currently `1`.
 - `id`: Stable, unique extension identifier.
 - `capability`: Stable behavior being supplied or replaced; defaults to `id`.
-- `mode`: `prefix`, `query`, `files`, or `workflow`; defaults to `prefix`.
+- `mode`: `prefix`, `query`, `files`, `workflow`, or `menu`; defaults to `prefix`.
 - `label`, `icon`, `iconFont`, `description`: Result presentation.
 - `rootDescription`: Optional description for the extension shortcut in Extensions and global search. Use it when activating the extension differs from activating one of its results; defaults to `description`.
 - `priority`: Selection priority; defaults to `0`.
 - `requires`: Executable names that must be available on `PATH`.
-- `command`: Argument array. Prefix mode supports `{prompt}`; query mode supports `{query}`.
+- `command`: Argument array. Prefix mode supports `{prompt}`; query mode supports `{query}`; menu providers support `{extensionDir}`.
 
 Commands are argument arrays. Omalaunch substitutes placeholders and shell-quotes action arguments. Do not embed pipes, redirects, or other shell syntax.
 

--- a/Menu.qml
+++ b/Menu.qml
@@ -680,7 +680,7 @@ Item {
     root.dynamicMenuGeneration += 1
     if (dynamicMenuProc.running) {
       dynamicMenuProc.stopping = true
-      dynamicMenuProc.stopGeneration = root.dynamicMenuGeneration
+      dynamicMenuProc.stopGeneration = dynamicMenuProc.generation
       dynamicMenuKillTimer.generation = dynamicMenuProc.stopGeneration
       dynamicMenuProc.running = false
       dynamicMenuKillTimer.restart()
@@ -696,7 +696,10 @@ Item {
     root.dynamicMenuSearchCandidate = []
     if (dynamicMenuSearchProc.running) {
       dynamicMenuSearchProc.stopping = true
+      dynamicMenuSearchProc.stopGeneration = dynamicMenuSearchProc.generation
+      dynamicMenuSearchKillTimer.generation = dynamicMenuSearchProc.stopGeneration
       dynamicMenuSearchProc.running = false
+      dynamicMenuSearchKillTimer.restart()
     }
   }
 
@@ -2850,9 +2853,23 @@ Item {
       root.rejectDynamicMenuSearch("global menu search preload exceeded the aggregate time limit")
   }
 
+  Timer {
+    id: dynamicMenuSearchKillTimer
+    interval: root.dynamicMenuTerminationGraceMs
+    repeat: false
+    property int generation: 0
+    onTriggered: {
+      if (!dynamicMenuSearchProc.stopping || generation !== dynamicMenuSearchProc.stopGeneration
+          || generation !== dynamicMenuSearchProc.generation) return
+      console.warn("Omalaunch: global menu search provider ignored SIGTERM; sending SIGKILL to direct child")
+      dynamicMenuSearchProc.signal(9)
+    }
+  }
+
   Process {
     id: dynamicMenuSearchProc
     property int generation: 0
+    property int stopGeneration: 0
     property var extension: null
     property bool stopping: false
     property string collected: ""
@@ -2865,7 +2882,7 @@ Item {
         var next = dynamicMenuSearchProc.collected + data + "\n"
         if (next.length > root.dynamicMenuOutputBytes || nextBytes > root.dynamicMenuSearchMaxOutputBytes) {
           dynamicMenuSearchProc.outputOverflow = true
-          dynamicMenuSearchProc.running = false
+          root.rejectDynamicMenuSearch("global menu search provider exceeded an output limit")
         } else {
           root.dynamicMenuSearchOutputBytes = nextBytes
           dynamicMenuSearchProc.collected = next
@@ -2880,12 +2897,15 @@ Item {
         if (dynamicMenuSearchProc.stderrBytes > root.dynamicMenuOutputBytes
             || root.dynamicMenuSearchOutputBytes > root.dynamicMenuSearchMaxOutputBytes) {
           dynamicMenuSearchProc.outputOverflow = true
-          dynamicMenuSearchProc.running = false
+          root.rejectDynamicMenuSearch("global menu search provider exceeded an output limit")
         }
       }
     }
     onExited: function(exitCode) {
       dynamicMenuSearchProviderTimeout.stop()
+      if (dynamicMenuSearchKillTimer.generation === dynamicMenuSearchProc.generation)
+        dynamicMenuSearchKillTimer.stop()
+      dynamicMenuSearchProc.stopGeneration = 0
       if (dynamicMenuSearchProc.generation !== root.dynamicMenuSearchGeneration) {
         dynamicMenuSearchProc.stopping = false
         root.startDynamicMenuSearchProvider()
@@ -2948,7 +2968,8 @@ Item {
     repeat: false
     property int generation: 0
     onTriggered: {
-      if (!dynamicMenuProc.stopping || generation !== dynamicMenuProc.stopGeneration) return
+      if (!dynamicMenuProc.stopping || generation !== dynamicMenuProc.stopGeneration
+          || generation !== dynamicMenuProc.generation) return
       console.warn("Omalaunch: dynamic menu provider ignored SIGTERM; sending SIGKILL to direct child")
       dynamicMenuProc.signal(9)
     }
@@ -2970,7 +2991,7 @@ Item {
         if (next.length > root.dynamicMenuOutputBytes) {
           dynamicMenuProc.outputOverflow = true
           dynamicMenuProc.collected = ""
-          dynamicMenuProc.running = false
+          root.invalidateDynamicMenu()
         } else dynamicMenuProc.collected = next
       }
     }
@@ -2980,7 +3001,7 @@ Item {
         dynamicMenuProc.stderrBytes += data.length + 1
         if (dynamicMenuProc.stderrBytes > root.dynamicMenuOutputBytes) {
           dynamicMenuProc.outputOverflow = true
-          dynamicMenuProc.running = false
+          root.invalidateDynamicMenu()
         }
       }
     }

--- a/Menu.qml
+++ b/Menu.qml
@@ -125,9 +125,28 @@ Item {
   property var workflowNode: null
   property var workflowContext: ({})
   property var workflowStack: []
+  property bool dynamicMenuLoading: false
+  property var workflowConfirmNode: null
+  property bool workflowConfirmOpen: false
+  property int dynamicMenuGeneration: 0
+  readonly property int dynamicMenuTimeoutMs: 5000
+  readonly property int dynamicMenuTerminationGraceMs: 500
+  readonly property int dynamicMenuOutputBytes: 256 * 1024
+  property var dynamicMenuSearchSnapshot: []
+  property var dynamicMenuSearchQueue: []
+  property var dynamicMenuSearchCandidate: []
+  property int dynamicMenuSearchGeneration: 0
+  property int dynamicMenuSearchOutputBytes: 0
+  readonly property int dynamicMenuSearchMaxProviders: 16
+  readonly property int dynamicMenuSearchMaxRows: 1000
+  readonly property int dynamicMenuSearchMaxOutputBytes: 1024 * 1024
+  readonly property int dynamicMenuSearchTotalTimeoutMs: 10 * 1000
   property int workflowGeneration: 0
   readonly property int workflowActionTimeoutMs: 30 * 1000
   readonly property int workflowTerminationGraceMs: 1000
+  property int backgroundActionGeneration: 0
+  readonly property int backgroundActionTimeoutMs: 30 * 1000
+  readonly property int backgroundDiagnosticTextLimit: 256
   property int fileScanSerial: 0
   readonly property string fileIndexHelper: root.pluginPath + "/extensions/files/file-index.py"
   readonly property string extensionLoaderHelper: root.pluginPath + "/libexec/load-extensions.py"
@@ -150,6 +169,18 @@ Item {
     ? displayModel.get(root.selectedIndex) : null
   readonly property string selectedFilePath: root.selectedFileRow ? String(root.selectedFileRow.action || "") : ""
   readonly property bool imagePreviewActive: MenuModel.isImagePath(root.selectedFilePath)
+  readonly property var selectedWorkflowNode: root.workflowActive && !root.fileBrowserActive
+    && root.workflowNode && root.workflowNode.kind === "menu" && root.cursorActive
+    && root.selectedIndex >= 0 && root.selectedIndex < displayModel.count
+    ? root.workflowNode.items[Number(displayModel.get(root.selectedIndex).action)] : null
+  readonly property bool selectedWorkflowHasActions: root.selectedWorkflowNode
+    && root.selectedWorkflowNode.actions && root.selectedWorkflowNode.actions.length > 0
+  readonly property var selectedWorkflowStarAction: root.workflowStarAction(root.selectedWorkflowNode)
+  readonly property var selectedDynamicSearchEntry: !root.workflowActive && root.cursorActive
+    && root.selectedIndex >= 0 && root.selectedIndex < displayModel.count
+    ? root.dynamicMenuSearchEntry(displayModel.get(root.selectedIndex).itemId) : null
+  readonly property var selectedDynamicStarAction: root.selectedDynamicSearchEntry
+    ? root.workflowStarAction(root.selectedDynamicSearchEntry.node) : null
   readonly property int previewPaneWidth: Style.space(280)
 
   // Shared application engine (entries, hidden filters, icons, launch,
@@ -179,6 +210,8 @@ Item {
   property var dependencyTarget: null
   onOpenedChanged: if (!opened) {
     root.invalidateWorkflowAction("launcher closed")
+    root.invalidateBackgroundAction("launcher closed")
+    root.invalidateDynamicMenu()
     root.invalidateExtensionQuery("launcher closed")
     deleteConfirmOpen = false
     deleteTarget = null
@@ -201,6 +234,9 @@ Item {
   }
 
   property color background: Color.menu.background
+  // Menu theme surfaces can include alpha. Confirmation cards must be opaque
+  // because they are rendered over the menu card and its rows.
+  readonly property color dialogBackground: Qt.rgba(background.r, background.g, background.b, 1)
   property color foreground: Color.menu.text
   property color border: Color.menu.border
   property var borderSpec: Border.surfaceSpec("menu", "border", border, Math.max(1, Style.space(2)))
@@ -231,8 +267,11 @@ Item {
     : Style.space(root.imagePreviewActive ? 900 : 600), panel.width - Style.gapsOut * 2)
   readonly property bool emptyRoot: !root.dmenuActive && root.activeMenu === "root" && !root.filterText && displayModel.count === 0
   property int visibleRowsHeight: root.emptyRoot || root.workflowInputActive ? 0 : (root.dmenuActive ? dmenuRowListHeight(layoutSerial, displayModel.count, filterText) : rowListHeight(layoutSerial, displayModel.count, filterText, searchDivider))
+  readonly property bool workflowFilterMenuActive: root.workflowActive && root.workflowNode && root.workflowNode.kind === "menu"
+  property int workflowHintHeight: (root.workflowInputActive || root.workflowFilterMenuActive) ? Style.space(18) : 0
   property int cardHeight: Math.min(contentMargin + actionBarBottomPadding + headerHeight + actionBarHeight + contentSpacing
-    + (visibleRowsHeight > 0 ? contentSpacing + visibleRowsHeight : 0), panel.height - Style.gapsOut * 2)
+    + (visibleRowsHeight > 0 ? contentSpacing + visibleRowsHeight : 0)
+    + (workflowHintHeight > 0 ? contentSpacing + workflowHintHeight : 0), panel.height - Style.gapsOut * 2)
 
   readonly property var actionBarHints: MenuModel.actionBarHints({
     dmenuActive: root.dmenuActive,
@@ -242,9 +281,11 @@ Item {
     fileBrowserActive: root.fileBrowserActive,
     directoryPickerActive: root.directoryPickerActive,
     actionPanelActive: root.actionPanelActive,
+    canContextActions: root.selectedWorkflowHasActions || (root.selectedDynamicSearchEntry
+      && root.selectedDynamicSearchEntry.node.actions.length > 0),
     focusedExtension: !!root.focusedExtension,
     hasSelection: displayModel.count > 0 && root.cursorActive,
-    canStar: !root.dmenuActive && !root.workflowActive && !root.actionPanelActive
+    canStar: (!root.dmenuActive && !root.workflowActive && !root.actionPanelActive) || !!root.selectedWorkflowStarAction || !!root.selectedDynamicStarAction
       && displayModel.count > 0 && root.cursorActive && root.selectedIndex >= 0
       && root.selectedIndex < displayModel.count
       && (root.fileBrowserActive || (displayModel.get(root.selectedIndex).itemId !== "omarchy"
@@ -612,6 +653,7 @@ Item {
     var activation = MenuModel.extensionRootActivation(extension)
     if (activation === "files") root.enterFileBrowser(extension)
     else if (activation === "workflow") root.enterWorkflow(extension)
+    else if (activation === "menu") root.enterDynamicMenu(extension)
     else if (activation === "input") root.enterFocusedExtension(extension)
   }
 
@@ -630,6 +672,117 @@ Item {
     var values = node && node.context ? node.context : ({})
     for (var key in values) result[key] = MenuModel.workflowInterpolate(values[key], Object.assign({}, result, { extensionDir: root.workflowExtension ? root.workflowExtension.sourceDir : "" }))
     return result
+  }
+
+  function invalidateDynamicMenu() {
+    if (dynamicMenuProc.stopping) return
+    dynamicMenuTimeout.stop()
+    root.dynamicMenuGeneration += 1
+    if (dynamicMenuProc.running) {
+      dynamicMenuProc.stopping = true
+      dynamicMenuProc.stopGeneration = root.dynamicMenuGeneration
+      dynamicMenuKillTimer.generation = dynamicMenuProc.stopGeneration
+      dynamicMenuProc.running = false
+      dynamicMenuKillTimer.restart()
+    }
+    root.dynamicMenuLoading = false
+  }
+
+  function invalidateDynamicMenuSearch() {
+    root.dynamicMenuSearchGeneration += 1
+    dynamicMenuSearchProviderTimeout.stop()
+    dynamicMenuSearchTotalTimeout.stop()
+    root.dynamicMenuSearchQueue = []
+    root.dynamicMenuSearchCandidate = []
+    if (dynamicMenuSearchProc.running) {
+      dynamicMenuSearchProc.stopping = true
+      dynamicMenuSearchProc.running = false
+    }
+  }
+
+  function preloadDynamicMenuSearch() {
+    root.invalidateDynamicMenuSearch()
+    var queue = []
+    for (var i = 0; i < root.extensions.length; i++) {
+      var extension = root.extensions[i]
+      if (extension.mode === "menu" && extension.available && extension.globalSearch) queue.push(extension)
+    }
+    if (queue.length > root.dynamicMenuSearchMaxProviders) {
+      console.warn("Omalaunch: global menu search preload exceeds the provider limit; retained the previous snapshot")
+      return
+    }
+    if (queue.length === 0) {
+      root.dynamicMenuSearchSnapshot = []
+      root.rebuildDisplay()
+      return
+    }
+    root.dynamicMenuSearchQueue = queue
+    root.dynamicMenuSearchOutputBytes = 0
+    dynamicMenuSearchTotalTimeout.generation = root.dynamicMenuSearchGeneration
+    dynamicMenuSearchTotalTimeout.restart()
+    root.startDynamicMenuSearchProvider()
+  }
+
+  function startDynamicMenuSearchProvider() {
+    if (dynamicMenuSearchProc.running || dynamicMenuSearchProc.stopping || root.dynamicMenuSearchQueue.length === 0) return
+    var extension = root.dynamicMenuSearchQueue[0]
+    root.dynamicMenuSearchQueue = root.dynamicMenuSearchQueue.slice(1)
+    dynamicMenuSearchProc.generation = root.dynamicMenuSearchGeneration
+    dynamicMenuSearchProc.extension = extension
+    dynamicMenuSearchProc.collected = ""
+    dynamicMenuSearchProc.stderrBytes = 0
+    dynamicMenuSearchProc.outputOverflow = false
+    dynamicMenuSearchProc.command = extension.command.map(function(argument) {
+      return MenuModel.workflowInterpolate(argument, { extensionDir: extension.sourceDir })
+    })
+    dynamicMenuSearchProc.running = true
+    dynamicMenuSearchProviderTimeout.generation = root.dynamicMenuSearchGeneration
+    dynamicMenuSearchProviderTimeout.restart()
+  }
+
+  function rejectDynamicMenuSearch(reason) {
+    console.warn("Omalaunch: " + reason + "; retained the previous global menu search snapshot")
+    root.invalidateDynamicMenuSearch()
+  }
+
+  function dynamicMenuSearchEntry(itemId) {
+    for (var i = 0; i < root.dynamicMenuSearchSnapshot.length; i++)
+      if (root.dynamicMenuSearchSnapshot[i].item.id === itemId) return root.dynamicMenuSearchSnapshot[i]
+    return null
+  }
+
+  function enterDynamicMenu(extension, retainRows) {
+    if (!extension || !extension.available || extension.mode !== "menu"
+        || dynamicMenuProc.running || dynamicMenuProc.stopping) return
+    var retainCurrentRows = retainRows === true && root.workflowActive && root.workflowNode
+    root.invalidateExtensionQuery("entered dynamic menu")
+    root.invalidateWorkflowAction("entered dynamic menu")
+    root.focusedExtension = null
+    root.leaveFileBrowser(false)
+    root.workflowActive = true
+    root.workflowExtension = extension
+    root.workflowStack = []
+    root.workflowContext = ({ extensionDir: extension.sourceDir })
+    if (!retainCurrentRows) {
+      root.workflowNode = { id: "root", kind: "menu", label: extension.label, description: extension.description, items: [] }
+      root.filterText = ""
+      root.selectedIndex = 0
+      root.cursorActive = false
+    }
+    root.dynamicMenuLoading = true
+    root.dynamicMenuGeneration += 1
+    dynamicMenuProc.generation = root.dynamicMenuGeneration
+    dynamicMenuProc.extensionCapability = extension.capability
+    dynamicMenuProc.selectionNodeId = retainCurrentRows && root.selectedWorkflowNode ? root.selectedWorkflowNode.id : ""
+    dynamicMenuProc.collected = ""
+    dynamicMenuProc.stderrBytes = 0
+    dynamicMenuProc.outputOverflow = false
+    dynamicMenuProc.command = extension.command.map(function(argument) {
+      return MenuModel.workflowInterpolate(argument, { extensionDir: extension.sourceDir })
+    })
+    dynamicMenuProc.running = true
+    dynamicMenuTimeout.restart()
+    if (!retainCurrentRows) root.rebuildDisplay()
   }
 
   function enterWorkflow(extension) {
@@ -657,6 +810,9 @@ Item {
 
   function leaveWorkflow() {
     root.invalidateWorkflowAction("left workflow")
+    root.invalidateDynamicMenu()
+    root.workflowConfirmOpen = false
+    root.workflowConfirmNode = null
     root.resetFileIndex()
     root.fileBrowserActive = false
     root.directoryPickerActive = false
@@ -666,6 +822,9 @@ Item {
     root.workflowNode = null
     root.workflowContext = ({})
     root.workflowStack = []
+    root.dynamicMenuLoading = false
+    root.workflowConfirmOpen = false
+    root.workflowConfirmNode = null
     root.filterText = ""
     root.rebuildDisplay()
   }
@@ -709,7 +868,126 @@ Item {
     if (!root.workflowNode || root.workflowNode.kind !== "menu") return
     var child = root.workflowNode.items[index]
     if (!child) return
-    root.showWorkflowNode(child, root.workflowContext, true)
+    if (child.kind === "action") root.dispatchWorkflowNode(child, "")
+    else if (child.kind === "confirm") {
+      root.workflowConfirmNode = child
+      root.workflowConfirmOpen = true
+    } else root.showWorkflowNode(child, root.workflowContext, true)
+  }
+
+  function workflowStarAction(node) {
+    if (!node || !node.starAction || !node.actions) return null
+    for (var i = 0; i < node.actions.length; i++)
+      if (node.actions[i].id === node.starAction) return node.actions[i]
+    return null
+  }
+
+  function toggleSelectedWorkflowStar() {
+    var action = root.selectedWorkflowStarAction
+    if (action) root.dispatchWorkflowNode(action, "", false, true)
+  }
+
+  function openWorkflowActions() {
+    if (!root.workflowActive || root.fileBrowserActive || !root.workflowNode || root.workflowNode.kind !== "menu"
+        || !root.cursorActive || root.selectedIndex < 0 || root.selectedIndex >= root.workflowNode.items.length) return
+    var child = root.selectedWorkflowNode
+    if (!child || !child.actions || child.actions.length === 0) return
+    root.showWorkflowNode({ id: child.id + ".actions", kind: "menu", label: child.label,
+      description: "Actions", items: child.actions }, root.workflowContext, true)
+  }
+
+  function toggleSelectedDynamicStar() {
+    var entry = root.selectedDynamicSearchEntry
+    var action = root.selectedDynamicStarAction
+    if (!entry || !action) return
+    var extension = root.extensionByCapability(entry.capability)
+    if (!extension || !extension.available || extension.id !== entry.extensionId) return
+    root.dispatchBackgroundAction(extension, action, "")
+  }
+
+  function openDynamicSearchActions() {
+    var entry = root.selectedDynamicSearchEntry
+    if (!entry || !entry.node.actions || entry.node.actions.length === 0) return
+    var extension = root.extensionByCapability(entry.capability)
+    if (!extension || !extension.available || extension.id !== entry.extensionId) return
+    root.workflowActive = true
+    root.workflowExtension = extension
+    root.workflowContext = ({ extensionDir: extension.sourceDir })
+    root.workflowStack = []
+    root.workflowNode = { id: entry.node.id + ".actions", kind: "menu", label: entry.node.label,
+      description: "Actions", items: entry.node.actions }
+    root.filterText = ""
+    root.selectedIndex = 0
+    root.rebuildDisplay()
+  }
+
+  function boundedBackgroundDiagnostic(value) {
+    var text = String(value || "").replace(/[\r\n\0]/g, " ")
+    return text.substring(0, root.backgroundDiagnosticTextLimit)
+  }
+
+  function dispatchBackgroundAction(extension, node, input) {
+    if (!extension || !node) return
+    var values = Object.assign({}, root.workflowContext || ({}), { extensionDir: extension.sourceDir, input: input })
+    var command = MenuModel.workflowCommand(node, input, values)
+    if (!MenuModel.workflowBackgroundEligible(node, command)) return
+    if (backgroundActionProc.running || backgroundActionProc.stopping) {
+      console.warn("Omalaunch: background action is busy; ignored " + root.boundedBackgroundDiagnostic(node.id))
+      return
+    }
+    root.backgroundActionGeneration += 1
+    backgroundActionProc.generation = root.backgroundActionGeneration
+    backgroundActionProc.extensionCapability = extension.capability
+    backgroundActionProc.refreshExtensions = node.refreshExtensions
+    backgroundActionProc.closeAfter = node.closeOnSuccess
+    backgroundActionProc.actionId = root.boundedBackgroundDiagnostic(node.id)
+    backgroundActionProc.command = command
+    backgroundActionProc.running = true
+    backgroundActionTimeout.restart()
+  }
+
+  function invalidateBackgroundAction(reason) {
+    if (backgroundActionProc.stopping || !backgroundActionProc.running) return
+    root.backgroundActionGeneration += 1
+    backgroundActionTimeout.stop()
+    backgroundActionProc.stopping = true
+    backgroundActionProc.stopGeneration = backgroundActionProc.generation
+    backgroundActionKillTimer.generation = backgroundActionProc.stopGeneration
+    backgroundActionProc.running = false
+    backgroundActionKillTimer.restart()
+  }
+
+  function dispatchWorkflowNode(node, input, returnToRoot, backgroundRequested) {
+    if (!node) return
+    var transition = node.kind === "input" ? MenuModel.workflowInputTransition(node, input, root.workflowContext)
+      : { node: node.next, context: root.workflowContext }
+    if (!transition) return
+    var command = MenuModel.workflowCommand(node, input, root.workflowValues({ input: input }))
+    if (command.length === 0) return
+    if (backgroundRequested === true && MenuModel.workflowBackgroundEligible(node, command)) {
+      root.dispatchBackgroundAction(root.workflowExtension, node, input)
+      return
+    }
+    if (workflowActionProc.running || workflowActionProc.stopping) return
+    if (MenuModel.workflowClosesOnDispatch(node, command)) {
+      Quickshell.execDetached(command)
+      root.closeWorkflowAfterDispatch()
+      return
+    }
+    root.workflowGeneration += 1
+    workflowActionProc.generation = root.workflowGeneration
+    workflowActionProc.extensionCapability = root.workflowExtension.capability
+    workflowActionProc.nextNode = node.next
+    workflowActionProc.nextContext = transition.context
+    workflowActionProc.refreshExtensions = node.refreshExtensions
+    workflowActionProc.refreshDynamicMenu = root.workflowExtension.mode === "menu" && !node.next && !node.refreshExtensions && !node.closeOnSuccess
+    workflowActionProc.nextBackSteps = node.nextBackSteps
+    workflowActionProc.closeAfter = node.closeOnSuccess || (root.workflowExtension.mode !== "menu" && !node.next)
+    workflowActionProc.returnToRoot = returnToRoot === true
+    console.warn("Omalaunch action dispatch: " + JSON.stringify(command))
+    workflowActionProc.command = command
+    workflowActionProc.running = true
+    workflowActionTimeout.restart()
   }
 
   function enterDirectoryPicker(startPath) {
@@ -740,30 +1018,12 @@ Item {
     var transition = MenuModel.workflowInputTransition(node, value, root.workflowContext)
     // Validation happens before any generation change or launcher close.
     if (!transition) return
-    var context = root.workflowValues({ input: value })
-    var command = MenuModel.workflowCommand(node, value, context)
+    var command = MenuModel.workflowCommand(node, value, root.workflowValues({ input: value }))
     if (command.length === 0) {
       if (node.next) root.showWorkflowNode(node.next, transition.context, true)
       return
     }
-    if (MenuModel.workflowClosesOnDispatch(node, command)) {
-      // Do not attach a long-lived terminal wrapper to the reusable Process.
-      // Argument arrays preserve prompt/path values literally.
-      Quickshell.execDetached(command)
-      root.closeWorkflowAfterDispatch()
-      return
-    }
-    root.workflowGeneration += 1
-    workflowActionProc.generation = root.workflowGeneration
-    workflowActionProc.extensionCapability = root.workflowExtension.capability
-    workflowActionProc.nextNode = node.next
-    workflowActionProc.nextContext = transition.context
-    workflowActionProc.refreshExtensions = node.refreshExtensions
-    workflowActionProc.nextBackSteps = node.nextBackSteps
-    workflowActionProc.closeAfter = !node.next
-    workflowActionProc.command = command
-    workflowActionProc.running = true
-    workflowActionTimeout.restart()
+    root.dispatchWorkflowNode(node, value)
   }
 
   function invalidateWorkflowAction(reason) {
@@ -775,6 +1035,7 @@ Item {
     workflowActionProc.nextNode = null
     workflowActionProc.nextContext = ({})
     workflowActionProc.refreshExtensions = false
+    workflowActionProc.refreshDynamicMenu = false
     workflowActionProc.nextBackSteps = 0
     workflowActionProc.closeAfter = false
     if (workflowActionProc.running) {
@@ -1463,6 +1724,7 @@ Item {
       displayModel.clear()
       root.searchDivider = false
       if (root.workflowNode && root.workflowNode.kind === "menu") {
+        var workflowQuery = MenuModel.prepareSearchQuery(root.filterText.trim())
         for (var workflowIndex = 0; workflowIndex < root.workflowNode.items.length; workflowIndex++) {
           var workflowChild = root.workflowNode.items[workflowIndex]
           var workflowItem = root.normalizeItem("workflow.node." + workflowIndex, {
@@ -1470,14 +1732,19 @@ Item {
             iconFont: workflowChild.iconFont,
             label: root.workflowText(workflowChild.label),
             description: root.workflowText(workflowChild.description),
+            aliases: workflowChild.aliases,
             action: String(workflowIndex)
           })
+          if (workflowQuery && !MenuModel.matchesQuery(workflowItem, workflowQuery, true)) continue
           if (workflowChild.kind === "menu" || workflowChild.kind === "directoryPicker") workflowItem.kind = "menu"
-          displayModel.append(root.displayRow(workflowItem, workflowItem.description, workflowIndex))
+          var workflowRow = root.displayRow(workflowItem, workflowItem.description, workflowIndex)
+          workflowRow.starred = workflowChild.starred
+          displayModel.append(workflowRow)
         }
       }
       root.layoutSerial += 1
       root.selectedIndex = displayModel.count > 0 ? Math.min(root.selectedIndex, displayModel.count - 1) : 0
+      root.cursorActive = displayModel.count > 0
       return
     }
     if (root.dmenuActive) {
@@ -1516,6 +1783,20 @@ Item {
         rows.push(row)
       }
 
+      // Keep the fixed Extensions directory searchable even while dynamic
+      // catalog and global-search snapshots rebuild the ordinary item order.
+      if (!root.focusedExtension && active === "root") {
+        var extensionsDirectory = root.item("extensions")
+        var extensionsDirectorySeen = false
+        for (var extensionsSeenIndex = 0; extensionsSeenIndex < rows.length; extensionsSeenIndex++)
+          if (rows[extensionsSeenIndex].itemId === "extensions") { extensionsDirectorySeen = true; break }
+        if (!extensionsDirectorySeen && extensionsDirectory && MenuModel.matchesQuery(extensionsDirectory, preparedQuery, true)) {
+          var extensionsDirectoryRow = root.displayRow(extensionsDirectory, extensionsDirectory.description, 0)
+          extensionsDirectoryRow.matchPriority = MenuModel.searchMatchPriority(extensionsDirectory, preparedQuery)
+          rows.push(extensionsDirectoryRow)
+        }
+      }
+
       // File favorites are synthetic starting-view rows rather than members of
       // the menu tree, so add matching ones explicitly during global search.
       if (!root.focusedExtension && active === "root") {
@@ -1533,6 +1814,17 @@ Item {
           searchFavoriteRow.starred = true
           searchFavoriteRow.matchPriority = MenuModel.searchMatchPriority(searchFavoriteItem, preparedQuery)
           rows.push(searchFavoriteRow)
+        }
+      }
+
+      if (!root.focusedExtension && active === "root") {
+        for (var dynamicSearchIndex = 0; dynamicSearchIndex < root.dynamicMenuSearchSnapshot.length; dynamicSearchIndex++) {
+          var dynamicSearchEntry = root.dynamicMenuSearchSnapshot[dynamicSearchIndex]
+          if (!MenuModel.matchesQuery(dynamicSearchEntry.item, preparedQuery, true)) continue
+          var dynamicSearchRow = root.displayRow(dynamicSearchEntry.item, dynamicSearchEntry.item.description, 0)
+          dynamicSearchRow.starred = dynamicSearchEntry.node.starred
+          dynamicSearchRow.matchPriority = MenuModel.searchMatchPriority(dynamicSearchEntry.item, preparedQuery)
+          rows.push(dynamicSearchRow)
         }
       }
 
@@ -1680,6 +1972,14 @@ Item {
       }
 
       if (active === "root") {
+        for (var starredDynamicIndex = 0; starredDynamicIndex < root.dynamicMenuSearchSnapshot.length; starredDynamicIndex++) {
+          var starredDynamicEntry = root.dynamicMenuSearchSnapshot[starredDynamicIndex]
+          if (!starredDynamicEntry.node.starred) continue
+          var starredDynamicRow = root.displayRow(starredDynamicEntry.item, starredDynamicEntry.item.description, 0)
+          starredDynamicRow.starred = true
+          rows.push(starredDynamicRow)
+        }
+
         var favoriteIds = Object.keys(favorites.starredIds)
         var seenFileFavorites = ({})
         for (var favoriteIndex = 0; favoriteIndex < favoriteIds.length; favoriteIndex++) {
@@ -1868,6 +2168,25 @@ Item {
     if (index < 0 || index >= displayModel.count) return
 
     var row = displayModel.get(index)
+    var dynamicSearchEntry = root.dynamicMenuSearchEntry(row.itemId)
+    if (dynamicSearchEntry) {
+      var dynamicSearchExtension = root.extensionByCapability(dynamicSearchEntry.capability)
+      if (!dynamicSearchExtension || !dynamicSearchExtension.available
+          || dynamicSearchExtension.id !== dynamicSearchEntry.extensionId) return
+      root.workflowActive = true
+      root.workflowExtension = dynamicSearchExtension
+      root.workflowContext = ({ extensionDir: dynamicSearchExtension.sourceDir })
+      root.workflowStack = []
+      root.workflowNode = { id: "root", kind: "menu", label: dynamicSearchExtension.label,
+        description: dynamicSearchExtension.description, items: dynamicSearchEntry.items }
+      if (dynamicSearchEntry.node.kind === "action") root.dispatchWorkflowNode(dynamicSearchEntry.node, "")
+      else if (dynamicSearchEntry.node.kind === "confirm") {
+        root.workflowConfirmNode = dynamicSearchEntry.node
+        root.workflowConfirmOpen = true
+        root.rebuildDisplay()
+      } else root.showWorkflowNode(dynamicSearchEntry.node, root.workflowContext, true)
+      return
+    }
     var rootExtension = root.extensionForRootId(row.itemId)
     if (rootExtension) {
       if (rootExtension.available) usage.record(row.itemId)
@@ -2047,6 +2366,7 @@ Item {
   function resetForOpen() {
     if (root.dmenuActive && root.requestActive) root.finishRequest(null)
     root.invalidateWorkflowAction("new launcher session")
+    root.invalidateDynamicMenu()
     root.routePendingForMenuSources = false
     root.resetFileIndex()
     root.invalidateExtensionQuery("new launcher session")
@@ -2067,6 +2387,9 @@ Item {
 
   function cancel() {
     root.invalidateWorkflowAction("launcher canceled")
+    root.invalidateDynamicMenu()
+    root.workflowConfirmOpen = false
+    root.workflowConfirmNode = null
     root.routePendingForMenuSources = false
     if (root.dmenuActive) root.finishRequest(null)
     root.resetFileIndex()
@@ -2080,6 +2403,7 @@ Item {
     root.workflowNode = null
     root.workflowContext = ({})
     root.workflowStack = []
+    root.dynamicMenuLoading = false
     root.focusedExtension = null
     root.extensionQuery = ""
     root.extensionResult = ""
@@ -2222,10 +2546,27 @@ Item {
     property string copyPath: ""
     property string successMessage: "Copied path"
     onExited: function(exitCode) {
+      if (exitCode === 0) {
+        root.cancel()
+        return
+      }
       root.fileCopyFeedbackPath = fileCopyProc.copyPath
-      root.fileCopyFeedback = exitCode === 0 ? fileCopyProc.successMessage : "Copy failed"
+      root.fileCopyFeedback = "Copy failed"
       if (root.fileBrowserActive) root.rebuildFileDisplay()
       fileCopyFeedbackTimer.restart()
+    }
+  }
+
+  Process {
+    id: pasteProc
+    command: ["wl-paste", "--no-newline", "--type", "text"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        if (!root.workflowInputActive) return
+        var limit = root.workflowNode ? root.workflowNode.maxLength : 4096
+        root.setFilter((root.filterText + text).substring(0, limit))
+      }
     }
   }
 
@@ -2430,6 +2771,7 @@ Item {
         var oldWorkflowNode = root.workflowNode
         var oldWorkflowStack = root.workflowStack
         root.extensions = catalog.extensions
+        root.preloadDynamicMenuSearch()
 
         if (focusedCapability) {
           var refreshedFocus = root.extensionByCapability(focusedCapability) || root.extensionById(focusedId)
@@ -2439,12 +2781,17 @@ Item {
         }
         if (root.workflowActive) {
           var refreshedWorkflow = root.extensionByCapability(workflowCapability) || root.extensionById(workflowId)
-          var rebound = MenuModel.rebindWorkflow(refreshedWorkflow, oldWorkflowStack, oldWorkflowNode)
-          if (rebound) {
-            root.workflowExtension = refreshedWorkflow
-            root.workflowNode = rebound.node
-            root.workflowStack = rebound.stack
-          } else root.leaveWorkflow()
+          if (refreshedWorkflow && refreshedWorkflow.available && refreshedWorkflow.mode === "menu") {
+            root.leaveWorkflow()
+            root.enterDynamicMenu(refreshedWorkflow)
+          } else {
+            var rebound = MenuModel.rebindWorkflow(refreshedWorkflow, oldWorkflowStack, oldWorkflowNode)
+            if (rebound) {
+              root.workflowExtension = refreshedWorkflow
+              root.workflowNode = rebound.node
+              root.workflowStack = rebound.stack
+            } else root.leaveWorkflow()
+          }
         }
         if (root.fileBrowserActive) {
           var refreshedFiles = root.filesExtensionForCapability(fileCapability) || root.extensionById(fileId)
@@ -2486,6 +2833,192 @@ Item {
   }
 
   Timer {
+    id: dynamicMenuSearchProviderTimeout
+    interval: root.dynamicMenuTimeoutMs
+    repeat: false
+    property int generation: 0
+    onTriggered: if (generation === root.dynamicMenuSearchGeneration)
+      root.rejectDynamicMenuSearch("global menu search provider timed out after " + interval + "ms")
+  }
+
+  Timer {
+    id: dynamicMenuSearchTotalTimeout
+    interval: root.dynamicMenuSearchTotalTimeoutMs
+    repeat: false
+    property int generation: 0
+    onTriggered: if (generation === root.dynamicMenuSearchGeneration)
+      root.rejectDynamicMenuSearch("global menu search preload exceeded the aggregate time limit")
+  }
+
+  Process {
+    id: dynamicMenuSearchProc
+    property int generation: 0
+    property var extension: null
+    property bool stopping: false
+    property string collected: ""
+    property int stderrBytes: 0
+    property bool outputOverflow: false
+    stdout: SplitParser {
+      onRead: function(data) {
+        if (dynamicMenuSearchProc.outputOverflow) return
+        var nextBytes = root.dynamicMenuSearchOutputBytes + data.length + 1
+        var next = dynamicMenuSearchProc.collected + data + "\n"
+        if (next.length > root.dynamicMenuOutputBytes || nextBytes > root.dynamicMenuSearchMaxOutputBytes) {
+          dynamicMenuSearchProc.outputOverflow = true
+          dynamicMenuSearchProc.running = false
+        } else {
+          root.dynamicMenuSearchOutputBytes = nextBytes
+          dynamicMenuSearchProc.collected = next
+        }
+      }
+    }
+    stderr: SplitParser {
+      onRead: function(data) {
+        if (dynamicMenuSearchProc.outputOverflow) return
+        dynamicMenuSearchProc.stderrBytes += data.length + 1
+        root.dynamicMenuSearchOutputBytes += data.length + 1
+        if (dynamicMenuSearchProc.stderrBytes > root.dynamicMenuOutputBytes
+            || root.dynamicMenuSearchOutputBytes > root.dynamicMenuSearchMaxOutputBytes) {
+          dynamicMenuSearchProc.outputOverflow = true
+          dynamicMenuSearchProc.running = false
+        }
+      }
+    }
+    onExited: function(exitCode) {
+      dynamicMenuSearchProviderTimeout.stop()
+      if (dynamicMenuSearchProc.generation !== root.dynamicMenuSearchGeneration) {
+        dynamicMenuSearchProc.stopping = false
+        root.startDynamicMenuSearchProvider()
+        return
+      }
+      dynamicMenuSearchProc.stopping = false
+      if (exitCode !== 0 || dynamicMenuSearchProc.outputOverflow) {
+        root.rejectDynamicMenuSearch("global menu search provider failed or exceeded an output limit")
+        return
+      }
+      var workflow = MenuModel.normalizeDynamicMenuOutput(dynamicMenuSearchProc.collected)
+      if (!workflow) {
+        root.rejectDynamicMenuSearch("global menu search provider returned an invalid snapshot")
+        return
+      }
+      var searchItems = MenuModel.dynamicMenuSearchItems(dynamicMenuSearchProc.extension, workflow)
+      if (root.dynamicMenuSearchCandidate.length + searchItems.length > root.dynamicMenuSearchMaxRows) {
+        root.rejectDynamicMenuSearch("global menu search preload exceeds the aggregate row limit")
+        return
+      }
+      var candidate = root.dynamicMenuSearchCandidate.slice()
+      for (var i = 0; i < searchItems.length; i++) {
+        var searchNode = null
+        for (var nodeIndex = 0; nodeIndex < workflow.items.length; nodeIndex++)
+          if (workflow.items[nodeIndex].id === searchItems[i].action) { searchNode = workflow.items[nodeIndex]; break }
+        if (!searchNode) {
+          root.rejectDynamicMenuSearch("global menu search row lost its normalized provider identity")
+          return
+        }
+        candidate.push({
+          item: searchItems[i], node: searchNode, items: workflow.items,
+          capability: dynamicMenuSearchProc.extension.capability, extensionId: dynamicMenuSearchProc.extension.id
+        })
+      }
+      root.dynamicMenuSearchCandidate = candidate
+      if (root.dynamicMenuSearchQueue.length > 0) root.startDynamicMenuSearchProvider()
+      else {
+        dynamicMenuSearchTotalTimeout.stop()
+        root.dynamicMenuSearchSnapshot = candidate
+        root.dynamicMenuSearchCandidate = []
+        root.rebuildDisplay()
+      }
+    }
+  }
+
+  Timer {
+    id: dynamicMenuTimeout
+    interval: root.dynamicMenuTimeoutMs
+    repeat: false
+    onTriggered: {
+      if (!dynamicMenuProc.running) return
+      console.warn("Omalaunch: dynamic menu provider timed out after " + interval + "ms")
+      root.invalidateDynamicMenu()
+    }
+  }
+
+  Timer {
+    id: dynamicMenuKillTimer
+    interval: root.dynamicMenuTerminationGraceMs
+    repeat: false
+    property int generation: 0
+    onTriggered: {
+      if (!dynamicMenuProc.stopping || generation !== dynamicMenuProc.stopGeneration) return
+      console.warn("Omalaunch: dynamic menu provider ignored SIGTERM; sending SIGKILL to direct child")
+      dynamicMenuProc.signal(9)
+    }
+  }
+
+  Process {
+    id: dynamicMenuProc
+    property int generation: 0
+    property int stopGeneration: 0
+    property bool stopping: false
+    property string extensionCapability: ""
+    property string selectionNodeId: ""
+    property string collected: ""
+    property bool outputOverflow: false
+    stdout: SplitParser {
+      onRead: function(data) {
+        if (dynamicMenuProc.outputOverflow) return
+        var next = dynamicMenuProc.collected + data + "\n"
+        if (next.length > root.dynamicMenuOutputBytes) {
+          dynamicMenuProc.outputOverflow = true
+          dynamicMenuProc.collected = ""
+          dynamicMenuProc.running = false
+        } else dynamicMenuProc.collected = next
+      }
+    }
+    stderr: SplitParser {
+      onRead: function(data) {
+        if (dynamicMenuProc.outputOverflow) return
+        dynamicMenuProc.stderrBytes += data.length + 1
+        if (dynamicMenuProc.stderrBytes > root.dynamicMenuOutputBytes) {
+          dynamicMenuProc.outputOverflow = true
+          dynamicMenuProc.running = false
+        }
+      }
+    }
+    property int stderrBytes: 0
+    onExited: function(exitCode) {
+      dynamicMenuTimeout.stop()
+      dynamicMenuKillTimer.stop()
+      dynamicMenuProc.stopGeneration = 0
+      dynamicMenuProc.stopping = false
+      if (dynamicMenuProc.generation !== root.dynamicMenuGeneration || !root.workflowActive
+          || !root.workflowExtension || root.workflowExtension.mode !== "menu"
+          || root.workflowExtension.capability !== dynamicMenuProc.extensionCapability) return
+      root.dynamicMenuLoading = false
+      var workflow = exitCode === 0 && !dynamicMenuProc.outputOverflow
+        ? MenuModel.normalizeDynamicMenuOutput(dynamicMenuProc.collected) : null
+      if (!workflow) {
+        console.warn("Omalaunch: dynamic menu provider returned invalid or failed output")
+        root.workflowNode = { id: "root", kind: "menu", label: root.workflowExtension.label,
+          description: "Provider failed", items: [] }
+      } else root.workflowNode = { id: "root", kind: "menu", label: root.workflowExtension.label,
+        description: root.workflowExtension.description, items: workflow.items }
+      var selectedWorkflowNodeIndex = -1
+      if (workflow && dynamicMenuProc.selectionNodeId) {
+        for (var selectedWorkflowIndex = 0; selectedWorkflowIndex < workflow.items.length; selectedWorkflowIndex++)
+          if (workflow.items[selectedWorkflowIndex].id === dynamicMenuProc.selectionNodeId) { selectedWorkflowNodeIndex = selectedWorkflowIndex; break }
+      }
+      dynamicMenuProc.selectionNodeId = ""
+      root.selectedIndex = 0
+      root.cursorActive = workflow && workflow.items.length > 0
+      root.rebuildDisplay()
+      if (selectedWorkflowNodeIndex >= 0) {
+        for (var selectedDisplayIndex = 0; selectedDisplayIndex < displayModel.count; selectedDisplayIndex++)
+          if (Number(displayModel.get(selectedDisplayIndex).action) === selectedWorkflowNodeIndex) { root.selectedIndex = selectedDisplayIndex; break }
+      }
+    }
+  }
+
+  Timer {
     id: workflowActionTimeout
     interval: root.workflowActionTimeoutMs
     repeat: false
@@ -2516,9 +3049,12 @@ Item {
     property var nextNode: null
     property var nextContext: ({})
     property bool refreshExtensions: false
+    property bool refreshDynamicMenu: false
     property int nextBackSteps: 0
     property bool closeAfter: false
+    property bool returnToRoot: false
     onExited: function(exitCode) {
+      console.warn("Omalaunch action exit: " + exitCode + " command=" + JSON.stringify(workflowActionProc.command))
       workflowActionTimeout.stop()
       workflowActionKillTimer.stop()
       workflowActionProc.stopGeneration = 0
@@ -2526,9 +3062,25 @@ Item {
       if (!MenuModel.workflowActionIsCurrent(workflowActionProc.generation, root.workflowGeneration,
           root.workflowActive, workflowActionProc.extensionCapability, root.workflowExtension)) return
       workflowActionProc.generation = 0
-      if (exitCode !== 0) return
+      if (exitCode !== 0) { workflowActionProc.returnToRoot = false; return }
+      if (workflowActionProc.returnToRoot) {
+        workflowActionProc.returnToRoot = false
+        root.workflowActive = false
+        root.workflowExtension = null
+        root.workflowNode = null
+        root.workflowContext = ({})
+        root.workflowStack = []
+        root.filterText = ""
+        root.preloadDynamicMenuSearch()
+        root.rebuildDisplay()
+        return
+      }
+      if (root.workflowExtension.mode === "menu") root.preloadDynamicMenuSearch()
       if (workflowActionProc.refreshExtensions) root.loadExtensions(true)
-      if (workflowActionProc.closeAfter) {
+      if (workflowActionProc.refreshDynamicMenu) {
+        var extension = root.workflowExtension
+        root.enterDynamicMenu(extension, true)
+      } else if (workflowActionProc.closeAfter) {
         root.cancel()
       } else if (workflowActionProc.nextNode) {
         if (workflowActionProc.nextBackSteps > 0) {
@@ -2537,6 +3089,59 @@ Item {
           root.showWorkflowNode(workflowActionProc.nextNode, workflowActionProc.nextContext, false)
         } else root.showWorkflowNode(workflowActionProc.nextNode, workflowActionProc.nextContext, true)
       }
+    }
+  }
+
+  Timer {
+    id: backgroundActionTimeout
+    interval: root.backgroundActionTimeoutMs
+    repeat: false
+    onTriggered: {
+      console.warn("Omalaunch: background action timed out: " + backgroundActionProc.actionId)
+      root.invalidateBackgroundAction("background action timed out")
+    }
+  }
+
+  Timer {
+    id: backgroundActionKillTimer
+    interval: root.workflowTerminationGraceMs
+    repeat: false
+    property int generation: 0
+    onTriggered: {
+      if (!backgroundActionProc.stopping || generation !== backgroundActionProc.stopGeneration) return
+      console.warn("Omalaunch: background action ignored SIGTERM; sending SIGKILL to direct child")
+      backgroundActionProc.signal(9)
+    }
+  }
+
+  Process {
+    id: backgroundActionProc
+    property int generation: 0
+    property int stopGeneration: 0
+    property bool stopping: false
+    property string extensionCapability: ""
+    property string actionId: ""
+    property bool refreshExtensions: false
+    property bool closeAfter: false
+    onExited: function(exitCode) {
+      backgroundActionTimeout.stop()
+      backgroundActionKillTimer.stop()
+      backgroundActionProc.stopGeneration = 0
+      backgroundActionProc.stopping = false
+      var extension = root.extensionByCapability(backgroundActionProc.extensionCapability)
+      if (!MenuModel.backgroundActionIsCurrent(backgroundActionProc.generation,
+          root.backgroundActionGeneration, backgroundActionProc.extensionCapability, extension)) return
+      backgroundActionProc.generation = 0
+      if (exitCode !== 0) {
+        console.warn("Omalaunch: background action failed (exit " + exitCode + "): " + backgroundActionProc.actionId)
+        return
+      }
+      if (backgroundActionProc.refreshExtensions) root.loadExtensions(true)
+      root.preloadDynamicMenuSearch()
+      if (root.workflowActive && root.workflowExtension
+          && root.workflowExtension.capability === extension.capability)
+        root.enterDynamicMenu(extension, true)
+      if (backgroundActionProc.closeAfter) root.cancel()
     }
   }
 
@@ -2829,11 +3434,15 @@ Item {
       Item {
         id: keyCatcher
         anchors.fill: parent
-        z: (root.deleteConfirmOpen || root.dependencyConfirmOpen) ? 20 : 0
+        z: (root.workflowConfirmOpen || root.deleteConfirmOpen || root.dependencyConfirmOpen) ? 20 : 0
         focus: true
 
         Keys.priority: Keys.BeforeItem
         Keys.onPressed: function(event) {
+          if (root.workflowConfirmOpen) {
+            if (workflowConfirm.handleKey(event)) event.accepted = true
+            return
+          }
           if (root.deleteConfirmOpen) {
             if (deleteConfirm.handleKey(event)) event.accepted = true
             return
@@ -2843,11 +3452,28 @@ Item {
             return
           }
 
-          if (root.fileBrowserActive && !root.directoryPickerActive && !root.actionPanelActive && event.key === Qt.Key_K && (event.modifiers & Qt.ControlModifier)) {
+          if (root.workflowInputActive
+              && ((event.key === Qt.Key_V && (event.modifiers & Qt.ControlModifier))
+                || (event.key === Qt.Key_Insert && (event.modifiers & Qt.ShiftModifier)))) {
+            if (!pasteProc.running) pasteProc.running = true
+            event.accepted = true
+          } else if (!root.workflowActive && root.selectedDynamicSearchEntry && event.key === Qt.Key_K && (event.modifiers & Qt.ControlModifier)) {
+            root.openDynamicSearchActions()
+            event.accepted = true
+          } else if (root.workflowActive && !root.fileBrowserActive && event.key === Qt.Key_K && (event.modifiers & Qt.ControlModifier)) {
+            root.openWorkflowActions()
+            event.accepted = true
+          } else if (root.fileBrowserActive && !root.directoryPickerActive && !root.actionPanelActive && event.key === Qt.Key_K && (event.modifiers & Qt.ControlModifier)) {
             root.openActionPanel()
             event.accepted = true
           } else if (root.fileBrowserActive && !root.directoryPickerActive && !root.actionPanelActive && event.key === Qt.Key_C && (event.modifiers & Qt.ControlModifier)) {
             root.copySelectedFilePath()
+            event.accepted = true
+          } else if (root.workflowActive && root.selectedWorkflowStarAction && event.key === Qt.Key_S && (event.modifiers & Qt.ControlModifier)) {
+            root.toggleSelectedWorkflowStar()
+            event.accepted = true
+          } else if (!root.workflowActive && root.selectedDynamicStarAction && event.key === Qt.Key_S && (event.modifiers & Qt.ControlModifier)) {
+            root.toggleSelectedDynamicStar()
             event.accepted = true
           } else if (!root.dmenuActive && !root.workflowActive && event.key === Qt.Key_S && (event.modifiers & Qt.ControlModifier)) {
             root.toggleSelectedStar()
@@ -2916,6 +3542,30 @@ Item {
         }
 
         ConfirmDialog {
+          id: workflowConfirm
+          anchors.fill: parent
+          opened: root.workflowConfirmOpen
+          z: 10
+          message: root.workflowConfirmNode ? (root.workflowConfirmNode.confirm || "Do you want to run " + root.workflowConfirmNode.label + "?") : ""
+          confirmText: root.workflowConfirmNode ? root.workflowConfirmNode.confirmLabel : "Run"
+          background: root.dialogBackground
+          foreground: root.foreground
+          scrim: root.scrim
+          selectedBackground: root.selectedBackground
+          selectedText: root.selectedText
+          fontFamily: root.fontFamily
+          cornerRadius: root.cornerRadius
+          onOpenedChanged: if (opened) { selectedIndex = 1; keyCatcher.forceActiveFocus() }
+          onCanceled: { root.workflowConfirmOpen = false; root.workflowConfirmNode = null }
+          onConfirmed: {
+            var node = root.workflowConfirmNode
+            root.workflowConfirmOpen = false
+            root.workflowConfirmNode = null
+            root.dispatchWorkflowNode(node, "")
+          }
+        }
+
+        ConfirmDialog {
           id: deleteConfirm
 
           anchors.fill: parent
@@ -2923,13 +3573,14 @@ Item {
           z: 10
           message: "Do you want to uninstall " + ((root.deleteTarget && root.deleteTarget.label) || "") + "?"
           confirmText: "Uninstall"
-          background: root.background
+          background: root.dialogBackground
           foreground: root.foreground
           scrim: root.scrim
           selectedBackground: root.selectedBackground
           selectedText: root.selectedText
           fontFamily: root.fontFamily
           cornerRadius: root.cornerRadius
+          onOpenedChanged: if (opened) { selectedIndex = 1; keyCatcher.forceActiveFocus() }
           onCanceled: root.cancelDelete()
           onConfirmed: root.confirmDelete()
         }
@@ -2947,13 +3598,14 @@ Item {
             : ""
           cancelText: "Not now"
           confirmText: "Install"
-          background: root.background
+          background: root.dialogBackground
           foreground: root.foreground
           scrim: root.scrim
           selectedBackground: root.selectedBackground
           selectedText: root.selectedText
           fontFamily: root.fontFamily
           cornerRadius: root.cornerRadius
+          onOpenedChanged: if (opened) { selectedIndex = 1; keyCatcher.forceActiveFocus() }
           onCanceled: root.cancelDependencyInstall()
           onConfirmed: root.confirmDependencyInstall()
         }
@@ -2983,9 +3635,7 @@ Item {
               : root.fileBrowserActive
                 ? (root.fileBrowserPath + (root.filterText ? "  ›  " + root.filterText : ""))
               : root.workflowActive
-                ? (root.workflowInputActive
-                  ? ((root.workflowNode.prompt || root.workflowNode.label) + "…" + (root.filterText ? "  " + root.filterText : ""))
-                  : (root.workflowText(root.workflowNode ? root.workflowNode.label : root.workflowExtension.label) + "…"))
+                ? root.filterText
               : (root.filterText || (root.dmenuActive ? (root.dmenuPrompt + "…") : ((root.item(root.activeMenu) ? (root.item(root.activeMenu).title || root.item(root.activeMenu).label) : "Go") + "…")))
             color: root.foreground
             opacity: root.filterText ? 1 : 0.58
@@ -3007,6 +3657,21 @@ Item {
             elide: Text.ElideRight
           }
 
+        }
+
+        Text {
+          width: parent.width
+          height: root.workflowHintHeight
+          visible: root.workflowInputActive || root.workflowFilterMenuActive
+          text: root.workflowInputActive
+            ? root.workflowText(root.workflowNode ? (root.workflowNode.prompt || root.workflowNode.label) : "")
+            : ("Search " + root.workflowText(root.workflowNode ? root.workflowNode.label : (root.workflowExtension ? root.workflowExtension.label : "items")))
+          color: root.foreground
+          opacity: 0.58
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.body
+          elide: Text.ElideRight
+          verticalAlignment: Text.AlignVCenter
         }
 
         Item {

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -314,7 +314,9 @@ function nameSearchText(entry) {
   var aliases = []
   var values = Array.isArray(entry.aliases) ? entry.aliases : []
   for (var i = 0; i < values.length; i++) aliases.push(searchableToken(values[i]))
-  return [entry.label, searchableToken(leafIdFor(entry.id)), aliases.join(" ")].join(" ").toLowerCase()
+  var identity = String(entry.id || "").indexOf("extension.menu:") === 0
+    ? "" : searchableToken(leafIdFor(entry.id))
+  return [entry.label, identity, aliases.join(" ")].join(" ").toLowerCase()
 }
 
 function wordSet(text) {
@@ -496,6 +498,7 @@ function safeExtensionPattern(pattern) {
 var MAX_WORKFLOW_NODES = 256
 var MAX_WORKFLOW_DEPTH = 8
 var MAX_WORKFLOW_TEXT = 4096
+var MAX_DYNAMIC_MENU_ROWS = 100
 var MAX_SAFE_JSON_INTEGER = 9007199254740991
 
 function finiteExtensionNumber(value, fallback) {
@@ -562,37 +565,61 @@ function normalizeWorkflowChildren(rawItems, state, depth) {
   return items
 }
 
+function normalizeWorkflowAliases(value) {
+  var values = value === undefined ? [] : (typeof value === "string" ? [value] : value)
+  if (!Array.isArray(values) || values.length > 16) return null
+  var result = []
+  for (var i = 0; i < values.length; i++) {
+    if (typeof values[i] !== "string") return null
+    var alias = boundedWorkflowText(values[i], 256).trim()
+    if (!alias && values[i]) return null
+    if (alias && result.indexOf(alias) < 0) result.push(alias)
+  }
+  return result
+}
+
 function normalizeWorkflowNode(raw, state, depth) {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)
       || depth >= MAX_WORKFLOW_DEPTH || state.count >= MAX_WORKFLOW_NODES) return null
   var kind = String(raw.kind || "menu")
-  if (["menu", "directoryPicker", "input"].indexOf(kind) < 0) return null
+  if (["menu", "directoryPicker", "input", "action", "confirm"].indexOf(kind) < 0) return null
   var id = boundedWorkflowText(raw.id, 128).trim()
   var label = boundedWorkflowText(raw.label, 256).trim()
   if (!id || !label) return null
+  var aliases = normalizeWorkflowAliases(raw.aliases)
+  if (!aliases) return null
   state.count += 1
   var node = {
     id: id,
     kind: kind,
     label: label,
     description: boundedWorkflowText(raw.description, 512),
+    aliases: aliases,
+    starred: raw.starred === true,
     icon: boundedWorkflowText(raw.icon, 32),
     iconFont: boundedWorkflowText(raw.iconFont, 128),
     context: workflowContext(raw.context),
     items: [],
     next: null,
     prompt: boundedWorkflowText(raw.prompt, 256),
+    capture: /^[A-Za-z][A-Za-z0-9_]*$/.test(String(raw.capture || "")) ? String(raw.capture) : "",
     defaultValue: "",
     allowEmpty: raw.allowEmpty === true,
     maxLength: MAX_WORKFLOW_TEXT,
     command: stringArray(raw.command),
     emptyCommand: stringArray(raw.emptyCommand),
     refreshExtensions: raw.refreshExtensions === true,
-    nextBackSteps: 0
+    closeOnSuccess: raw.closeOnSuccess === true,
+    nextBackSteps: 0,
+    confirm: boundedWorkflowText(raw.confirm, 512),
+    confirmLabel: boundedWorkflowText(raw.confirmLabel, 64) || "Run",
+    starAction: boundedWorkflowText(raw.starAction, 128),
+    actions: []
   }
   var maxLength = finiteExtensionNumber(raw.maxLength, MAX_WORKFLOW_TEXT)
   var nextBackSteps = finiteExtensionNumber(raw.nextBackSteps, 0)
-  if (maxLength === null || nextBackSteps === null) return null
+  if (maxLength === null || nextBackSteps === null || (raw.capture !== undefined && !node.capture)
+      || (raw.starred !== undefined && typeof raw.starred !== "boolean")) return null
   node.maxLength = Math.max(1, Math.min(MAX_WORKFLOW_TEXT, maxLength))
   node.nextBackSteps = Math.max(0, Math.min(MAX_WORKFLOW_DEPTH, nextBackSteps))
   node.defaultValue = boundedWorkflowText(raw.default, MAX_WORKFLOW_TEXT).substring(0, node.maxLength)
@@ -611,6 +638,25 @@ function normalizeWorkflowNode(raw, state, depth) {
   }
   if (kind === "directoryPicker" && !node.next) return null
   if (kind === "input" && node.command.length === 0 && !node.next) return null
+  if ((kind === "action" || kind === "confirm") && node.command.length === 0) return null
+  if (Array.isArray(raw.actions) && kind !== "menu") {
+    if (raw.actions.length > 16) return null
+    node.actions = normalizeWorkflowChildren(raw.actions.map(function(action) {
+      var copy = Object.assign({}, action)
+      copy.kind = copy.confirm ? "confirm" : (copy.input ? "input" : "action")
+      if (copy.input) copy = Object.assign({}, copy, copy.input, { kind: "input", command: copy.input.command || copy.command })
+      delete copy.actions
+      return copy
+    }), state, depth + 1)
+    if (!node.actions) return null
+  }
+  if (raw.starAction !== undefined) {
+    if (!node.starAction) return null
+    var hasStarAction = false
+    for (var starIndex = 0; starIndex < node.actions.length; starIndex++)
+      if (node.actions[starIndex].id === node.starAction && node.actions[starIndex].kind === "action") { hasStarAction = true; break }
+    if (!hasStarAction) return null
+  }
   return node
 }
 
@@ -637,7 +683,7 @@ function workflowInitialInput(node, context) {
 }
 
 function workflowCommand(node, input, context) {
-  if (!node || node.kind !== "input") return []
+  if (!node || ["input", "action", "confirm"].indexOf(node.kind) < 0) return []
   var value = String(input === undefined || input === null ? "" : input).substring(0, node.maxLength)
   var source = value ? node.command : (node.emptyCommand.length > 0 ? node.emptyCommand : node.command)
   var replacements = Object.assign({}, context || ({}), { input: value })
@@ -661,7 +707,9 @@ function workflowDirectoryTransition(node, path, context) {
 function workflowInputTransition(node, input, context) {
   var value = node ? String(input || "").substring(0, node.maxLength) : ""
   if (!node || node.kind !== "input" || (!value && !node.allowEmpty)) return null
-  return { node: node.next, context: Object.assign({}, context || ({}), { input: value }) }
+  var nextContext = Object.assign({}, context || ({}), { input: value })
+  if (node.capture) nextContext[node.capture] = value
+  return { node: node.next, context: nextContext }
 }
 
 function workflowChild(node, id) {
@@ -723,7 +771,21 @@ function rebindWorkflow(extension, stack, current) {
 
 function workflowActionIsCurrent(actionGeneration, generation, workflowActive, expectedCapability, extension) {
   return actionGeneration > 0 && actionGeneration === generation && workflowActive === true
-    && !!extension && extension.available === true && extension.mode === "workflow"
+    && !!extension && extension.available === true && ["workflow", "menu"].indexOf(extension.mode) >= 0
+    && extension.capability === expectedCapability
+}
+
+// Only a complete, non-interactive leaf can use the independent background
+// runner. Input and confirmation nodes must keep the staged foreground path.
+function workflowBackgroundEligible(node, command) {
+  return !!node && node.kind === "action" && !node.next
+    && Array.isArray(command) && command.length > 0
+    && !workflowClosesOnDispatch(node, command)
+}
+
+function backgroundActionIsCurrent(actionGeneration, generation, expectedCapability, extension) {
+  return actionGeneration > 0 && actionGeneration === generation
+    && !!extension && extension.available === true && extension.mode === "menu"
     && extension.capability === expectedCapability
 }
 
@@ -777,6 +839,7 @@ function extensionRootActivation(extension) {
   if (!extension || !extension.available) return ""
   if (extension.mode === "files") return "files"
   if (extension.mode === "workflow") return "workflow"
+  if (extension.mode === "menu") return "menu"
   return "input"
 }
 
@@ -801,9 +864,57 @@ function focusedPrefixMatch(extension, input) {
 }
 
 function workflowClosesOnDispatch(node, command) {
-  if (!node || node.kind !== "input" || node.next || !Array.isArray(command) || command.length === 0) return false
+  if (!node || ["input", "action", "confirm"].indexOf(node.kind) < 0 || node.next || !Array.isArray(command) || command.length === 0) return false
   var executable = String(command[0] || "").split("/").pop()
   return executable === "xdg-terminal-exec" || executable === "omarchy-launch-terminal"
+}
+
+function dynamicMenuSearchItems(extension, workflow) {
+  if (!extension || !workflow || !Array.isArray(workflow.items)) return []
+  var result = []
+  for (var i = 0; i < workflow.items.length; i++) {
+    var node = workflow.items[i]
+    if (!node || ["action", "confirm", "input"].indexOf(node.kind) < 0) continue
+    result.push(normalizeItem("extension.menu:" + JSON.stringify([extension.capability, node.id]), {
+      parent: "extensions",
+      icon: node.icon || extension.icon,
+      iconFont: node.iconFont || extension.iconFont,
+      label: node.label,
+      description: node.description,
+      aliases: node.aliases,
+      starred: node.starred,
+      action: node.id
+    }))
+  }
+  return result
+}
+
+function dynamicMenuSearchIdentity(itemId) {
+  var prefix = "extension.menu:"
+  var value = String(itemId || "")
+  if (value.indexOf(prefix) !== 0) return null
+  try {
+    var parsed = JSON.parse(value.substring(prefix.length))
+    return Array.isArray(parsed) && parsed.length === 2 && typeof parsed[0] === "string" && typeof parsed[1] === "string"
+      ? { capability: parsed[0], id: parsed[1] } : null
+  } catch (e) { return null }
+}
+
+function normalizeDynamicMenuOutput(raw) {
+  var parsed
+  try { parsed = typeof raw === "string" ? JSON.parse(raw) : raw } catch (e) { return null }
+  var rows = Array.isArray(parsed) ? parsed : (parsed && Array.isArray(parsed.items) ? parsed.items : null)
+  if (!rows || rows.length > MAX_DYNAMIC_MENU_ROWS) return null
+  var prepared = []
+  for (var i = 0; i < rows.length; i++) {
+    var row = rows[i]
+    if (!row || typeof row !== "object" || Array.isArray(row)) return null
+    var copy = Object.assign({}, row)
+    copy.kind = copy.confirm ? "confirm" : (copy.input ? "input" : "action")
+    if (copy.input) copy = Object.assign({}, copy, copy.input, { kind: "input", command: copy.input.command || copy.command })
+    prepared.push(copy)
+  }
+  return normalizeWorkflow({ items: prepared })
 }
 
 function normalizeExtension(raw) {
@@ -813,7 +924,7 @@ function normalizeExtension(raw) {
   var label = String(raw.label || "").trim()
   var mode = String(raw.mode || "prefix")
   var command = stringArray(raw.command)
-  if (!id || !label || ["prefix", "query", "files", "workflow"].indexOf(mode) < 0) return null
+  if (!id || !label || ["prefix", "query", "files", "workflow", "menu"].indexOf(mode) < 0) return null
   if (mode !== "workflow" && command.length === 0) return null
 
   var priority = finiteExtensionNumber(raw.priority, 0)
@@ -833,11 +944,12 @@ function normalizeExtension(raw) {
     bundled: raw._bundled === true,
     sourceDir: String(raw._sourceDir || ""),
     source: String(raw._source || ""),
+    globalSearch: mode === "menu" && raw.globalSearch === true,
     requires: stringArray(raw.requires),
     missingRequires: stringArray(raw._missingRequires)
   }
 
-  if (mode === "prefix" || mode === "files" || mode === "workflow") {
+  if (mode === "prefix" || mode === "files" || mode === "workflow" || mode === "menu") {
     var sourcePrefixes = Array.isArray(raw.prefixes) ? raw.prefixes : [raw.prefix]
     extension.prefixes = []
     for (var i = 0; i < sourcePrefixes.length; i++) {
@@ -848,6 +960,10 @@ function normalizeExtension(raw) {
     if (mode === "workflow") {
       extension.workflow = normalizeWorkflow(raw.workflow)
       if (!extension.workflow) return null
+    } else if (mode === "menu") {
+      if (command.length > 32) return null
+      for (var menuArg = 0; menuArg < command.length; menuArg++)
+        if (!boundedWorkflowText(command[menuArg])) return null
     } else if (mode === "files") {
       extension.root = String(raw.root || "~")
       extension.directoryCommand = stringArray(raw.directoryCommand)
@@ -1494,8 +1610,10 @@ function actionBarHints(state) {
     hints.push({ label: primary, shortcut: "Enter" })
   }
 
-  if (value.fileBrowserActive && value.hasSelection && !value.directoryPickerActive && !value.actionPanelActive) {
+  if (value.canContextActions)
     hints.push({ label: "Actions", shortcut: "Ctrl K" })
+  if (value.fileBrowserActive && value.hasSelection && !value.directoryPickerActive && !value.actionPanelActive) {
+    if (!value.canContextActions) hints.push({ label: "Actions", shortcut: "Ctrl K" })
     hints.push({ label: "Copy Path", shortcut: "Ctrl C" })
   }
   if (value.canStar) hints.push({ label: value.starred ? "Unstar" : "Star", shortcut: "Ctrl S" })
@@ -1555,6 +1673,9 @@ if (typeof module !== "undefined") {
     safeExtensionPattern: safeExtensionPattern,
     openStateReset: openStateReset,
     normalizeWorkflow: normalizeWorkflow,
+    normalizeDynamicMenuOutput: normalizeDynamicMenuOutput,
+    dynamicMenuSearchItems: dynamicMenuSearchItems,
+    dynamicMenuSearchIdentity: dynamicMenuSearchIdentity,
     workflowInterpolate: workflowInterpolate,
     workflowInitialInput: workflowInitialInput,
     workflowCommand: workflowCommand,
@@ -1562,6 +1683,8 @@ if (typeof module !== "undefined") {
     workflowInputTransition: workflowInputTransition,
     rebindWorkflow: rebindWorkflow,
     workflowActionIsCurrent: workflowActionIsCurrent,
+    workflowBackgroundEligible: workflowBackgroundEligible,
+    backgroundActionIsCurrent: backgroundActionIsCurrent,
     workflowClosesOnDispatch: workflowClosesOnDispatch,
     extensionRootId: extensionRootId,
     extensionRootCapability: extensionRootCapability,

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -262,6 +262,49 @@ const workflowExtensions = menu.parseExtensions(JSON.stringify([{
     }]
   }
 }]))
+const dynamicMenuExtensions = menu.parseExtensions(JSON.stringify([{
+  schemaVersion: 1, id: 'quicklinks', capability: 'quicklinks', mode: 'menu', label: 'Quicklinks',
+  prefixes: ['links'], command: ['{extensionDir}/bin/menu', '--json'], globalSearch: true
+}, {
+  schemaVersion: 1, id: 'private-menu', mode: 'menu', label: 'Private', prefixes: ['private'], command: ['private-menu']
+}]))
+assert(dynamicMenuExtensions.length === 2 && dynamicMenuExtensions[0].command[0] === '{extensionDir}/bin/menu', 'dynamic menu provider extensions are parsed')
+assert(dynamicMenuExtensions[0].globalSearch && !dynamicMenuExtensions[1].globalSearch, 'dynamic menu global search is explicit opt-in')
+assert(menu.extensionRootActivation(dynamicMenuExtensions[0]) === 'menu', 'dynamic menu roots start their provider')
+const dynamicMenu = menu.normalizeDynamicMenuOutput(JSON.stringify({ items: [
+  { id: 'open', label: 'Open docs', description: 'Documentation', aliases: ['manual', 'reference'], starred: true, starAction: 'star', command: ['xdg-open', 'https://example.test'], closeOnSuccess: true, actions: [
+    { id: 'star', label: 'Unstar', command: ['links', 'star', 'open', 'false'] },
+    { id: 'delete', label: 'Delete', confirm: 'Delete this link?', confirmLabel: 'Delete', command: ['links', 'delete', 'open'], refreshExtensions: true }
+  ] },
+  { id: 'add', label: 'Add Quicklink', input: { prompt: 'URL', maxLength: 200, command: ['links', 'add', '{input}'] } }
+] }))
+assert(dynamicMenu && dynamicMenu.items.length === 2, 'bounded dynamic menu output is normalized')
+assert(dynamicMenu.items[0].kind === 'action' && dynamicMenu.items[0].actions[1].kind === 'confirm', 'rows retain direct actions and contextual confirmations')
+assert(dynamicMenu.items[0].closeOnSuccess, 'launch rows can request launcher closure after successful dispatch')
+assert(dynamicMenu.items[0].starred, 'dynamic rows retain explicit starred state')
+assert(dynamicMenu.items[0].starAction === 'star', 'dynamic rows can identify a direct Ctrl+S star action')
+const dynamicSearchItems = menu.dynamicMenuSearchItems(dynamicMenuExtensions[0], dynamicMenu)
+assert(dynamicSearchItems.length === 2 && dynamicSearchItems[0].aliases.join(',') === 'manual,reference', 'search rows retain bounded provider aliases')
+assert(menu.matchesQuery(dynamicSearchItems[0], menu.prepareSearchQuery('documentation'), true), 'dynamic menu rows search descriptions')
+assert(menu.matchesQuery(dynamicSearchItems[0], menu.prepareSearchQuery('reference'), true), 'dynamic menu rows search aliases')
+assert(!menu.matchesQuery(dynamicSearchItems[0], menu.prepareSearchQuery('quicklinks'), true), 'dynamic routing identities do not leak provider capabilities into search')
+assert(menu.matchesQuery(dynamicSearchItems[1], menu.prepareSearchQuery('quicklink'), true), 'dynamic rows still match provider words in visible labels')
+assert(menu.dynamicMenuSearchIdentity(dynamicSearchItems[0].id).capability === 'quicklinks', 'dynamic search identities retain stable extension capability')
+assert(menu.dynamicMenuSearchIdentity('extension.menu:not-json') === null, 'malformed dynamic search identities are rejected')
+assert(dynamicMenu.items[0].actions[1].refreshExtensions, 'mutation actions can request an extension refresh')
+assert(dynamicMenu.items[1].kind === 'input' && dynamicMenu.items[1].prompt === 'URL', 'rows can open bounded host input forms')
+assert(menu.workflowCommand(dynamicMenu.items[1], 'https://literal.test/?q=$(bad)', {}).slice(-1)[0] === 'https://literal.test/?q=$(bad)', 'dynamic input is substituted as one literal argument')
+const capturedMenu = menu.normalizeDynamicMenuOutput([{ id: 'add', label: 'Add', input: {
+  prompt: 'Target', capture: 'target', next: { id: 'name', kind: 'input', label: 'Name', command: ['links', 'add', '{target}', '{input}'] }
+} }])
+const capturedTransition = menu.workflowInputTransition(capturedMenu.items[0], 'https://example.test', {})
+assert(capturedTransition.context.target === 'https://example.test' && capturedTransition.node.id === 'name', 'input capture passes a named literal value to the next host input without persistent draft state')
+assert(menu.normalizeDynamicMenuOutput([{ id: 'bad-capture', label: 'Bad', input: { prompt: 'Bad', capture: '__proto__', command: ['true'] } }]) === null, 'input capture names reject unsafe structural keys')
+assert(menu.normalizeDynamicMenuOutput('{bad') === null, 'malformed dynamic menu output is rejected')
+assert(menu.normalizeDynamicMenuOutput({ items: Array.from({ length: 101 }, (_, i) => ({ id: String(i), label: String(i), command: ['true'] })) }) === null, 'dynamic menu row counts are bounded')
+assert(menu.normalizeDynamicMenuOutput([{ id: 'bad', label: 'Bad', command: 'true' }]) === null, 'dynamic menu commands must be argument arrays')
+assert(menu.normalizeDynamicMenuOutput([{ id: 'same', label: 'One', command: ['true'] }, { id: 'same', label: 'Two', command: ['true'] }]) === null, 'dynamic menu row ids are unique')
+
 assert(workflowExtensions.length === 1 && workflowExtensions[0].mode === 'workflow', 'workflow extension menus are parsed')
 assert(menu.extensionRootActivation(workflowExtensions[0]) === 'workflow', 'workflow extension roots enter their host-rendered workflow')
 const projectsNode = workflowExtensions[0].workflow.items[0]
@@ -281,6 +324,14 @@ assert(menu.workflowClosesOnDispatch(sessionNode, ['/usr/bin/omarchy-launch-term
 assert(!menu.workflowClosesOnDispatch({ ...sessionNode, next: { id: 'next', kind: 'menu', label: 'Next', items: [] } }, promptedCommand), 'workflow commands with a next stage stay open')
 assert(!menu.workflowClosesOnDispatch(sessionNode, ['helper', 'save']), 'non-terminal workflow commands wait for successful completion')
 assert(!menu.workflowClosesOnDispatch({ ...sessionNode, allowEmpty: false }, []), 'pre-dispatch validation failures do not request closure')
+const backgroundStar = dynamicMenu.items[0].actions[0]
+assert(menu.workflowBackgroundEligible(backgroundStar, menu.workflowCommand(backgroundStar, '', {})), 'non-interactive action leaves are eligible for the background runner')
+assert(!menu.workflowBackgroundEligible(dynamicMenu.items[0].actions[1], menu.workflowCommand(dynamicMenu.items[0].actions[1], '', {})), 'confirmation actions remain on the staged foreground path')
+assert(!menu.workflowBackgroundEligible(dynamicMenu.items[1], menu.workflowCommand(dynamicMenu.items[1], 'value', {})), 'input actions remain on the staged foreground path')
+assert(!menu.workflowBackgroundEligible({ ...backgroundStar, next: { id: 'next' } }, ['true']), 'actions with a next stage remain on the foreground path')
+assert(menu.backgroundActionIsCurrent(3, 3, 'quicklinks', dynamicMenuExtensions[0]), 'current dynamic-provider background actions can publish completion')
+assert(!menu.backgroundActionIsCurrent(2, 3, 'quicklinks', dynamicMenuExtensions[0])
+  && !menu.backgroundActionIsCurrent(3, 3, 'other', dynamicMenuExtensions[0]), 'stale and provider-mismatched background actions cannot publish completion')
 assert(menu.normalizeWorkflow({ items: [{ id: 'bad', kind: 'directoryPicker', label: 'Bad' }] }) === null, 'directory picker stages require a declared next transition')
 assert(menu.normalizeWorkflow({ items: [
   { id: 'duplicate', kind: 'menu', label: 'First', items: [] },

--- a/tests/qml-extension-path-test.js
+++ b/tests/qml-extension-path-test.js
@@ -67,3 +67,70 @@ assert(qml.includes('root.invalidateExtensionQuery("launcher closed")')
 'close/open and catalog/query context changes invalidate live-query generations')
 assert(qml.includes('if (root.directoryPickerActive) root.workflowBack()'),
 'directory picker Backspace at filesystem root returns through workflow history')
+
+const dynamicProviderBody = qml.slice(qml.indexOf('id: dynamicMenuProc'), qml.indexOf('id: workflowActionTimeout'))
+assert(qml.includes('else if (activation === "menu") root.enterDynamicMenu(extension)')
+  && qml.includes('MenuModel.normalizeDynamicMenuOutput(dynamicMenuProc.collected)'),
+'dynamic menu roots run a provider and install only normalized snapshots')
+assert(dynamicProviderBody.includes('root.dynamicMenuOutputBytes')
+  && dynamicProviderBody.includes('dynamicMenuProc.generation !== root.dynamicMenuGeneration')
+  && qml.includes('id: dynamicMenuTimeout'),
+'dynamic menu providers have output, timeout, and stale-generation bounds')
+assert(qml.includes(': root.workflowActive\n                ? root.filterText')
+  && qml.includes('height: root.workflowHintHeight')
+  && qml.includes('visible: root.workflowInputActive || root.workflowFilterMenuActive')
+  && qml.includes('root.workflowNode.prompt || root.workflowNode.label')
+  && qml.includes('"Search " + root.workflowText'),
+'workflow inputs and filterable menus keep context helper text below the typed-value field')
+assert(qml.includes('id: pasteProc')
+  && qml.includes('["wl-paste", "--no-newline", "--type", "text"]')
+  && qml.includes('event.key === Qt.Key_V && (event.modifiers & Qt.ControlModifier)')
+  && qml.includes('event.key === Qt.Key_Insert && (event.modifiers & Qt.ShiftModifier)')
+  && qml.includes('root.setFilter((root.filterText + text).substring(0, limit))'),
+'workflow inputs accept bounded Ctrl+V and global clipboard text')
+assert(qml.includes('root.enterDynamicMenu(extension, true)')
+  && qml.includes('if (!retainCurrentRows) root.rebuildDisplay()')
+  && qml.includes('dynamicMenuProc.selectionNodeId = retainCurrentRows')
+  && qml.includes('Number(displayModel.get(selectedDisplayIndex).action) === selectedWorkflowNodeIndex'),
+'dynamic menu mutations retain visible rows and selection until the refreshed provider snapshot is ready')
+assert(qml.includes('root.workflowActive && root.selectedWorkflowStarAction && event.key === Qt.Key_S')
+  && qml.includes('root.dispatchWorkflowNode(action, "", false, true)'),
+'workflow rows with a declared star action support Ctrl+S through the background action lifecycle')
+assert(qml.includes('!root.workflowActive && root.selectedDynamicStarAction && event.key === Qt.Key_S')
+  && qml.includes('root.dispatchBackgroundAction(extension, action, "")')
+  && qml.includes('id: backgroundActionProc')
+  && !qml.slice(qml.indexOf('function toggleSelectedDynamicStar()'), qml.indexOf('function openDynamicSearchActions()')).includes('root.workflowActive = true'),
+'globally searchable dynamic rows use an independent runner without entering visible workflow state')
+assert(qml.includes('workflowRow.starred = workflowChild.starred')
+  && qml.includes('if (!starredDynamicEntry.node.starred) continue')
+  && qml.includes('starredDynamicRow.starred = true'),
+'starred globally searchable dynamic rows appear on the top-level launcher view')
+assert(qml.includes('var extensionsDirectory = root.item("extensions")')
+  && qml.includes('MenuModel.matchesQuery(extensionsDirectory, preparedQuery, true)'),
+'fixed Extensions directory remains explicit in top-level global search during dynamic snapshot rebuilds')
+assert(qml.includes('var workflowQuery = MenuModel.prepareSearchQuery(root.filterText.trim())')
+  && qml.includes('MenuModel.matchesQuery(workflowItem, workflowQuery, true)')
+  && qml.includes('root.workflowNode.items[Number(displayModel.get(root.selectedIndex).action)]'),
+'workflow menus filter provider rows while retaining original activation and action identities')
+assert(qml.includes('function dispatchWorkflowNode(node, input, returnToRoot, backgroundRequested)')
+  && qml.includes('workflowActionProc.refreshDynamicMenu = root.workflowExtension.mode === "menu"')
+  && qml.includes('workflowActionProc.closeAfter = node.closeOnSuccess')
+  && qml.includes('if (workflowActionProc.refreshExtensions) root.loadExtensions(true)'),
+'dynamic row mutations reuse tracked workflow actions and refresh successful state')
+const fileCopyExit = qml.slice(qml.indexOf('id: fileCopyProc'), qml.indexOf('id: pasteProc'))
+assert(fileCopyExit.includes('if (exitCode === 0) {')
+  && fileCopyExit.includes('root.cancel()')
+  && fileCopyExit.includes('root.fileCopyFeedback = "Copy failed"')
+  && fileCopyExit.indexOf('root.cancel()') < fileCopyExit.indexOf('root.fileCopyFeedback = "Copy failed"'),
+'Files copy completion closes only after success and keeps failure feedback in the open launcher')
+assert(qml.includes('function openWorkflowActions()')
+  && qml.includes('root.openWorkflowActions()')
+  && qml.includes('id: workflowConfirm'),
+'dynamic rows expose host-rendered contextual actions and confirmations')
+assert(qml.includes('readonly property color dialogBackground: Qt.rgba(background.r, background.g, background.b, 1)')
+  && (qml.match(/background: root\.dialogBackground/g) || []).length === 3,
+'confirmation cards use one theme-compatible opaque surface')
+assert(qml.includes('z: (root.workflowConfirmOpen || root.deleteConfirmOpen || root.dependencyConfirmOpen) ? 20 : 0')
+  && (qml.match(/onOpenedChanged: if \(opened\) \{ selectedIndex = 1; keyCatcher\.forceActiveFocus\(\) \}/g) || []).length === 3
+  && qml.includes('workflowConfirm.handleKey(event)'),
+'confirmation dialogs retain focus, reset the safe button, and route keyboard input')

--- a/tests/qml-extension-path-test.js
+++ b/tests/qml-extension-path-test.js
@@ -76,6 +76,18 @@ assert(dynamicProviderBody.includes('root.dynamicMenuOutputBytes')
   && dynamicProviderBody.includes('dynamicMenuProc.generation !== root.dynamicMenuGeneration')
   && qml.includes('id: dynamicMenuTimeout'),
 'dynamic menu providers have output, timeout, and stale-generation bounds')
+assert(qml.includes('id: dynamicMenuKillTimer')
+  && qml.includes('generation !== dynamicMenuProc.stopGeneration')
+  && qml.includes('generation !== dynamicMenuProc.generation')
+  && qml.includes('dynamicMenuProc.signal(9)')
+  && qml.includes('root.invalidateDynamicMenu()'),
+'dynamic menu timeout and output cancellation escalate SIGTERM only for the same provider child')
+assert(qml.includes('id: dynamicMenuSearchKillTimer')
+  && qml.includes('generation !== dynamicMenuSearchProc.stopGeneration')
+  && qml.includes('generation !== dynamicMenuSearchProc.generation')
+  && qml.includes('dynamicMenuSearchProc.signal(9)')
+  && qml.includes('dynamicMenuSearchKillTimer.stop()'),
+'global menu preload cancellation escalates SIGTERM safely and disarms stale escalation on exit')
 assert(qml.includes(': root.workflowActive\n                ? root.filterText')
   && qml.includes('height: root.workflowHintHeight')
   && qml.includes('visible: root.workflowInputActive || root.workflowFilterMenuActive')


### PR DESCRIPTION
## Summary

- Add host-rendered dynamic menus with direct and contextual actions.
- Add staged inputs, confirmations, filtering, global search, and starred rows.
- Add background actions with bounded process lifecycle and stale-generation protection.
- Fix generic confirmation-dialog rendering and keyboard behavior.
- Close Files copy actions only after successful completion.
- Document and test the actionable extension contract.

## Tests

- `node tests/menu-model-test.js`
- `node tests/qml-extension-path-test.js`
- `python tests/extension-loader-test.py`
- `python tests/file-index-integration-test.py`
- `bash tests/manifest-test.sh`
- `bash tests/qalc-integration-test.sh`
- `bash tests/timezone-integration-test.sh`
- `bash tests/live-query-process-integration-test.sh`
- Python compilation
- `git diff --check`

## Stack

This is PR 1 of 3. PR 2 targets this branch.
