### PR TITLE
Add provider-owned configuration and state storage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,17 @@ jobs:
       - name: Run extension loader tests
         run: python tests/extension-loader-test.py
 
+      - name: Validate provider storage schemas
+        run: python tests/provider-config-schema-test.py
+
+      - name: Run provider storage runtime tests
+        run: python tests/provider-config-runtime-test.py
+
+      - name: Run provider storage migration tests
+        run: python tests/provider-config-migration-test.py
+
       - name: Compile Python helpers
-        run: python -m py_compile libexec/load-extensions.py extensions/files/file-index.py extensions/timezone/convert-timezone.py
+        run: python -m py_compile libexec/load-extensions.py libexec/provider_config.py libexec/migrate-provider-config.py extensions/files/file-index.py extensions/timezone/convert-timezone.py
 
       - name: Run qalc integration tests
         run: bash tests/qalc-integration-test.sh

--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -11,7 +11,7 @@ Both use the same extension format. An external extension with the same `capabil
 
 Omalaunch gives every resolved bundled and external extension one shortcut in the fixed top-level **Extensions** directory. The directory is always present and cannot be starred. Its shortcuts are ordered with starred extensions first and then alphabetically.
 
-Extension shortcuts do not otherwise appear on the launcher's starting view. Press Ctrl+S on a shortcut to promote it there; the same shortcut remains in **Extensions**, and Ctrl+S removes it from both views. Favorites use the extension's stable `capability`, so replacing a bundled provider with an external provider preserves the shortcut and its starred state. Extension roots are also included in global search whether or not they are starred.
+Extension shortcuts do not otherwise appear on the launcher's starting view. Press Ctrl+S on a shortcut to promote it there; the same shortcut remains in **Extensions**, and Ctrl+S removes it from both views. Favorites use the extension provider's stable `id`, so a replacement does not inherit the shortcut or its starred state. Extension roots are also included in global search whether or not they are starred.
 
 Activating a shortcut enters the interface appropriate to its mode:
 
@@ -133,7 +133,7 @@ File browser extensions provide navigation, recursive search, opening, and path 
 }
 ```
 
-Ctrl+K opens the contextual Action Panel. `command` opens files, `directoryCommand` opens directories in the file manager, `terminalCommand` opens a terminal, `copyCommand` copies the path, and `copyFileCommand` places a file URI on the clipboard. All command fields support `{path}`. Files and directories can be starred from the Action Panel or with Ctrl+S and then opened directly from the launcher’s starting view. Each star retains the extension capability that created it, so the currently selected provider for that capability handles it. The bundled implementation starts at the home directory, uses `fd` traversal and fzf path ranking, omits hidden and ignored paths, and limits each ranked result set to 100 entries. Exact basename matches rank before paths that match only through a parent directory, so many descendants cannot hide a matching file or directory. Recursive candidates are indexed once per active directory and reused while typing; the index refreshes after 30 seconds or when navigation changes directories.
+Ctrl+K opens the contextual Action Panel. `command` opens files, `directoryCommand` opens directories in the file manager, `terminalCommand` opens a terminal, `copyCommand` copies the path, and `copyFileCommand` places a file URI on the clipboard. All command fields support `{path}`. Files and directories can be starred from the Action Panel or with Ctrl+S and then opened directly from the launcher’s starting view. Each star belongs to the exact provider that created it, so a replacement does not inherit bundled Files favorites. The bundled implementation starts at the home directory, uses `fd` traversal and fzf path ranking, omits hidden and ignored paths, and limits each ranked result set to 100 entries. Exact basename matches rank before paths that match only through a parent directory, so many descendants cannot hide a matching file or directory. Recursive candidates are indexed once per active directory and reused while typing; the index refreshes after 30 seconds or when navigation changes directories.
 
 ## Workflow extension
 
