### PR TITLE
Expand Files image preview to half width

### DIFF
--- a/Menu.qml
+++ b/Menu.qml
@@ -181,7 +181,8 @@ Item {
     ? root.dynamicMenuSearchEntry(displayModel.get(root.selectedIndex).itemId) : null
   readonly property var selectedDynamicStarAction: root.selectedDynamicSearchEntry
     ? root.workflowStarAction(root.selectedDynamicSearchEntry.node) : null
-  readonly property int previewPaneWidth: Style.space(280)
+  readonly property int previewPaneWidth: Math.round((root.cardWidth
+    - card.contentLeftInset - card.contentRightInset - root.contentSpacing) / 2)
 
   // Shared application engine (entries, hidden filters, icons, launch,
   // removal), owned by the shell and also used by the standalone launcher.


### PR DESCRIPTION
## Summary

- size the Files image preview from the available card content width
- split the result area evenly between the file list and image preview

## Testing

- full automated test suite passes
- verified the updated preview layout in a local Omarchy shell instance