@@ -328,14 +328,6 @@ Select a provider by extension `id` in `config.jsonc`. The key is the capability
 }
 ```
 
-Host-supported capability settings are independent of the selected provider and use one file per capability. Omalaunch does not load arbitrary configuration files for external capabilities. The first supported file is `~/.config/omarchy/omalaunch/extensions/files.jsonc`:
+Provider settings are separate from capability selection. User-edited JSONC is under `~/.config/omarchy/omalaunch/extensions/`; machine-managed JSON state is under `${XDG_STATE_HOME:-~/.local/state}/omarchy/omalaunch/extensions/`. Both use the exact provider ID as the filename. A replacement provider never inherits, merges, or shares either namespace. UI mutations write only state and never rewrite JSONC comments or formatting.
 
-```jsonc
-{
-  "version": 1,
-  // Include paths ignored by Git, but continue to honor other fd ignore rules.
-  "includeGitIgnored": true,
-}
-```
-
-`includeGitIgnored` defaults to `false`. When true, both directory browsing and the recursive Files index use `fd --no-ignore-vcs`.
+The exact version-1 structures, defaults, limits, identities, path rules, and separate configuration and state schemas are in [PROVIDER-CONFIGURATION.md](PROVIDER-CONFIGURATION.md). Apps and Extensions have no user configuration file. Files has only `includeGitIgnored` in configuration.

--- a/LauncherFavorites.qml
+++ b/LauncherFavorites.qml
@@ -4,82 +4,83 @@ import Quickshell.Io
 
 Item {
   id: root
-
-  readonly property string stateDir: Quickshell.env("HOME") + "/.local/state/omarchy"
-  readonly property string statePath: stateDir + "/starred-launcher-items.json"
+  property string helperPath: ""
+  property var extensions: []
+  property var providerConfig: ({})
+  property bool migrationComplete: false
   property var starredIds: ({})
-  property bool directoryReady: false
+  property var legacyIds: ({})
   property bool loaded: false
-
   signal changed()
 
-  function load(rawText) {
-    var next = ({})
-    try {
-      var parsed = JSON.parse(String(rawText || "{}"))
-      var ids = parsed && parsed.version === 1 && Array.isArray(parsed.ids) ? parsed.ids : []
-      for (var i = 0; i < ids.length; i++) {
-        var id = String(ids[i] || "")
-        if (id) next[id] = true
-      }
-    } catch (e) {
-      next = ({})
+  readonly property string stateHome: Quickshell.env("XDG_STATE_HOME") || (Quickshell.env("HOME") + "/.local/state")
+  readonly property string legacyPath: root.stateHome + "/omarchy/starred-launcher-items.json"
+
+  function extensionByCapability(capability) {
+    for (var i=0;i<root.extensions.length;i++) if (root.extensions[i].capability===capability) return root.extensions[i]
+    return null
+  }
+  function rebuild() {
+    var next=({}), apps=root.providerConfig["omalaunch.apps"] || {favorites:[]}
+    for (var a=0;a<apps.favorites.length;a++) next["apps."+apps.favorites[a]]=true
+    var filesExt=root.extensionByCapability("files"), files=root.providerConfig["omalaunch.files"] || {favorites:[]}
+    if (filesExt && filesExt.id==="omalaunch.files") for (var f=0;f<files.favorites.length;f++) {
+      var x=files.favorites[f]
+      next["file.favorite:"+JSON.stringify(["files",x.type,x.path])]=true
+      next["file.favorite."+x.type+":"+x.path]=true
     }
-    root.starredIds = next
-    root.loaded = true
-    root.changed()
+    var exts=root.providerConfig["omalaunch.extensions"] || {favorites:[]}
+    for (var e=0;e<root.extensions.length;e++) if (exts.favorites.indexOf(root.extensions[e].id)>=0)
+      next["extension.root:"+JSON.stringify(root.extensions[e].capability)]=true
+    if (!root.migrationComplete) for (var id in root.legacyIds) next[id]=true
+    root.starredIds=next; root.loaded=true; root.changed()
   }
-
-  function isStarred(itemId) {
-    return root.starredIds[String(itemId || "")] === true
+  function configure(configs, complete) { root.providerConfig=configs || ({}); root.migrationComplete=complete===true; root.rebuild() }
+  function isStarred(itemId) { return root.starredIds[String(itemId||"")]===true }
+  function target(itemId) {
+    var id=String(itemId||"")
+    if (id.indexOf("apps.")===0 && id.length>5) return ["omalaunch.apps",id.slice(5)]
+    if (id.indexOf("extension.root:")===0) {
+      try { var ext=root.extensionByCapability(JSON.parse(id.slice(15))); return ext ? ["omalaunch.extensions",ext.id] : null } catch(e) { return null }
+    }
+    if (id.indexOf("file.favorite:")===0) {
+      try { var p=JSON.parse(id.slice(14)); if (p.length===3 && p[0]==="files") return ["omalaunch.files",p[1]+":"+p[2]] } catch(e) {}
+    }
+    var match=id.match(/^file\.favorite\.(file|directory):(\/.*)$/)
+    return match ? ["omalaunch.files",match[1]+":"+match[2]] : null
   }
-
-  function save(next) {
-    var ids = Object.keys(next).filter(function(id) { return next[id] === true }).sort()
-    stateFile.setText(JSON.stringify({ version: 1, ids: ids }, null, 2) + "\n")
-  }
-
   function toggle(itemId) {
-    var id = String(itemId || "")
-    if (!root.loaded || !id) return
-    var next = Object.assign({}, root.starredIds)
-    if (next[id] === true) delete next[id]
-    else next[id] = true
-    root.starredIds = next
-    root.save(next)
-    root.changed()
+    if (!root.loaded || mutation.running) return
+    var value=root.target(itemId); if (!value) return
+    mutation.command=[root.helperPath,"toggle",value[0],value[1]]; mutation.running=true
   }
-
-  function removeIds(itemIds) {
-    if (!root.loaded || !Array.isArray(itemIds)) return
-    var next = Object.assign({}, root.starredIds)
-    var changed = false
-    for (var i = 0; i < itemIds.length; i++) {
-      var id = String(itemIds[i] || "")
-      if (!id || next[id] !== true) continue
-      delete next[id]
-      changed = true
-    }
-    if (!changed) return
-    root.starredIds = next
-    root.save(next)
-    root.changed()
+  function removeIds(ids) {
+    if (!Array.isArray(ids)) return
+    for (var i=0;i<ids.length;i++) if (root.isStarred(ids[i])) { root.toggle(ids[i]); return }
   }
-
   Process {
-    id: initDir
-    command: ["install", "-d", "-m", "0700", root.stateDir]
-    onExited: root.directoryReady = true
+    id: mutation
+    onExited: function(code) { if (code===0) reload.running=true; else console.warn("Omalaunch: provider favorite write failed") }
   }
-
+  Process {
+    id: reload
+    property string output:""
+    stdout: SplitParser { onRead:function(data){ reload.output += data } }
+    command: [root.helperPath,"read-all"]
+    onExited:function(code) {
+      if (code!==0) return
+      try { var value=JSON.parse(reload.output); root.providerConfig=value.configs; root.rebuild() } catch(e) {}
+      reload.output=""
+    }
+  }
   FileView {
-    id: stateFile
-    path: root.directoryReady ? root.statePath : ""
-    atomicWrites: true
-    printErrors: false
-    onLoaded: root.load(text())
-    onLoadFailed: if (root.directoryReady) root.load("{}")
+    id: legacyFile
+    path: root.migrationComplete ? "" : root.legacyPath
+    printErrors:false
+    onLoaded: {
+      var next=({}); try { var data=JSON.parse(text()); if(data.version===1&&Array.isArray(data.ids)) for(var i=0;i<data.ids.length;i++) next[data.ids[i]]=true } catch(e) {}
+      root.legacyIds=next; root.rebuild()
+    }
+    onLoadFailed: { root.legacyIds=({}); root.rebuild() }
   }
-
-  Component.onCompleted: initDir.running = true
 }

--- a/Menu.qml
+++ b/Menu.qml
@@ -221,7 +221,11 @@ Item {
   // Bound to the central [menu] section in shell.toml via Color.qml.
   // Each color already includes its alpha companion (composed in the
   // singleton), so consumers can drop them straight into a Rectangle.
-  LauncherFavorites { id: favorites }
+  LauncherFavorites {
+    id: favorites
+    helperPath: root.pluginPath + "/libexec/provider-config"
+    extensions: root.extensions
+  }
   LauncherUsage { id: usage }
   CurrencyExtension.CurrencyRates { id: currencyRates }
 
@@ -2774,6 +2778,7 @@ Item {
         var oldWorkflowNode = root.workflowNode
         var oldWorkflowStack = root.workflowStack
         root.extensions = catalog.extensions
+        favorites.configure(catalog.providerConfig, catalog.migrationComplete)
         root.preloadDynamicMenuSearch()
 
         if (focusedCapability) {

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -1089,8 +1089,8 @@ function parseExtensionCatalog(text) {
 
   var providerPreferences = parsed && typeof parsed.providerPreferences === "object" && !Array.isArray(parsed.providerPreferences)
     ? parsed.providerPreferences : ({})
-  var capabilityConfig = parsed && typeof parsed.capabilityConfig === "object" && !Array.isArray(parsed.capabilityConfig)
-    ? parsed.capabilityConfig : ({})
+  var providerConfig = parsed && typeof parsed.providerConfig === "object" && !Array.isArray(parsed.providerConfig)
+    ? parsed.providerConfig : ({})
   var extensions = []
   var ids = ({})
   if (values.length > MAX_EXTENSION_CATALOG_VALUES)
@@ -1109,8 +1109,8 @@ function parseExtensionCatalog(text) {
       continue
     }
     ids[idKey] = extensionSource(values[i], i)
-    extension.config = capabilityConfig[extension.capability] && typeof capabilityConfig[extension.capability] === "object"
-      ? capabilityConfig[extension.capability] : ({})
+    extension.config = providerConfig[extension.id] && typeof providerConfig[extension.id] === "object"
+      ? providerConfig[extension.id] : ({})
     extensions.push(extension)
     if (!extension.available)
       appendExtensionDiagnostic(diagnostics, extension.id + " is missing: " + extension.missingRequires.join(", "), diagnosticState)
@@ -1129,7 +1129,8 @@ function parseExtensionCatalog(text) {
       else prefixes[prefixKey] = current.id + " (" + (current.source || "unknown source") + ")"
     }
   }
-  return { extensions: resolved, diagnostics: diagnostics, valid: true, complete: complete }
+  return { extensions: resolved, diagnostics: diagnostics, valid: true, complete: complete,
+    providerConfig: providerConfig, migrationComplete: parsed && parsed.migrationComplete === true }
 }
 
 function parseExtensions(text) {

--- a/PROVIDER-CONFIGURATION.md
+++ b/PROVIDER-CONFIGURATION.md
@@ -1,0 +1,79 @@
+# Bundled provider storage
+
+This document defines the version-1 storage contract for `omalaunch.apps`, `omalaunch.files`, and `omalaunch.extensions`.
+
+## Ownership and locations
+
+Each provider ID owns two independent namespaces:
+
+- User configuration: `~/.config/omarchy/omalaunch/extensions/<provider-id>.jsonc`
+- Machine-managed state: `${XDG_STATE_HOME:-~/.local/state}/omarchy/omalaunch/extensions/<provider-id>.json`
+
+Provider selection does not copy or merge these files. A replacement has a different provider ID and never inherits either file. Selecting the original provider restores its data.
+
+Configuration is read-only at runtime. It accepts UTF-8 JSONC comments and trailing commas. UI actions never create, normalize, or rewrite it. State is strict UTF-8 JSON and is normalized after a successful mutation. State writes use a lock for that provider ID, a private temporary file, `fsync`, and atomic replacement. Thus, concurrent mutations do not lose updates.
+
+Both file types have a 64 KiB limit and a maximum depth of eight. The root is an object, `version` is `1`, and unknown fields are errors. An invalid file is ignored with a bounded diagnostic and is not overwritten. A missing file supplies defaults. Files for providers with no setting are not created.
+
+The schemas in [`schemas/provider-config`](schemas/provider-config) describe user configuration. The schemas in [`schemas/provider-state`](schemas/provider-state) describe state. JSON Schema applies after JSONC parsing and does not specify byte or depth limits.
+
+Identities are case-sensitive and are not trimmed or Unicode-normalized. IDs cannot contain control characters or `/`. Duplicate identities invalidate the complete file. Arrays preserve their order.
+
+## Apps
+
+Apps has no version-1 user configuration file. Interactive favorites are in `omalaunch.apps.json`:
+
+```json
+{"version": 1, "favorites": ["org.gnome.Nautilus.desktop"]}
+```
+
+`favorites` defaults to `[]`, has at most 256 unique desktop-entry IDs, and keeps missing applications for a later return.
+
+## Files
+
+The optional `omalaunch.files.jsonc` configuration contains only the user setting:
+
+```jsonc
+{
+  "version": 1,
+  // Also search paths ignored by Git.
+  "includeGitIgnored": true,
+}
+```
+
+`includeGitIgnored` defaults to `false`. Omalaunch does not create this file when the default is used.
+
+Typed favorites are in state:
+
+```json
+{
+  "version": 1,
+  "favorites": [
+    {"type": "directory", "path": "/home/alice/Documents"},
+    {"type": "file", "path": "/home/alice/notes.txt"}
+  ]
+}
+```
+
+There are at most 256 favorites. `type` is `file` or `directory`. A path is 1 to 4096 characters and starts with `/` or `~/`. Before storage, the provider expands a leading `~/`, removes repeated separators and `.` parts, resolves `..` lexically, and removes a trailing separator except at `/`. It does not access the filesystem or resolve symlinks. Identity is `(type, normalized absolute path)`.
+
+## Extensions
+
+Extensions has no version-1 user configuration file. Exact provider-ID favorites are in `omalaunch.extensions.json`:
+
+```json
+{"version": 1, "favorites": ["omalaunch.files", "example.calculator"]}
+```
+
+The array defaults to `[]` and has at most 256 unique values. A replacement provider is not starred unless its own ID is present.
+
+## Released shared-favorites migration
+
+At startup, Omalaunch reads `${XDG_STATE_HOME:-~/.local/state}/omarchy/starred-launcher-items.json` and writes provider state, not configuration. It keeps the source, uses migration and provider locks, backs up existing targets, writes atomically, verifies writes, and records completion only after success. Repeated runs do not duplicate data.
+
+- `apps.<desktop-id>` becomes an Apps favorite after removal of `apps.`.
+- Bundled `file.favorite` file and directory forms become normalized Files favorites.
+- `extension.root:<capability>` resolves the provider active during migration and stores that provider ID in Extensions state.
+- Non-bundled, dynamic, malformed, missing, and unknown values stay in the shared source and produce bounded diagnostics.
+
+Existing valid state entries win. Migrated entries append in source order. Invalid target state is never overwritten, and the migration retries later.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Calculation results appear first and are copied to the clipboard when activated.
 
 Open the fixed top-level **Extensions** directory to find every active bundled and external extension, including Calculator, Currency conversion, Files, Timezone, and installed workflow integrations such as Codex. Star an extension with Ctrl+S to add the same shortcut to the starting view; it remains in **Extensions**, where starred shortcuts sort first and all others sort alphabetically. The directory itself cannot be starred. Global search finds extension shortcuts whether or not they are starred.
 
-Shortcut activation follows the extension type: Files opens its browser, Timezone prepares its prefix, Calculator and Currency conversion open focused query input, and workflow extensions open their workflow. A replacement provider keeps the same shortcut and favorite because identity is based on stable capability rather than provider id. Missing dependencies are shown on the shortcut without affecting unrelated extensions.
+Shortcut activation follows the extension type: Files opens its browser, Timezone prepares its prefix, Calculator and Currency conversion open focused query input, and workflow extensions open their workflow. A replacement provider supplies the capability shortcut, but it does not inherit the original provider's favorite because stored ownership uses the exact provider ID. Missing dependencies are shown on the shortcut without affecting unrelated extensions.
 
 Omalaunch includes replaceable bundled extensions. Every external Omalaunch extension is simply a standard Omarchy plugin, so it uses the same installation, enable/disable, update, and removal workflow as any other Omarchy plugin.
 
@@ -161,14 +161,7 @@ Omalaunch core settings live in the dedicated `~/.config/omarchy/omalaunch/confi
 }
 ```
 
-Each capability has an independent configuration file. For example, include files ignored by Git in Files browsing and search with `extensions/files.jsonc`:
-
-```jsonc
-{
-  "version": 1,
-  "includeGitIgnored": true,
-}
-```
+Bundled provider settings use provider-ID JSONC files under the configuration directory. Interactive data uses provider-ID JSON state under `${XDG_STATE_HOME:-~/.local/state}`. Replacement providers do not inherit either namespace. See [PROVIDER-CONFIGURATION.md](PROVIDER-CONFIGURATION.md) for the separate version-1 schemas and migration rules.
 
 If a preferred provider is missing or unavailable, Omalaunch reports a diagnostic and uses its normal provider selection rules.
 

--- a/libexec/load-extensions.py
+++ b/libexec/load-extensions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+import importlib.util
 import json
 import math
 import os
@@ -78,7 +79,8 @@ class CatalogBuilder:
         # current and future Omalaunch core settings. Only validated settings
         # are copied from the user-owned config file.
         self.omalaunch_config: dict[str, Any] = {}
-        self.capability_config: dict[str, dict[str, Any]] = {}
+        self.provider_config: dict[str, dict[str, Any]] = {}
+        self.migration_complete = False
         # Reserve room for useful diagnostics. The final envelope still uses
         # the exact public catalog limit and trims diagnostics linearly.
         reserve = min(64 * 1024, max(64, limits.catalog_output_bytes // 4))
@@ -149,7 +151,8 @@ class CatalogBuilder:
                 "complete": complete,
                 "providerPreferences": self.provider_preferences,
                 "omalaunchConfig": self.omalaunch_config,
-                "capabilityConfig": self.capability_config,
+                "providerConfig": self.provider_config,
+                "migrationComplete": self.migration_complete,
             }
             base_size = len(self.encoded(result))
             used = base_size
@@ -476,20 +479,28 @@ def load_user_configuration(home: Path, builder: CatalogBuilder, limits: Limits)
         except (OSError, UnicodeDecodeError, ValueError) as error:
             builder.diagnostic(f"Could not load configuration {main_path}: {error}")
 
-    # Capability configuration is independent of provider identity. Load only
-    # host-supported capability schemas, so files cannot select arbitrary paths.
-    files_path = config_root / "extensions" / "files.jsonc"
-    if files_path.exists():
-        try:
-            value = read_jsonc(files_path, maximum_depth=limits.json_nesting_depth)
-            if not isinstance(value, dict) or value.get("version") != 1:
-                raise ValueError("expected an object with version 1")
-            include = value.get("includeGitIgnored", False)
-            if not isinstance(include, bool):
-                raise ValueError("includeGitIgnored must be a boolean")
-            builder.capability_config["files"] = {"includeGitIgnored": include}
-        except (OSError, UnicodeDecodeError, ValueError) as error:
-            builder.diagnostic(f"Could not load configuration {files_path}: {error}")
+def load_provider_configuration(plugin_path: Path, home: Path, builder: CatalogBuilder) -> None:
+    """Load only the files owned by bundled provider IDs."""
+    specification = importlib.util.spec_from_file_location("omalaunch_provider_config", Path(__file__).parent / "provider_config.py")
+    if specification is None or specification.loader is None:
+        raise OSError("could not load provider configuration reader")
+    module = importlib.util.module_from_spec(specification); specification.loader.exec_module(module)
+    for provider in module.PROVIDERS:
+        has_state = module.state_path(provider, home).exists()
+        has_config = provider in module.CONFIG_PROVIDERS and module.config_path(provider, home).exists()
+        if not has_state and not has_config:
+            continue
+        try: state = module.load_state(provider, home)
+        except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError) as error:
+            state = module.state_default(provider)
+            builder.diagnostic(f"Could not load state for {provider}: {error}")
+        config = {}
+        if provider in module.CONFIG_PROVIDERS:
+            try: config = module.load_config(provider, home)
+            except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError) as error:
+                config = module.config_default(provider)
+                builder.diagnostic(f"Could not load configuration for {provider}: {error}")
+        builder.provider_config[provider] = {**state, **config}
 
 
 def load_catalog(plugin_path: Path, omarchy_path: Path, home: Path, limits: Limits) -> dict[str, Any]:
@@ -692,7 +703,27 @@ def load_catalog(plugin_path: Path, omarchy_path: Path, home: Path, limits: Limi
                 continue
             builder.append(definitions, bundled=False, source_dir=plugin_dir, source=source)
 
+    # Provider selection is needed to resolve legacy capability favorites.
+    # Run migrations after the complete extension catalog is known, but before
+    # any provider or compatibility configuration is consumed.
     load_user_configuration(home, builder, limits)
+    try:
+        migration_path = plugin_path / "libexec" / "migrate-provider-config.py"
+        specification = importlib.util.spec_from_file_location("omalaunch_provider_migration", migration_path)
+        if specification is None or specification.loader is None:
+            raise OSError(f"could not load {migration_path}")
+        migration = importlib.util.module_from_spec(specification)
+        specification.loader.exec_module(migration)
+        migration_diagnostics, builder.migration_complete = migration.run(
+            home, builder.catalog, builder.provider_preferences
+        )
+        for message in migration_diagnostics:
+            builder.diagnostic(message)
+    except Exception as error:
+        # Legacy readers remain active, so a migration failure must not make the
+        # catalog transient or prevent the launcher from starting.
+        builder.diagnostic(f"Provider configuration migration could not run and will retry: {error}")
+    load_provider_configuration(plugin_path, home, builder)
     return builder.finish(complete=complete)
 
 

--- a/libexec/migrate-provider-config.py
+++ b/libexec/migrate-provider-config.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Migrate released shared favorites into provider-owned state."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import math
+import os
+from pathlib import Path
+import re
+import shutil
+import sys
+import tempfile
+from typing import Any
+
+MAX_BYTES = 64 * 1024
+MAX_DEPTH = 8
+MAX_DIAGNOSTICS = 64
+MAX_DIAGNOSTIC_CHARS = 512
+MAX_SAFE_INTEGER = 9007199254740991
+MIGRATION_STARRED = "provider-config.legacy-starred.v1"
+CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+class Diagnostics:
+    def __init__(self) -> None:
+        self.values: list[str] = []
+
+    def add(self, value: str) -> None:
+        text = str(value).replace("\x00", "�")
+        if len(text) > MAX_DIAGNOSTIC_CHARS:
+            text = text[:MAX_DIAGNOSTIC_CHARS - 1] + "…"
+        if len(self.values) < MAX_DIAGNOSTICS:
+            self.values.append(text)
+        elif self.values and not self.values[-1].startswith("Further migration diagnostics"):
+            self.values[-1] = f"Further migration diagnostics were omitted after {MAX_DIAGNOSTICS} messages"
+
+
+def reject_constant(value: str) -> Any:
+    raise ValueError(f"non-finite JSON number {value!r} is not permitted")
+
+
+def parse_float(value: str) -> float:
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"non-finite JSON number {value!r} is not permitted")
+    return result
+
+
+def parse_int(value: str) -> int:
+    result = int(value)
+    if abs(result) > MAX_SAFE_INTEGER:
+        raise ValueError("JSON integer exceeds the interoperable safe-integer range")
+    return result
+
+
+def check_depth(value: Any, maximum: int = MAX_DEPTH) -> None:
+    stack = [(value, 0)]
+    while stack:
+        current, parent = stack.pop()
+        if isinstance(current, (dict, list)):
+            depth = parent + 1
+            if depth > maximum:
+                raise ValueError(f"JSON nesting exceeds the {maximum}-level limit")
+            children = current.values() if isinstance(current, dict) else current
+            stack.extend((child, depth) for child in children if isinstance(child, (dict, list)))
+
+
+def strip_jsonc(data: bytes) -> str:
+    text = data.decode("utf-8")
+    output: list[str] = []
+    index = 0
+    string = escaped = False
+    while index < len(text):
+        char = text[index]
+        if string:
+            output.append(char)
+            if escaped: escaped = False
+            elif char == "\\": escaped = True
+            elif char == '"': string = False
+            index += 1
+        elif char == '"':
+            string = True; output.append(char); index += 1
+        elif text.startswith("//", index):
+            end = text.find("\n", index + 2); index = len(text) if end < 0 else end
+        elif text.startswith("/*", index):
+            end = text.find("*/", index + 2)
+            if end < 0: raise ValueError("unterminated block comment")
+            output.extend("\n" for char in text[index:end + 2] if char == "\n"); index = end + 2
+        else:
+            output.append(char); index += 1
+    text = "".join(output); output = []; index = 0; string = escaped = False
+    while index < len(text):
+        char = text[index]
+        if string:
+            output.append(char)
+            if escaped: escaped = False
+            elif char == "\\": escaped = True
+            elif char == '"': string = False
+        elif char == '"': string = True; output.append(char)
+        elif char == ",":
+            look = index + 1
+            while look < len(text) and text[look].isspace(): look += 1
+            if look >= len(text) or text[look] not in "]}": output.append(char)
+        else: output.append(char)
+        index += 1
+    return "".join(output)
+
+
+def read_data(path: Path, *, jsonc: bool = False) -> Any:
+    size = path.stat().st_size
+    if size > MAX_BYTES: raise ValueError(f"file is {size} bytes; limit is {MAX_BYTES} bytes")
+    raw: str | bytes = strip_jsonc(path.read_bytes()) if jsonc else path.read_bytes()
+    try:
+        value = json.loads(raw, parse_constant=reject_constant, parse_float=parse_float, parse_int=parse_int)
+    except RecursionError as error:
+        raise ValueError("JSON parsing exceeded Python's recursion limit") from error
+    check_depth(value)
+    return value
+
+
+def valid_identity(value: Any, maximum: int = 255) -> bool:
+    return isinstance(value, str) and 1 <= len(value) <= maximum and "/" not in value and not CONTROL_RE.search(value)
+
+
+def normalize_path(value: Any, home: Path) -> str | None:
+    if not isinstance(value, str) or not 1 <= len(value) <= 4096: return None
+    if value.startswith("~/"): value = str(home) + value[1:]
+    if not value.startswith("/"): return None
+    parts: list[str] = []
+    for part in value.split("/"):
+        if not part or part == ".": continue
+        if part == "..":
+            if not parts: return None
+            parts.pop()
+        else: parts.append(part)
+    return "/" + "/".join(parts)
+
+
+def default_config(provider: str) -> dict[str, Any]:
+    return {"version": 1, "favorites": []}
+
+
+def validate_config(provider: str, value: Any, home: Path) -> None:
+    if not isinstance(value, dict) or value.get("version") != 1: raise ValueError("expected an object with version 1")
+    allowed = {"version", "favorites"}
+    if provider == "omalaunch.files": allowed.add("includeGitIgnored")
+    if not set(value) <= allowed: raise ValueError("configuration has unknown fields")
+    if provider == "omalaunch.files":
+        if "includeGitIgnored" in value and not isinstance(value["includeGitIgnored"], bool): raise ValueError("includeGitIgnored must be boolean")
+        entries = value.get("favorites", [])
+        identities = []
+        if not isinstance(entries, list) or len(entries) > 256: raise ValueError("favorites are invalid")
+        for item in entries:
+            if not isinstance(item, dict) or set(item) != {"type", "path"} or item.get("type") not in ("file", "directory"):
+                raise ValueError("file favorite is invalid")
+            path = normalize_path(item.get("path"), home)
+            if path is None or path != item["path"]: raise ValueError("file favorite path is not normalized")
+            identities.append((item["type"], path))
+        if len(set(identities)) != len(identities): raise ValueError("file favorites are duplicated")
+    else:
+        entries = value.get("favorites", [])
+        if not isinstance(entries, list) or len(entries) > 256 or not all(valid_identity(item) for item in entries) or len(set(entries)) != len(entries):
+            raise ValueError("favorites are invalid or duplicated")
+
+
+def load_target(path: Path, provider: str, home: Path) -> dict[str, Any]:
+    if not path.exists(): return default_config(provider)
+    value = read_data(path); validate_config(provider, value, home); return value
+
+
+def fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try: os.fsync(descriptor)
+    finally: os.close(descriptor)
+
+
+def backup(path: Path) -> None:
+    if not path.exists(): return
+    suffix = 0
+    while True:
+        candidate = path.with_name(path.name + ".pre-migration.bak" + (f".{suffix}" if suffix else ""))
+        try:
+            descriptor = os.open(candidate, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            break
+        except FileExistsError: suffix += 1
+    try:
+        with os.fdopen(descriptor, "wb") as output, path.open("rb") as source:
+            shutil.copyfileobj(source, output); output.flush(); os.fsync(output.fileno())
+    except Exception:
+        candidate.unlink(missing_ok=True); raise
+    fsync_directory(path.parent)
+
+
+def atomic_write(path: Path, value: Any, *, make_backup: bool = True) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if make_backup: backup(path)
+    data = (json.dumps(value, ensure_ascii=False, indent=2, allow_nan=False) + "\n").encode()
+    descriptor, temporary = tempfile.mkstemp(prefix="." + path.name + ".", dir=path.parent)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "wb") as output:
+            output.write(data); output.flush(); os.fsync(output.fileno())
+        os.replace(temporary, path); fsync_directory(path.parent)
+        if read_data(path) != value:
+            raise OSError(f"atomic write verification failed for {path}")
+    except Exception:
+        try: os.unlink(temporary)
+        except FileNotFoundError: pass
+        raise
+
+
+def active_providers(catalog: list[Any], preferences: dict[str, str]) -> dict[str, str]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    seen: set[str] = set()
+    for raw in catalog:
+        if not isinstance(raw, dict) or not valid_identity(raw.get("id")) or raw["id"] in seen: continue
+        seen.add(raw["id"])
+        capability = raw.get("capability", raw["id"])
+        if not valid_identity(capability) or raw.get("_missingRequires"): continue
+        grouped.setdefault(capability, []).append(raw)
+    result = {}
+    for capability, values in grouped.items():
+        preferred = preferences.get(capability)
+        selected = next((item for item in values if item["id"] == preferred), None)
+        if selected is None:
+            selected = max(values, key=lambda item: (item.get("priority", 0) if isinstance(item.get("priority", 0), (int, float)) else 0,
+                                                     not bool(item.get("_bundled", False))))
+        result[capability] = selected["id"]
+    return result
+
+
+def parse_legacy_favorite(value: Any, home: Path, active: dict[str, str], diagnostics: Diagnostics) -> tuple[str, Any] | None:
+    if not isinstance(value, str) or not value: return None
+    if value.startswith("apps."):
+        item = value[5:]
+        return ("omalaunch.apps", item) if valid_identity(item) else None
+    for prefix, kind in (("file.favorite.directory:", "directory"), ("file.favorite.file:", "file")):
+        if value.startswith(prefix):
+            path = normalize_path(value[len(prefix):], home)
+            return ("omalaunch.files", {"type": kind, "path": path}) if path else None
+    if value.startswith("file.favorite:"):
+        try: parts = json.loads(value[len("file.favorite:"):], parse_constant=reject_constant)
+        except (ValueError, TypeError, RecursionError): return None
+        if not isinstance(parts, list) or len(parts) != 3 or parts[1] not in ("file", "directory"): return None
+        path = normalize_path(parts[2], home)
+        if parts[0] != "files":
+            diagnostics.add(f"Preserved favorite for non-bundled capability {parts[0]!r}"); return ("preserved", None)
+        return ("omalaunch.files", {"type": parts[1], "path": path}) if path else None
+    if value.startswith("extension.root:"):
+        try: capability = json.loads(value[len("extension.root:"):], parse_constant=reject_constant)
+        except (ValueError, TypeError, RecursionError): return None
+        provider = active.get(capability) if isinstance(capability, str) else None
+        if not provider:
+            diagnostics.add(f"Could not resolve extension favorite capability {capability!r}"); return ("preserved", None)
+        return "omalaunch.extensions", provider
+    return None
+
+
+def migrate_starred(source: Path, targets: Path, home: Path, active: dict[str, str], diagnostics: Diagnostics) -> bool:
+    if not source.exists(): return True
+    raw = read_data(source)
+    if not isinstance(raw, dict) or raw.get("version") != 1 or not isinstance(raw.get("ids"), list):
+        raise ValueError(f"legacy favorites {source} is not a version-1 ids object")
+    targets.mkdir(parents=True, exist_ok=True, mode=0o700)
+    providers=("omalaunch.apps", "omalaunch.files", "omalaunch.extensions")
+    locks=[]
+    try:
+        for provider in providers:
+            descriptor=os.open(targets / f"{provider}.lock", os.O_RDWR | os.O_CREAT, 0o600)
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                os.close(descriptor)
+                raise ValueError(f"{provider} state is busy; migration will retry")
+            locks.append(descriptor)
+        configs = {provider: load_target(targets / f"{provider}.json", provider, home) for provider in providers}
+        changed: set[str] = set()
+        for value in raw["ids"][:1025]:
+            mapped = parse_legacy_favorite(value, home, active, diagnostics)
+            if mapped is None:
+                diagnostics.add(f"Preserved unknown legacy favorite {value!r}"); continue
+            provider, entry = mapped
+            if provider == "preserved": continue
+            entries = configs[provider]["favorites"]
+            identity = (entry["type"], entry["path"]) if isinstance(entry, dict) else entry
+            identities = {(item["type"], item["path"]) if isinstance(item, dict) else item for item in entries}
+            if identity in identities: continue
+            if len(entries) >= 256: diagnostics.add(f"{provider} favorites are full; skipped {entry!r}"); continue
+            entries.append(entry); changed.add(provider)
+        if len(raw["ids"]) > 1024: diagnostics.add("Legacy favorites has more than 1024 ids; trailing ids were skipped")
+        for provider in sorted(changed): atomic_write(targets / f"{provider}.json", configs[provider])
+        return True
+    finally:
+        for descriptor in reversed(locks): os.close(descriptor)
+
+
+def run(home: Path, catalog: list[Any], preferences: dict[str, str], *, config_home: Path | None = None,
+        state_home: Path | None = None) -> tuple[list[str], bool]:
+    diagnostics = Diagnostics()
+    config_home = config_home or home / ".config"
+    state_home = state_home or Path(os.environ.get("XDG_STATE_HOME", home / ".local/state"))
+    targets = state_home / "omarchy" / "omalaunch" / "extensions"
+    marker = state_home / "omarchy" / "omalaunch-provider-migrations.json"
+    lock_path = state_home / "omarchy" / "omalaunch-provider-migrations.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    lock = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        try: fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            diagnostics.add("Provider configuration migration is already running; this startup kept compatibility state")
+            return diagnostics.values, False
+        completed: list[str] = []
+        if marker.exists():
+            try:
+                value = read_data(marker)
+                if isinstance(value, dict) and value.get("version") == 1 and isinstance(value.get("completed"), list):
+                    completed = [item for item in value["completed"] if item == MIGRATION_STARRED]
+            except (OSError, UnicodeDecodeError, ValueError) as error:
+                diagnostics.add(f"Could not read migration marker {marker}: {error}; migrations will retry")
+        steps = [
+            (MIGRATION_STARRED, lambda: migrate_starred(state_home / "omarchy/starred-launcher-items.json", targets, home, active_providers(catalog, preferences), diagnostics)),
+        ]
+        all_complete = True
+        for migration_id, operation in steps:
+            if migration_id in completed: continue
+            try:
+                operation()
+                completed.append(migration_id)
+                atomic_write(marker, {"version": 1, "completed": completed}, make_backup=False)
+            except (OSError, UnicodeDecodeError, ValueError) as error:
+                all_complete = False; diagnostics.add(f"Migration {migration_id} failed and will retry: {error}")
+        return diagnostics.values, all_complete
+    finally:
+        os.close(lock)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(); parser.add_argument("--home", type=Path, default=Path.home()); parser.add_argument("--catalog", type=Path)
+    args = parser.parse_args(); catalog = []
+    if args.catalog: catalog = read_data(args.catalog)
+    diagnostics, complete = run(args.home.resolve(), catalog if isinstance(catalog, list) else [], {})
+    print(json.dumps({"diagnostics": diagnostics, "complete": complete}, ensure_ascii=False)); return 0
+
+
+if __name__ == "__main__": raise SystemExit(main())

--- a/libexec/migrate-provider-config.py
+++ b/libexec/migrate-provider-config.py
@@ -145,11 +145,8 @@ def default_config(provider: str) -> dict[str, Any]:
 
 def validate_config(provider: str, value: Any, home: Path) -> None:
     if not isinstance(value, dict) or value.get("version") != 1: raise ValueError("expected an object with version 1")
-    allowed = {"version", "favorites"}
-    if provider == "omalaunch.files": allowed.add("includeGitIgnored")
-    if not set(value) <= allowed: raise ValueError("configuration has unknown fields")
+    if not set(value) <= {"version", "favorites"}: raise ValueError("state has unknown fields")
     if provider == "omalaunch.files":
-        if "includeGitIgnored" in value and not isinstance(value["includeGitIgnored"], bool): raise ValueError("includeGitIgnored must be boolean")
         entries = value.get("favorites", [])
         identities = []
         if not isinstance(entries, list) or len(entries) > 256: raise ValueError("favorites are invalid")
@@ -195,9 +192,11 @@ def backup(path: Path) -> None:
 
 
 def atomic_write(path: Path, value: Any, *, make_backup: bool = True) -> None:
+    data = (json.dumps(value, ensure_ascii=False, indent=2, allow_nan=False) + "\n").encode()
+    if len(data) > MAX_BYTES:
+        raise ValueError(f"result is {len(data)} bytes; limit is {MAX_BYTES} bytes")
     path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     if make_backup: backup(path)
-    data = (json.dumps(value, ensure_ascii=False, indent=2, allow_nan=False) + "\n").encode()
     descriptor, temporary = tempfile.mkstemp(prefix="." + path.name + ".", dir=path.parent)
     try:
         os.fchmod(descriptor, 0o600)

--- a/libexec/provider-config
+++ b/libexec/provider-config
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json, os, sys
+from pathlib import Path
+sys.path.insert(0,str(Path(__file__).parent))
+import provider_config as pc
+
+def fail(e:object)->None:
+    print("provider-config: "+str(e),file=sys.stderr); raise SystemExit(1)
+def main(a:list[str])->None:
+    home=Path(os.environ.get("HOME",str(Path.home())))
+    if not a: fail("missing command")
+    if a[0]=="read-all":
+        values={}; diagnostics=[]
+        for provider in pc.PROVIDERS:
+            try: state=pc.load_state(provider,home)
+            except (OSError,UnicodeError,ValueError,json.JSONDecodeError) as e:
+                state=pc.state_default(provider); diagnostics.append(f"Could not load state for {provider}: {e}"[:512])
+            config={}
+            if provider in pc.CONFIG_PROVIDERS:
+                try: config=pc.load_config(provider,home)
+                except (OSError,UnicodeError,ValueError,json.JSONDecodeError) as e:
+                    config=pc.config_default(provider); diagnostics.append(f"Could not load configuration for {provider}: {e}"[:512])
+            values[provider]={**state,**config}
+        print(json.dumps({"configs":values,"diagnostics":diagnostics[:64]},ensure_ascii=False)); return
+    if len(a)<2: fail("missing provider")
+    command,provider=a[:2]
+    if command=="read": print(json.dumps(pc.load(provider,home),ensure_ascii=False)); return
+    def toggle(data,key):
+        values=data["favorites"]
+        if key in values: values.remove(key)
+        elif len(values)<pc.MAX_ITEMS: values.append(key)
+        else: fail("favorites are full")
+    if command=="toggle" and len(a)==3:
+        value=a[2]
+        if provider=="omalaunch.files":
+            kind,path=value.split(":",1); path=pc.normalize_path(path,home); key={"type":kind,"path":path}
+            pc.mutate(provider,home,lambda d: d["favorites"].remove(key) if key in d["favorites"] else d["favorites"].append(key))
+        else: pc.mutate(provider,home,lambda d: toggle(d,value))
+        return
+    fail("invalid command")
+try: main(sys.argv[1:])
+except (OSError,UnicodeError,ValueError,json.JSONDecodeError,KeyError) as e: fail(e)

--- a/libexec/provider_config.py
+++ b/libexec/provider_config.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Strict provider configuration readers and locked provider state writers."""
+from __future__ import annotations
+import fcntl, json, math, os, re, tempfile
+from pathlib import Path
+from typing import Any, Callable
+
+MAX_BYTES=64*1024; MAX_DEPTH=8; MAX_ITEMS=256; MAX_SAFE=9007199254740991
+CONTROL=re.compile(r"[\x00-\x1f\x7f]")
+PROVIDERS=("omalaunch.apps","omalaunch.files","omalaunch.extensions")
+CONFIG_PROVIDERS=("omalaunch.files",)
+
+def reject_constant(v:str)->Any: raise ValueError(f"non-finite number {v}")
+def parse_int(v:str)->int:
+    n=int(v)
+    if abs(n)>MAX_SAFE: raise ValueError("integer exceeds safe range")
+    return n
+def parse_float(v:str)->float:
+    n=float(v)
+    if not math.isfinite(n): raise ValueError("non-finite number")
+    return n
+def depth(value:Any)->None:
+    stack=[(value,0)]
+    while stack:
+        item,parent=stack.pop()
+        if isinstance(item,(dict,list)):
+            level=parent+1
+            if level>MAX_DEPTH: raise ValueError("nesting exceeds 8 levels")
+            children=item.values() if isinstance(item,dict) else item
+            stack.extend((x,level) for x in children if isinstance(x,(dict,list)))
+def strip_jsonc(raw:bytes)->str:
+    text=raw.decode("utf-8"); out=[]; i=0; string=False; escaped=False
+    while i<len(text):
+        c=text[i]
+        if string:
+            out.append(c)
+            if escaped: escaped=False
+            elif c=="\\": escaped=True
+            elif c=='"': string=False
+            i+=1
+        elif c=='"': string=True; out.append(c); i+=1
+        elif text.startswith("//",i):
+            end=text.find("\n",i+2); i=len(text) if end<0 else end
+        elif text.startswith("/*",i):
+            end=text.find("*/",i+2)
+            if end<0: raise ValueError("unterminated block comment")
+            out.extend("\n" for c in text[i:end+2] if c=="\n"); i=end+2
+        else: out.append(c); i+=1
+    text="".join(out); out=[]; i=0; string=False; escaped=False
+    while i<len(text):
+        c=text[i]
+        if string:
+            out.append(c)
+            if escaped: escaped=False
+            elif c=="\\": escaped=True
+            elif c=='"': string=False
+        elif c=='"': string=True; out.append(c)
+        elif c==",":
+            j=i+1
+            while j<len(text) and text[j].isspace(): j+=1
+            if j>=len(text) or text[j] not in "]}": out.append(c)
+        else: out.append(c)
+        i+=1
+    return "".join(out)
+def read_json(path:Path,*,jsonc:bool)->Any:
+    raw=path.read_bytes()
+    if len(raw)>MAX_BYTES: raise ValueError("file exceeds 64 KiB")
+    value=json.loads(strip_jsonc(raw) if jsonc else raw,parse_constant=reject_constant,parse_int=parse_int,parse_float=parse_float)
+    depth(value); return value
+
+def config_default(provider:str)->dict[str,Any]:
+    if provider!="omalaunch.files": return {}
+    return {"version":1,"includeGitIgnored":False}
+def state_default(provider:str)->dict[str,Any]:
+    return {"version":1,"favorites":[]}
+def identity(v:Any,maxlen:int=255)->bool:
+    return isinstance(v,str) and 1<=len(v)<=maxlen and "/" not in v and CONTROL.search(v) is None
+def normalize_path(v:Any,home:Path)->str:
+    if not isinstance(v,str) or not 1<=len(v)<=4096: raise ValueError("invalid path")
+    if v.startswith("~/"): v=str(home)+v[1:]
+    if not v.startswith("/"): raise ValueError("path is not absolute")
+    parts=[]
+    for part in v.split("/"):
+        if not part or part==".": continue
+        if part=="..":
+            if not parts: raise ValueError("path moves above root")
+            parts.pop()
+        else: parts.append(part)
+    return "/"+"/".join(parts)
+def validate_config(provider:str,value:Any)->dict[str,Any]:
+    if provider not in CONFIG_PROVIDERS: raise ValueError("provider has no configuration")
+    if not isinstance(value,dict) or value.get("version")!=1 or set(value)-{"version","includeGitIgnored"}: raise ValueError("invalid files configuration")
+    include=value.get("includeGitIgnored",False)
+    if not isinstance(include,bool): raise ValueError("includeGitIgnored must be boolean")
+    return {"version":1,"includeGitIgnored":include}
+def validate_state(provider:str,value:Any,home:Path)->dict[str,Any]:
+    if provider not in PROVIDERS or not isinstance(value,dict) or value.get("version")!=1: raise ValueError("expected version-1 provider state")
+    allowed={"version","favorites"}
+    if set(value)-allowed: raise ValueError("unknown state fields")
+    result=state_default(provider)
+    if provider=="omalaunch.files":
+        entries=value.get("favorites",[])
+        if not isinstance(entries,list) or len(entries)>MAX_ITEMS: raise ValueError("invalid file favorites")
+        seen=set()
+        for raw in entries:
+            if not isinstance(raw,dict) or set(raw)!={"type","path"} or raw["type"] not in ("file","directory"): raise ValueError("invalid file favorite")
+            path=normalize_path(raw["path"],home); key=(raw["type"],path)
+            if key in seen: raise ValueError("duplicate file favorite")
+            seen.add(key); result["favorites"].append({"type":raw["type"],"path":path})
+    else:
+        entries=value.get("favorites",[])
+        if not isinstance(entries,list) or len(entries)>MAX_ITEMS or any(not identity(x) for x in entries) or len(set(entries))!=len(entries): raise ValueError("invalid favorites")
+        result["favorites"]=list(entries)
+    return result
+
+def config_path(provider:str,home:Path)->Path: return home/".config/omarchy/omalaunch/extensions"/(provider+".jsonc")
+def state_root(home:Path,state_home:Path|None=None)->Path:
+    return (state_home or Path(os.environ.get("XDG_STATE_HOME",home/".local/state")))/"omarchy/omalaunch/extensions"
+def state_path(provider:str,home:Path,state_home:Path|None=None)->Path: return state_root(home,state_home)/(provider+".json")
+def load_config(provider:str,home:Path)->dict[str,Any]:
+    path=config_path(provider,home)
+    return config_default(provider) if not path.exists() else validate_config(provider,read_json(path,jsonc=True))
+def load_state(provider:str,home:Path,state_home:Path|None=None)->dict[str,Any]:
+    path=state_path(provider,home,state_home)
+    return state_default(provider) if not path.exists() else validate_state(provider,read_json(path,jsonc=False),home)
+def load(provider:str,home:Path,state_home:Path|None=None)->dict[str,Any]:
+    value=load_state(provider,home,state_home)
+    if provider in CONFIG_PROVIDERS: value={**value,**load_config(provider,home)}
+    return value
+
+def atomic_write_state(provider:str,home:Path,value:dict[str,Any],state_home:Path|None=None)->None:
+    path=state_path(provider,home,state_home); value=validate_state(provider,value,home); path.parent.mkdir(parents=True,exist_ok=True,mode=0o700)
+    data=(json.dumps(value,ensure_ascii=False,indent=2,allow_nan=False)+"\n").encode()
+    if len(data)>MAX_BYTES: raise ValueError("result exceeds 64 KiB")
+    fd,tmp=tempfile.mkstemp(prefix="."+path.name+".",dir=path.parent)
+    try:
+        os.fchmod(fd,0o600)
+        with os.fdopen(fd,"wb") as f: f.write(data); f.flush(); os.fsync(f.fileno())
+        os.replace(tmp,path)
+        d=os.open(path.parent,os.O_RDONLY|getattr(os,"O_DIRECTORY",0)); os.fsync(d); os.close(d)
+    finally:
+        try: os.unlink(tmp)
+        except FileNotFoundError: pass
+def mutate(provider:str,home:Path,fn:Callable[[dict[str,Any]],None],state_home:Path|None=None)->dict[str,Any]:
+    root=state_root(home,state_home); root.mkdir(parents=True,exist_ok=True,mode=0o700)
+    lock_path=root/(provider+".lock"); lock=os.open(lock_path,os.O_RDWR|os.O_CREAT,0o600)
+    try:
+        fcntl.flock(lock,fcntl.LOCK_EX)
+        value=load_state(provider,home,state_home) # Invalid state stops before write.
+        fn(value); atomic_write_state(provider,home,value,state_home)
+        return load_state(provider,home,state_home)
+    finally: os.close(lock)

--- a/schemas/provider-config/omalaunch.files.v1.schema.json
+++ b/schemas/provider-config/omalaunch.files.v1.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/DanielLemky/omalaunch/schemas/provider-config/omalaunch.files.v1.schema.json",
+  "title": "omalaunch.files user configuration version 1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version"],
+  "properties": {
+    "version": { "const": 1 },
+    "includeGitIgnored": { "type": "boolean", "default": false }
+  }
+}

--- a/schemas/provider-state/omalaunch.apps.v1.schema.json
+++ b/schemas/provider-state/omalaunch.apps.v1.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/DanielLemky/omalaunch/schemas/provider-state/omalaunch.apps.v1.schema.json",
+  "title": "omalaunch.apps machine-managed state version 1",
+  "type": "object", "additionalProperties": false, "required": ["version"],
+  "properties": {
+    "version": {"const": 1},
+    "favorites": {"type": "array", "maxItems": 256, "uniqueItems": true, "items": {"type": "string", "minLength": 1, "maxLength": 255, "pattern": "^[^\\u0000-\\u001f\\u007f/]+$"}}
+  }
+}

--- a/schemas/provider-state/omalaunch.extensions.v1.schema.json
+++ b/schemas/provider-state/omalaunch.extensions.v1.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/DanielLemky/omalaunch/schemas/provider-state/omalaunch.extensions.v1.schema.json",
+  "title": "omalaunch.extensions machine-managed state version 1",
+  "type": "object", "additionalProperties": false, "required": ["version"],
+  "properties": {
+    "version": {"const": 1},
+    "favorites": {"type": "array", "maxItems": 256, "uniqueItems": true, "items": {"type": "string", "minLength": 1, "maxLength": 255, "pattern": "^[^\\u0000-\\u001f\\u007f/]+$"}}
+  }
+}

--- a/schemas/provider-state/omalaunch.files.v1.schema.json
+++ b/schemas/provider-state/omalaunch.files.v1.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/DanielLemky/omalaunch/schemas/provider-state/omalaunch.files.v1.schema.json",
+  "title": "omalaunch.files machine-managed state version 1",
+  "type": "object", "additionalProperties": false, "required": ["version"],
+  "properties": {
+    "version": {"const": 1},
+    "favorites": {
+      "type": "array", "maxItems": 256, "uniqueItems": true,
+      "items": {
+        "type": "object", "additionalProperties": false, "required": ["type", "path"],
+        "properties": {
+          "type": {"enum": ["file", "directory"]},
+          "path": {"type": "string", "minLength": 1, "maxLength": 4096, "pattern": "^(?:/|~/)"}
+        }
+      }
+    }
+  }
+}

--- a/tests/extension-loader-test.py
+++ b/tests/extension-loader-test.py
@@ -143,14 +143,15 @@ elif mode == 'integer-overflow':
     enabled_file = base / "enabled.json"
     enabled_file.write_text(json.dumps([{"id": "example.dynamic", "enabled": True}]), encoding="utf-8")
     write_executable(bin_dir / "omarchy", f"#!/bin/sh\ncat {enabled_file}\n")
-    env = dict(os.environ, PATH=f"{bin_dir}:{os.environ['PATH']}")
+    env = dict(os.environ, PATH=f"{bin_dir}:{os.environ['PATH']}",
+               XDG_STATE_HOME=str(home / ".local" / "state"))
     omarchy_root = base / "omarchy"
     omarchy_root.mkdir()
 
     config_root = home / ".config" / "omarchy" / "omalaunch"
     (config_root / "extensions").mkdir(parents=True)
     (config_root / "config.jsonc").write_text('{\n// selection\n"version": 1, "capabilities": {"files": {"provider": "chosen",},},\n}')
-    (config_root / "extensions" / "files.jsonc").write_text('{"version": 1, "includeGitIgnored": true,}')
+    (config_root / "extensions" / "omalaunch.files.jsonc").write_text('{"version": 1, "includeGitIgnored": true,}')
 
     catalog = run_loader(plugin_root, omarchy_root, home, env)
     check(catalog["providerPreferences"] == {"files": "chosen"}
@@ -158,8 +159,8 @@ elif mode == 'integer-overflow':
               "version": 1,
               "capabilities": {"files": {"provider": "chosen"}},
           }
-          and catalog["capabilityConfig"] == {"files": {"includeGitIgnored": True}},
-          "bounded JSONC loads core and capability configuration")
+          and catalog["providerConfig"]["omalaunch.files"] == {"version": 1, "includeGitIgnored": True, "favorites": []},
+          "bounded JSONC loads core and provider configuration")
     ids = [item.get("id") for item in catalog["extensions"]]
     messages = "\n".join(catalog["diagnostics"])
     check(ids == ["bundled", "static", "dynamic", "argument"],

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -704,10 +704,10 @@ const configuredProviderCatalog = menu.parseExtensionCatalog(JSON.stringify({
   extensions: [
     { schemaVersion: 1, id: 'default-files', capability: 'files', mode: 'files', label: 'Default', prefixes: ['default'], command: ['true'], _bundled: true },
     { schemaVersion: 1, id: 'chosen-files', capability: 'files', mode: 'files', label: 'Chosen', prefixes: ['chosen'], command: ['true'], priority: -10 }
-  ], providerPreferences: { files: 'chosen-files' }, capabilityConfig: { files: { includeGitIgnored: true } }
+  ], providerPreferences: { files: 'chosen-files' }, providerConfig: { 'default-files': { includeGitIgnored: true }, 'chosen-files': { includeGitIgnored: false } }
 }))
-assert(configuredProviderCatalog.extensions[0].id === 'chosen-files' && configuredProviderCatalog.extensions[0].config.includeGitIgnored === true,
-  'provider configuration selects an available id and capability configuration follows capability identity')
+assert(configuredProviderCatalog.extensions[0].id === 'chosen-files' && configuredProviderCatalog.extensions[0].config.includeGitIgnored === false,
+  'provider configuration selects an available id and configuration follows provider identity')
 const missingProviderCatalog = menu.parseExtensionCatalog(JSON.stringify({
   extensions: [{ schemaVersion: 1, id: 'fallback', capability: 'files', mode: 'files', label: 'Fallback', prefixes: ['fallback'], command: ['true'] }],
   providerPreferences: { files: 'missing' }

--- a/tests/provider-config-migration-test.py
+++ b/tests/provider-config-migration-test.py
@@ -102,6 +102,26 @@ with tempfile.TemporaryDirectory() as temporary:
 
 with tempfile.TemporaryDirectory() as temporary:
     home, config, state, targets = paths(Path(temporary))
+    invalid = {"version": 1, "favorites": [], "includeGitIgnored": True}
+    write(targets / "omalaunch.files.json", invalid)
+    write(state / "omarchy/starred-launcher-items.json", {"version": 1, "ids": ['file.favorite:["files","file","/tmp/new"]']})
+    diagnostics, complete = run(home, config, state)
+    check(not complete and migration.read_data(targets / "omalaunch.files.json") == invalid,
+          "migration rejects configuration fields in provider state")
+
+with tempfile.TemporaryDirectory() as temporary:
+    home, config, state, targets = paths(Path(temporary))
+    target = targets / "omalaunch.apps.json"
+    original = {"version": 1, "favorites": ["keep"]}
+    write(target, original)
+    try: migration.atomic_write(target, {"version": 1, "favorites": ["x" * migration.MAX_BYTES]})
+    except ValueError: pass
+    else: raise AssertionError("migration wrote provider state above the runtime byte limit")
+    check(migration.read_data(target) == original and not (targets / "omalaunch.apps.json.pre-migration.bak").exists(),
+          "oversized migration output leaves state unchanged without a misleading backup")
+
+with tempfile.TemporaryDirectory() as temporary:
+    home, config, state, targets = paths(Path(temporary))
     write(state / "omarchy/starred-launcher-items.json", {"version": 1, "ids": ["apps.One"]})
     original = migration.atomic_write
     def fail_apps(path, value, **kwargs):

--- a/tests/provider-config-migration-test.py
+++ b/tests/provider-config-migration-test.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+
+import fcntl
+import importlib.util
+import json
+import os
+from pathlib import Path
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / "libexec" / "migrate-provider-config.py"
+spec = importlib.util.spec_from_file_location("migration", HELPER)
+migration = importlib.util.module_from_spec(spec); spec.loader.exec_module(migration)
+
+
+def check(value, message):
+    if not value: raise AssertionError(message)
+    print("ok - " + message)
+
+
+def write(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def paths(base):
+    home = base / "home"; config = base / "config"; state = base / "state"
+    return home, config, state, state / "omarchy/omalaunch/extensions"
+
+
+def run(home, config, state, catalog=None, preferences=None):
+    return migration.run(home, catalog or [], preferences or {}, config_home=config,
+                         state_home=state)
+
+
+catalog = [
+    {"id": "omalaunch.files", "capability": "files", "priority": 0, "_bundled": True, "_missingRequires": []},
+    {"id": "external.files", "capability": "files", "priority": 10, "_bundled": False, "_missingRequires": []},
+    {"id": "external.calc", "capability": "calculator", "priority": 0, "_bundled": False, "_missingRequires": []},
+]
+
+with tempfile.TemporaryDirectory() as temporary:
+    home, config, state, targets = paths(Path(temporary))
+    legacy = state / "omarchy/starred-launcher-items.json"
+    write(legacy, {"version": 1, "ids": [
+        "apps.Fastmail", "apps.org.gnome.Nautilus.desktop",
+        "file.favorite.directory:/tmp/Projects/../Docs//",
+        'file.favorite:["files","file","/tmp/notes.txt"]',
+        'file.favorite:["other-files","file","/tmp/private"]',
+        'extension.root:"files"', 'extension.root:"calculator"',
+        'extension.root:"missing"', 'extension.menu:["dynamic-provider","item"]',
+        'extension.menu:["missing","item"]', "unknown.temporary",
+    ]})
+    diagnostics, complete = run(home, config, state, catalog)
+    check(complete, "valid legacy favorites migrate successfully")
+    apps = migration.read_data(targets / "omalaunch.apps.json")
+    files = migration.read_data(targets / "omalaunch.files.json")
+    extensions = migration.read_data(targets / "omalaunch.extensions.json")
+    check(apps["favorites"] == ["Fastmail", "org.gnome.Nautilus.desktop"], "real legacy app IDs lose only the apps namespace")
+    check(files["favorites"] == [{"type": "directory", "path": "/tmp/Docs"}, {"type": "file", "path": "/tmp/notes.txt"}], "legacy and current JSON-array file IDs normalize in source order")
+    check(extensions["favorites"] == ["external.files", "external.calc"], "extension capabilities resolve to active provider IDs without shared configuration")
+    check(any("non-bundled capability" in item for item in diagnostics)
+          and any('extension.menu:["dynamic-provider","item"]' in item for item in diagnostics)
+          and any('extension.menu:["missing","item"]' in item for item in diagnostics)
+          and any("unknown legacy" in item for item in diagnostics)
+          and any("Could not resolve" in item for item in diagnostics),
+          "unknown, missing, dynamic, and provider-owned values remain and produce bounded diagnostics")
+    before = {path: path.read_bytes() for path in targets.iterdir()}
+    second, complete = run(home, config, state, catalog)
+    check(complete and before == {path: path.read_bytes() for path in targets.iterdir()}, "completed migrations are idempotent")
+    check(legacy.exists(), "migration does not delete or rewrite the legacy favorites source")
+
+with tempfile.TemporaryDirectory() as temporary:
+    home, config, state, targets = paths(Path(temporary))
+    write(targets / "omalaunch.apps.json", {"version": 1, "favorites": ["Fastmail", "Existing"]})
+    write(targets / "omalaunch.files.json", {"version": 1, "favorites": [{"type": "file", "path": "/tmp/a"}]})
+    write(state / "omarchy/starred-launcher-items.json", {"version": 1, "ids": ["apps.Fastmail", "apps.New", 'file.favorite:["files","file","/tmp/a"]', 'file.favorite:["files","directory","/tmp/b"]']})
+    run(home, config, state, catalog)
+    check(migration.read_data(targets / "omalaunch.apps.json")["favorites"] == ["Fastmail", "Existing", "New"], "existing valid target entries win and migrated entries append")
+    file_target = migration.read_data(targets / "omalaunch.files.json")
+    check(len(file_target["favorites"]) == 2, "duplicate merge preserves normalized identities")
+    check((targets / "omalaunch.apps.json.pre-migration.bak").exists(), "an existing target receives a non-overwriting backup")
+
+with tempfile.TemporaryDirectory() as temporary:
+    home, config, state, targets = paths(Path(temporary))
+    malformed = state / "omarchy/starred-launcher-items.json"
+    malformed.parent.mkdir(parents=True); malformed.write_text('{"version":1,"ids":[NaN]}')
+    diagnostics, complete = run(home, config, state)
+    marker_path = state / "omarchy/omalaunch-provider-migrations.json"
+    marker = migration.read_data(marker_path) if marker_path.exists() else {"completed": []}
+    check(not complete and migration.MIGRATION_STARRED not in marker["completed"] and any("will retry" in item for item in diagnostics), "malformed strict JSON does not mark its migration complete")
+    malformed.write_text('{"version":1,"ids":["apps.Retry"]}')
+    diagnostics, complete = run(home, config, state)
+    check(complete and migration.read_data(targets / "omalaunch.apps.json")["favorites"] == ["Retry"], "a failed migration retries on the next startup")
+
+with tempfile.TemporaryDirectory() as temporary:
+    home, config, state, targets = paths(Path(temporary))
+    write(targets / "omalaunch.apps.json", {"version": 2, "favorites": []})
+    write(state / "omarchy/starred-launcher-items.json", {"version": 1, "ids": ["apps.Skip"]})
+    diagnostics, complete = run(home, config, state)
+    check(not complete and migration.read_data(targets / "omalaunch.apps.json")["version"] == 2, "invalid existing provider state is skipped and never rewritten")
+
+with tempfile.TemporaryDirectory() as temporary:
+    home, config, state, targets = paths(Path(temporary))
+    write(state / "omarchy/starred-launcher-items.json", {"version": 1, "ids": ["apps.One"]})
+    original = migration.atomic_write
+    def fail_apps(path, value, **kwargs):
+        if path.name == "omalaunch.apps.json": raise OSError("injected write failure")
+        return original(path, value, **kwargs)
+    migration.atomic_write = fail_apps
+    diagnostics, complete = run(home, config, state)
+    migration.atomic_write = original
+    marker = migration.read_data(state / "omarchy/omalaunch-provider-migrations.json") if (state / "omarchy/omalaunch-provider-migrations.json").exists() else {"completed": []}
+    check(not complete and migration.MIGRATION_STARRED not in marker["completed"], "failed favorites migration remains incomplete")
+    run(home, config, state)
+    check(migration.read_data(targets / "omalaunch.apps.json")["favorites"] == ["One"], "failed migration retries safely")
+
+with tempfile.TemporaryDirectory() as temporary:
+    home, config, state, targets = paths(Path(temporary))
+    lock_path = state / "omarchy/omalaunch-provider-migrations.lock"; lock_path.parent.mkdir(parents=True)
+    descriptor = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600); fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    diagnostics, complete = run(home, config, state)
+    os.close(descriptor)
+    check(not complete and any("already running" in item for item in diagnostics), "migration lock is nonblocking and retains compatibility behavior")
+
+with tempfile.TemporaryDirectory() as temporary:
+    home, config, state, targets = paths(Path(temporary))
+    write(state / "omarchy/starred-launcher-items.json", {"version": 1, "ids": ["apps.One"]})
+    targets.mkdir(parents=True)
+    lock_path = targets / "omalaunch.apps.lock"
+    descriptor = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600); fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    diagnostics, complete = run(home, config, state)
+    os.close(descriptor)
+    check(not complete and any("state is busy" in item for item in diagnostics), "provider state locks do not block startup migration")
+
+with tempfile.TemporaryDirectory() as temporary:
+    home, config, state, targets = paths(Path(temporary))
+    diagnostics, complete = run(home, config, state)
+    check(complete and not targets.exists(), "missing legacy sources complete without creating provider state files")
+
+print("ok - provider state startup migration suite")

--- a/tests/provider-config-runtime-test.py
+++ b/tests/provider-config-runtime-test.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+import importlib.util, json, os, pathlib, subprocess, tempfile
+ROOT=pathlib.Path(__file__).resolve().parents[1]
+spec=importlib.util.spec_from_file_location("pc",ROOT/"libexec/provider_config.py"); pc=importlib.util.module_from_spec(spec); spec.loader.exec_module(pc)
+def check(v,m):
+    if not v: raise AssertionError(m)
+    print("ok - "+m)
+with tempfile.TemporaryDirectory() as raw:
+    base=pathlib.Path(raw); home=base/"home"; state=base/"state"; home.mkdir()
+    env={**os.environ,"HOME":str(home),"XDG_STATE_HOME":str(state)}; os.environ["XDG_STATE_HOME"]=str(state); cli=ROOT/"libexec/provider-config"
+    for provider in pc.PROVIDERS: check(pc.load_state(provider,home)==pc.state_default(provider),provider+" has missing-state defaults")
+    check(pc.load_config("omalaunch.files",home)=={"version":1,"includeGitIgnored":False},"Files has a missing-config default")
+    for provider in ("omalaunch.apps","omalaunch.extensions"):
+        check(not pc.config_path(provider,home).exists(),provider+" has no meaningless config file")
+    config=pc.config_path("omalaunch.files",home); config.parent.mkdir(parents=True)
+    original=b'{\n  // preserve this comment and layout\n  "version": 1,\n  "includeGitIgnored": true,\n}\n'; config.write_bytes(original)
+    subprocess.run([cli,"toggle","omalaunch.apps","app.desktop"],env=env,check=True)
+    subprocess.run([cli,"toggle","omalaunch.files","directory:/tmp/a/../docs"],env=env,check=True)
+    subprocess.run([cli,"toggle","omalaunch.extensions","omalaunch.files"],env=env,check=True)
+    check(config.read_bytes()==original,"UI mutations preserve JSONC comments and formatting byte for byte")
+    check(pc.load("omalaunch.files",home)["includeGitIgnored"] is True,"runtime merges read-only Files configuration with state")
+    check(pc.load_state("omalaunch.files",home)["favorites"]==[{"type":"directory","path":"/tmp/docs"}],"Files stores normalized typed favorites in state")
+    bad=b'{"version":1,"favorites":[],"bad":true}'; app_state=pc.state_path("omalaunch.apps",home); app_state.write_bytes(bad)
+    result=subprocess.run([cli,"toggle","omalaunch.apps","other.desktop"],env=env)
+    check(result.returncode!=0 and app_state.read_bytes()==bad,"invalid state is not overwritten")
+    bad_config=b'{/*keep*/"version":1,"includeGitIgnored":"yes"}'; config.write_bytes(bad_config)
+    result=subprocess.run([cli,"read-all"],env=env,check=True,capture_output=True,text=True); payload=json.loads(result.stdout)
+    check(config.read_bytes()==bad_config and payload["configs"]["omalaunch.files"]["includeGitIgnored"] is False and payload["diagnostics"],"invalid config is not overwritten and gets a bounded diagnostic")
+    app_state.unlink(); workers=[subprocess.Popen([cli,"toggle","omalaunch.apps",f"app-{i}"],env=env) for i in range(24)]
+    check(all(p.wait()==0 for p in workers) and len(pc.load_state("omalaunch.apps",home)["favorites"])==24,"per-provider locks prevent lost concurrent updates")
+    check(pc.state_path("omalaunch.apps",home).is_relative_to(state),"runtime honors XDG_STATE_HOME")
+    replacement=pc.state_path("example.apps",home); check(not replacement.exists(),"replacement IDs do not inherit bundled state")
+    check(pc.state_path("omalaunch.apps",home).stat().st_mode&0o777==0o600,"state writes are private")
+print("ok - bundled provider runtime suite")

--- a/tests/provider-config-schema-test.py
+++ b/tests/provider-config-schema-test.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Check separate strict configuration and state schema contracts."""
+import importlib.util, json
+from pathlib import Path
+ROOT=Path(__file__).resolve().parents[1]
+spec=importlib.util.spec_from_file_location("pc",ROOT/"libexec/provider_config.py"); pc=importlib.util.module_from_spec(spec); spec.loader.exec_module(pc)
+def check(v,m):
+    if not v: raise AssertionError(m)
+    print("ok - "+m)
+def schema(path):
+    value=json.loads(path.read_text())
+    check(value["$schema"]=="https://json-schema.org/draft/2020-12/schema" and value["additionalProperties"] is False,path.name+" is a strict draft-2020-12 schema")
+    return value
+config_dir=ROOT/"schemas/provider-config"; state_dir=ROOT/"schemas/provider-state"
+check(sorted(x.name for x in config_dir.glob("*.json"))==["omalaunch.files.v1.schema.json"],"only Files has a user configuration schema")
+files_config=schema(config_dir/"omalaunch.files.v1.schema.json")
+check(set(files_config["properties"])=={"version","includeGitIgnored"},"Files configuration contains no machine state")
+for provider in pc.PROVIDERS:
+    value=schema(state_dir/f"{provider}.v1.schema.json")
+    check("includeGitIgnored" not in value["properties"],provider+" state excludes user configuration")
+valid={
+ "omalaunch.apps":{"version":1,"favorites":["app.desktop"]},
+ "omalaunch.files":{"version":1,"favorites":[{"type":"directory","path":"/tmp/docs"}]},
+ "omalaunch.extensions":{"version":1,"favorites":["omalaunch.files"]},
+}
+for provider,value in valid.items():
+    check(pc.validate_state(provider,value,Path("/home/test"))==value,provider+" valid state passes strict runtime validation")
+    bad={**value,"unknown":True}
+    try: pc.validate_state(provider,bad,Path("/home/test"))
+    except ValueError: pass
+    else: raise AssertionError(provider+" accepted unknown state")
+check(pc.validate_config("omalaunch.files",{"version":1,"includeGitIgnored":True})["includeGitIgnored"],"valid Files JSONC shape passes")
+for bad in ({"version":1,"favorites":[]},{"version":2},{"version":1,"includeGitIgnored":"yes"}):
+    try: pc.validate_config("omalaunch.files",bad)
+    except ValueError: pass
+    else: raise AssertionError("invalid Files config passed")
+print("ok - separate provider configuration and state schema suite")

--- a/tests/qml-extension-path-test.js
+++ b/tests/qml-extension-path-test.js
@@ -7,6 +7,11 @@ function assert(condition, message) {
 }
 
 const qml = fs.readFileSync(path.join(__dirname, '..', 'Menu.qml'), 'utf8')
+const favoritesQml = fs.readFileSync(path.join(__dirname, '..', 'LauncherFavorites.qml'), 'utf8')
+
+assert(favoritesQml.includes('Quickshell.env("XDG_STATE_HOME") || (Quickshell.env("HOME") + "/.local/state")')
+  && favoritesQml.includes('root.stateHome + "/omarchy/starred-launcher-items.json"'),
+'legacy favorite compatibility reads the same XDG state root as startup migration')
 
 const openBody = qml.slice(qml.indexOf('function open(payloadJson)'), qml.indexOf('function close()', qml.indexOf('function open(payloadJson)')))
 const resetBody = qml.slice(qml.indexOf('function resetForOpen()'), qml.indexOf('function cancel()', qml.indexOf('function resetForOpen()')))


### PR DESCRIPTION
## Summary

- Add provider-owned state for Apps, Files, and Extensions.
- Add read-only JSONC configuration for the Files provider.
- Add strict schemas and runtime validation.
- Add provider locks, private temporary files, `fsync`, and atomic writes.
- Add startup migration for released shared favorites with backups, markers, retries, and compatibility fallback.
- Honor `XDG_STATE_HOME` and keep replacement-provider data isolated.
- Add storage, migration, loader, and schema tests.

## Tests

- `python tests/provider-config-schema-test.py`
- `python tests/provider-config-runtime-test.py`
- `python tests/provider-config-migration-test.py`
- `python tests/extension-loader-test.py`
- `python tests/file-index-integration-test.py`
- `node tests/menu-model-test.js`
- `node tests/qml-extension-path-test.js`
- `bash tests/manifest-test.sh`
- `bash tests/qalc-integration-test.sh`
- `bash tests/timezone-integration-test.sh`
- `bash tests/live-query-process-integration-test.sh`
- Python compilation
- `git diff --check`

## Stack

This is PR 2 of 3. It depends on the actionable menu contract PR. PR 3 targets this branch.
