### PR TITLE
Configure compact menu typography

### DIFF
--- a/Menu.qml
+++ b/Menu.qml
@@ -53,6 +53,20 @@ Item {
   function ping() { return "ok" }
 
   property string fontFamily: Style.font.menuFamily
+
+  function styleFontSize(fontClass) {
+    switch (fontClass) {
+    case "caption": return Style.font.caption
+    case "bodySmall": return Style.font.bodySmall
+    case "subtitle": return Style.font.subtitle
+    case "title": return Style.font.title
+    case "heading": return Style.font.heading
+    case "display": return Style.font.display
+    case "displayLarge": return Style.font.displayLarge
+    default: return Style.font.body
+    }
+  }
+
   // JSONC menu definitions. The shell parses both at startup and merges
   // the user file on top of the defaults, so the keybind → IPC → visible
   // path doesn't have to shell out to bash + jq on every open.
@@ -254,16 +268,25 @@ Item {
   readonly property real rowReservedBorderRight: Border.right(selectedBorderSpec)
   readonly property int cornerRadius: Style.cornerRadius
   property int contentMargin: Style.spacing.panelPadding
-  property int headerHeight: Math.max(Style.space(34), Style.font.title + Style.spacing.controlPaddingY * 2)
-  property int actionBarHeight: Math.max(Style.space(36), Style.font.bodySmall + Style.spacing.controlPaddingY * 2)
+  property int headerHeight: Math.max(Style.space(28), Math.round(Style.space(34) * menuItemScale))
+  property int actionBarHeight: Math.max(Style.space(26), Math.round(Style.space(36) * menuItemScale))
   property int actionBarBottomPadding: Style.space(6)
   property int contentSpacing: Style.spacing.md
-  property int baseRowHeight: Math.max(Style.space(50), Style.font.body + Style.spacing.rowPaddingX * 2)
-  property int detailRowHeight: Math.max(Style.space(58), Style.font.body + Style.font.caption + Style.spacing.rowPaddingX * 2)
+  property string menuItemFontClass: "title"
+  property int configuredMenuItemFontSize: 0
+  readonly property int menuItemFontSize: configuredMenuItemFontSize > 0
+    ? configuredMenuItemFontSize : styleFontSize(menuItemFontClass)
+  readonly property real menuItemScale: menuItemFontSize / Style.font.body
+  readonly property int menuSecondaryFontSize: Math.max(1, Math.round(Style.font.bodySmall * menuItemScale))
+  readonly property int menuCaptionFontSize: Math.max(1, Math.round(Style.font.caption * menuItemScale))
+  readonly property int menuItemIconSize: Math.max(Style.space(10), Math.min(Style.space(32),
+    Math.round(menuItemFontSize * 1.25)))
+  property int baseRowHeight: Math.max(Style.space(28), Math.round(Style.space(44) * menuItemScale))
+  property int detailRowHeight: Math.max(Style.space(36), Math.round(Style.space(52) * menuItemScale))
   // How much of the first hidden row stays visible at the fold — enough to
   // read as a cut-off row rather than a bottom border.
   property int rowPeek: Math.round(baseRowHeight * 0.55)
-  property int rowSpacing: Style.spacing.xs
+  property int rowSpacing: Math.max(Style.space(1), Math.round(Style.spacing.xs * menuItemScale))
   property int dividerHeight: Style.space(17)
   property bool searchDivider: false
   property int layoutSerial: 0
@@ -273,7 +296,8 @@ Item {
   readonly property bool emptyRoot: !root.dmenuActive && root.activeMenu === "root" && !root.filterText && displayModel.count === 0
   property int visibleRowsHeight: root.emptyRoot || root.workflowInputActive ? 0 : (root.dmenuActive ? dmenuRowListHeight(layoutSerial, displayModel.count, filterText) : rowListHeight(layoutSerial, displayModel.count, filterText, searchDivider))
   readonly property bool workflowFilterMenuActive: root.workflowActive && root.workflowNode && root.workflowNode.kind === "menu"
-  property int workflowHintHeight: (root.workflowInputActive || root.workflowFilterMenuActive) ? Style.space(18) : 0
+  property int workflowHintHeight: (root.workflowInputActive || root.workflowFilterMenuActive)
+    ? Math.max(Style.space(12), Math.round(Style.space(18) * menuItemScale)) : 0
   property int cardHeight: Math.min(contentMargin + actionBarBottomPadding + headerHeight + actionBarHeight + contentSpacing
     + (visibleRowsHeight > 0 ? contentSpacing + visibleRowsHeight : 0)
     + (workflowHintHeight > 0 ? contentSpacing + workflowHintHeight : 0), panel.height - Style.gapsOut * 2)
@@ -300,7 +324,9 @@ Item {
     starred: displayModel.count > 0 && root.cursorActive && root.selectedIndex >= 0
       && root.selectedIndex < displayModel.count && displayModel.get(root.selectedIndex).starred
   })
-  readonly property var displayedActionBarHints: root.cardWidth < Style.space(560)
+  readonly property real actionBarFontScale: menuItemFontSize / Style.font.title
+  readonly property var displayedActionBarHints: root.cardWidth
+    < Math.round(Style.space(560) * Math.max(1, actionBarFontScale))
     ? MenuModel.compactActionBarHints(root.actionBarHints) : root.actionBarHints
 
   function finishRequest(selection) {
@@ -2788,6 +2814,10 @@ Item {
         var oldWorkflowNode = root.workflowNode
         var oldWorkflowStack = root.workflowStack
         root.extensions = catalog.extensions
+        root.menuItemFontClass = catalog.omalaunchConfig && catalog.omalaunchConfig.menuItemFontClass
+          ? catalog.omalaunchConfig.menuItemFontClass : "title"
+        root.configuredMenuItemFontSize = catalog.omalaunchConfig && catalog.omalaunchConfig.menuItemFontSize !== undefined
+          ? catalog.omalaunchConfig.menuItemFontSize : 0
         favorites.configure(catalog.providerConfig, catalog.migrationComplete)
         root.preloadDynamicMenuSearch()
 
@@ -3685,7 +3715,7 @@ Item {
             color: root.foreground
             opacity: root.filterText ? 1 : 0.58
             font.family: root.fontFamily
-            font.pixelSize: Style.font.heading
+            font.pixelSize: root.menuItemFontSize
             elide: Text.ElideRight
           }
 
@@ -3698,7 +3728,7 @@ Item {
             color: root.foreground
             opacity: root.filterText ? 1 : 0.58
             font.family: root.fontFamily
-            font.pixelSize: Style.font.heading
+            font.pixelSize: root.menuItemFontSize
             elide: Text.ElideRight
           }
 
@@ -3714,7 +3744,7 @@ Item {
           color: root.foreground
           opacity: 0.58
           font.family: root.fontFamily
-          font.pixelSize: Style.font.body
+          font.pixelSize: root.menuItemFontSize
           elide: Text.ElideRight
           verticalAlignment: Text.AlignVCenter
         }
@@ -3798,7 +3828,7 @@ Item {
                 text: row.icon
                 color: row.hasCursor ? root.selectedText : root.foreground
                 font.family: row.iconFont.length > 0 ? row.iconFont : root.fontFamily
-                font.pixelSize: Style.font.iconLarge
+                font.pixelSize: root.menuItemIconSize
                 width: Style.space(36)
                 horizontalAlignment: Text.AlignHCenter
                 verticalAlignment: Text.AlignVCenter
@@ -3810,8 +3840,8 @@ Item {
               Rectangle {
                 id: imagePreview
                 visible: row.isImageFile
-                width: Style.space(36)
-                height: Style.space(36)
+                width: root.menuItemIconSize
+                height: root.menuItemIconSize
                 radius: Math.min(root.cornerRadius, Style.space(5))
                 color: Util.alpha(root.foreground, 0.08)
                 clip: true
@@ -3833,8 +3863,8 @@ Item {
               Image {
                 id: appIconImage
                 visible: row.isApp
-                width: Style.font.iconLarge
-                height: Style.font.iconLarge
+                width: root.menuItemIconSize
+                height: root.menuItemIconSize
                 fillMode: Image.PreserveAspectFit
                 // Decode at physical pixels — a logical-size decode leaves
                 // PNG icons upscaled and blurry on HiDPI displays.
@@ -3849,12 +3879,12 @@ Item {
 
               Column {
                 id: contentColumn
-                anchors.left: row.isImageFile ? imagePreview.right : (row.hasIcon ? iconText.right : parent.left)
+                anchors.left: row.hasIcon ? iconText.right : parent.left
                 anchors.leftMargin: row.hasIcon ? Style.space(6) : root.rowReservedBorderLeft + Style.space(18)
                 anchors.right: trail.left
                 anchors.rightMargin: Style.space(6)
                 anchors.verticalCenter: parent.verticalCenter
-                spacing: Style.space(3)
+                spacing: Math.max(Style.space(1), Math.round(Style.space(3) * root.menuItemScale))
 
                 Text {
                   id: labelText
@@ -3862,7 +3892,7 @@ Item {
                   text: row.label
                   color: row.hasCursor ? root.selectedText : root.foreground
                   font.family: root.fontFamily
-                  font.pixelSize: Style.font.heading
+                  font.pixelSize: root.menuItemFontSize
                   font.weight: Font.Medium
                   elide: Text.ElideRight
                 }
@@ -3874,7 +3904,7 @@ Item {
                   color: root.foreground
                   opacity: 0.52
                   font.family: root.fontFamily
-                  font.pixelSize: Style.font.bodySmall
+                  font.pixelSize: root.menuSecondaryFontSize
                   elide: Text.ElideRight
                 }
               }
@@ -3893,7 +3923,7 @@ Item {
                   color: row.hasCursor ? root.selectedText : root.foreground
                   opacity: 0.7
                   font.family: root.fontFamily
-                  font.pixelSize: Style.font.body
+                  font.pixelSize: root.menuItemFontSize
                   anchors.verticalCenter: parent.verticalCenter
                 }
 
@@ -3903,7 +3933,7 @@ Item {
                   color: root.foreground
                   opacity: 0.45
                   font.family: root.fontFamily
-                  font.pixelSize: Style.font.body
+                  font.pixelSize: root.menuItemFontSize
                   anchors.verticalCenter: parent.verticalCenter
                 }
 
@@ -3912,7 +3942,7 @@ Item {
                   color: row.hasCursor ? root.selectedText : root.foreground
                   opacity: row.starred ? 0.7 : (row.kind === "menu" || row.kind === "link" ? 0.36 : 0)
                   font.family: root.fontFamily
-                  font.pixelSize: row.starred ? Style.font.bodySmall : Style.font.heading
+                  font.pixelSize: row.starred ? root.menuSecondaryFontSize : root.menuItemFontSize
                   font.weight: Font.Normal
                   anchors.verticalCenter: parent.verticalCenter
                 }
@@ -3976,7 +4006,7 @@ Item {
               color: root.foreground
               opacity: 0.72
               font.family: root.fontFamily
-              font.pixelSize: Style.font.bodySmall
+              font.pixelSize: root.menuSecondaryFontSize
               horizontalAlignment: Text.AlignHCenter
               elide: Text.ElideMiddle
             }
@@ -4022,7 +4052,7 @@ Item {
 
           Column {
             anchors.centerIn: parent
-            spacing: Style.space(8)
+            spacing: Math.max(Style.space(3), Math.round(Style.space(8) * root.menuItemScale))
             visible: !root.focusedExtension && displayModel.count === 0 && root.mode !== "input" && !root.workflowInputActive && (root.filterText || root.activeMenu !== "root") && !root.isPotentialExtensionQuery(root.filterText)
 
             Text {
@@ -4031,7 +4061,7 @@ Item {
               color: root.selectedText
               opacity: 0.8
               font.family: root.fontFamily
-              font.pixelSize: Style.font.displayLarge
+              font.pixelSize: Math.max(1, Math.round(Style.font.displayLarge * root.menuItemScale))
               horizontalAlignment: Text.AlignHCenter
               width: Style.space(320)
             }
@@ -4043,7 +4073,7 @@ Item {
               color: root.foreground
               opacity: 0.7
               font.family: root.fontFamily
-              font.pixelSize: Style.font.title
+              font.pixelSize: Math.max(1, Math.round(Style.font.title * root.menuItemScale))
               horizontalAlignment: Text.AlignHCenter
               width: Style.space(320)
             }
@@ -4090,7 +4120,7 @@ Item {
                   color: root.foreground
                   opacity: 0.68
                   font.family: root.fontFamily
-                  font.pixelSize: Style.font.bodySmall
+                  font.pixelSize: root.menuSecondaryFontSize
                   anchors.verticalCenter: parent.verticalCenter
                 }
 
@@ -4103,12 +4133,16 @@ Item {
 
                     Item {
                       required property string modelData
-                      width: Math.max(height, shortcutText.implicitWidth + Style.space(10))
-                      height: Math.max(Style.space(22), shortcutText.implicitHeight + Style.space(6))
+                      width: Math.max(height, shortcutText.implicitWidth
+                        + Math.max(Style.space(4), Math.round(Style.space(10) * root.menuItemScale)))
+                      height: Math.max(Style.space(14), Math.round(Style.space(22) * root.menuItemScale),
+                        shortcutText.implicitHeight
+                          + Math.max(Style.space(2), Math.round(Style.space(6) * root.menuItemScale)))
 
                       Rectangle {
                         anchors.fill: parent
-                        radius: Math.min(root.cornerRadius, Style.space(5))
+                        radius: Math.min(root.cornerRadius,
+                          Math.max(Style.space(2), Math.round(Style.space(5) * root.menuItemScale)))
                         color: "transparent"
                         border.width: Style.spacing.hairline
                         border.color: Util.alpha(root.foreground, 0.13)
@@ -4120,7 +4154,7 @@ Item {
                           color: root.foreground
                           opacity: 0.82
                           font.family: root.fontFamily
-                          font.pixelSize: Style.font.caption
+                          font.pixelSize: root.menuCaptionFontSize
                           font.weight: Font.Medium
                         }
                       }

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -1118,6 +1118,8 @@ function parseExtensionCatalog(text) {
 
   var providerPreferences = parsed && typeof parsed.providerPreferences === "object" && !Array.isArray(parsed.providerPreferences)
     ? parsed.providerPreferences : ({})
+  var omalaunchConfig = parsed && typeof parsed.omalaunchConfig === "object" && !Array.isArray(parsed.omalaunchConfig)
+    ? parsed.omalaunchConfig : ({})
   var providerConfig = parsed && typeof parsed.providerConfig === "object" && !Array.isArray(parsed.providerConfig)
     ? parsed.providerConfig : ({})
   var extensions = []
@@ -1159,7 +1161,8 @@ function parseExtensionCatalog(text) {
     }
   }
   return { extensions: resolved, diagnostics: diagnostics, valid: true, complete: complete,
-    providerConfig: providerConfig, migrationComplete: parsed && parsed.migrationComplete === true }
+    omalaunchConfig: omalaunchConfig, providerConfig: providerConfig,
+    migrationComplete: parsed && parsed.migrationComplete === true }
 }
 
 function parseExtensions(text) {

--- a/README.md
+++ b/README.md
@@ -160,11 +160,17 @@ Omalaunch core settings live in the dedicated `~/.config/omarchy/omalaunch/confi
 ```jsonc
 {
   "version": 1,
+  // Theme class for primary menu item text.
+  "menuItemFontClass": "title",
+  // Optional explicit override. Valid range: 8–24 pixels.
+  // "menuItemFontSize": 15,
   "capabilities": {
     "files": { "provider": "omalaunch.files" },
   },
 }
 ```
+
+`menuItemFontClass` accepts `caption`, `bodySmall`, `body`, `subtitle`, `title`, `heading`, `display`, or `displayLarge`. It defaults to `title`. If `menuItemFontSize` is set, its explicit pixel size takes priority over the theme class.
 
 Bundled provider settings use provider-ID JSONC files under the configuration directory. Interactive data uses provider-ID JSON state under `${XDG_STATE_HOME:-~/.local/state}`. Replacement providers do not inherit either namespace. See [PROVIDER-CONFIGURATION.md](PROVIDER-CONFIGURATION.md) for the separate version-1 schemas and migration rules. Quicklinks does not import external or unreleased data.
 

--- a/libexec/load-extensions.py
+++ b/libexec/load-extensions.py
@@ -470,12 +470,36 @@ def load_user_configuration(home: Path, builder: CatalogBuilder, limits: Limits)
                 if not isinstance(provider, str) or not provider:
                     builder.diagnostic(f"Ignored invalid provider for capability {capability!r} in {main_path}")
                     continue
-                builder.provider_preferences[capability] = provider
                 normalized_capabilities[capability] = {"provider": provider}
+            menu_item_font_class = value.get("menuItemFontClass")
+            valid_font_classes = {
+                "caption", "bodySmall", "body", "subtitle", "title",
+                "heading", "display", "displayLarge",
+            }
+            if menu_item_font_class is not None and (
+                not isinstance(menu_item_font_class, str)
+                or menu_item_font_class not in valid_font_classes
+            ):
+                raise ValueError("menuItemFontClass must be a supported Style.font class")
+            menu_item_font_size = value.get("menuItemFontSize")
+            if menu_item_font_size is not None and (
+                not isinstance(menu_item_font_size, int)
+                or isinstance(menu_item_font_size, bool)
+                or not 8 <= menu_item_font_size <= 24
+            ):
+                raise ValueError("menuItemFontSize must be an integer from 8 to 24")
+            builder.provider_preferences = {
+                capability: setting["provider"]
+                for capability, setting in normalized_capabilities.items()
+            }
             builder.omalaunch_config = {
                 "version": 1,
                 "capabilities": normalized_capabilities,
             }
+            if menu_item_font_class is not None:
+                builder.omalaunch_config["menuItemFontClass"] = menu_item_font_class
+            if menu_item_font_size is not None:
+                builder.omalaunch_config["menuItemFontSize"] = menu_item_font_size
         except (OSError, UnicodeDecodeError, ValueError) as error:
             builder.diagnostic(f"Could not load configuration {main_path}: {error}")
 

--- a/tests/extension-loader-test.py
+++ b/tests/extension-loader-test.py
@@ -150,7 +150,7 @@ elif mode == 'integer-overflow':
 
     config_root = home / ".config" / "omarchy" / "omalaunch"
     (config_root / "extensions").mkdir(parents=True)
-    (config_root / "config.jsonc").write_text('{\n// selection\n"version": 1, "capabilities": {"files": {"provider": "chosen",},},\n}')
+    (config_root / "config.jsonc").write_text('{\n// selection\n"version": 1, "menuItemFontClass": "title", "menuItemFontSize": 14, "capabilities": {"files": {"provider": "chosen",},},\n}')
     (config_root / "extensions" / "omalaunch.files.jsonc").write_text('{"version": 1, "includeGitIgnored": true,}')
 
     catalog = run_loader(plugin_root, omarchy_root, home, env)
@@ -158,6 +158,8 @@ elif mode == 'integer-overflow':
           and catalog["omalaunchConfig"] == {
               "version": 1,
               "capabilities": {"files": {"provider": "chosen"}},
+              "menuItemFontClass": "title",
+              "menuItemFontSize": 14,
           }
           and catalog["providerConfig"]["omalaunch.files"] == {"version": 1, "includeGitIgnored": True, "favorites": []},
           "bounded JSONC loads core and provider configuration")
@@ -167,6 +169,28 @@ elif mode == 'integer-overflow':
           "bundled, static, and successful dynamic definitions coexist")
     check(not marker.exists() and next(item for item in catalog["extensions"] if item.get("id") == "argument")["label"] == hostile_argument,
           "provider arguments are passed literally without shell interpretation")
+
+    for boundary in (8, 24):
+        (config_root / "config.jsonc").write_text(json.dumps({"version": 1, "menuItemFontSize": boundary}))
+        boundary_catalog = run_loader(plugin_root, omarchy_root, home, env)
+        check(boundary_catalog["omalaunchConfig"].get("menuItemFontSize") == boundary,
+              f"core menu font size boundary {boundary} is accepted")
+    for invalid_size in (7, 25, True, 12.5):
+        (config_root / "config.jsonc").write_text(json.dumps({
+            "version": 1,
+            "menuItemFontSize": invalid_size,
+            "capabilities": {"files": {"provider": "chosen"}},
+        }))
+        invalid_font_catalog = run_loader(plugin_root, omarchy_root, home, env)
+        check(invalid_font_catalog["omalaunchConfig"] == {}
+              and invalid_font_catalog["providerPreferences"] == {}
+              and "menuItemFontSize must be an integer from 8 to 24" in "\n".join(invalid_font_catalog["diagnostics"]),
+              f"invalid core menu font size {invalid_size!r} is rejected atomically")
+    (config_root / "config.jsonc").write_text('{"version":1,"menuItemFontClass":"large"}')
+    invalid_font_class_catalog = run_loader(plugin_root, omarchy_root, home, env)
+    check(invalid_font_class_catalog["omalaunchConfig"] == {}
+          and "menuItemFontClass must be a supported Style.font class" in "\n".join(invalid_font_class_catalog["diagnostics"]),
+          "invalid core menu font classes are rejected")
     check("emitted invalid JSON" in messages, "malformed provider output produces a diagnostic")
     check("exited with code 7" in messages and "provider setup failed" in messages,
           "provider failures include exit status and bounded stderr")

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -721,10 +721,14 @@ const configuredProviderCatalog = menu.parseExtensionCatalog(JSON.stringify({
   extensions: [
     { schemaVersion: 1, id: 'default-files', capability: 'files', mode: 'files', label: 'Default', prefixes: ['default'], command: ['true'], _bundled: true },
     { schemaVersion: 1, id: 'chosen-files', capability: 'files', mode: 'files', label: 'Chosen', prefixes: ['chosen'], command: ['true'], priority: -10 }
-  ], providerPreferences: { files: 'chosen-files' }, providerConfig: { 'default-files': { includeGitIgnored: true }, 'chosen-files': { includeGitIgnored: false } }
+  ], providerPreferences: { files: 'chosen-files' }, omalaunchConfig: { version: 1, menuItemFontClass: 'title', menuItemFontSize: 14 },
+  providerConfig: { 'default-files': { includeGitIgnored: true }, 'chosen-files': { includeGitIgnored: false } }
 }))
 assert(configuredProviderCatalog.extensions[0].id === 'chosen-files' && configuredProviderCatalog.extensions[0].config.includeGitIgnored === false,
   'provider configuration selects an available id and configuration follows provider identity')
+assert(configuredProviderCatalog.omalaunchConfig.menuItemFontClass === 'title'
+  && configuredProviderCatalog.omalaunchConfig.menuItemFontSize === 14,
+  'validated core launcher settings pass through the extension catalog')
 const missingProviderCatalog = menu.parseExtensionCatalog(JSON.stringify({
   extensions: [{ schemaVersion: 1, id: 'fallback', capability: 'files', mode: 'files', label: 'Fallback', prefixes: ['fallback'], command: ['true'] }],
   providerPreferences: { files: 'missing' }

--- a/tests/qml-extension-path-test.js
+++ b/tests/qml-extension-path-test.js
@@ -161,6 +161,41 @@ assert(qml.includes('function openWorkflowActions()')
   && qml.includes('root.openWorkflowActions()')
   && qml.includes('id: workflowConfirm'),
 'dynamic rows expose host-rendered contextual actions and confirmations')
+assert(qml.includes('readonly property real menuItemScale: menuItemFontSize / Style.font.body')
+  && qml.includes('readonly property int menuItemIconSize: Math.max(Style.space(10), Math.min(Style.space(32),')
+  && qml.includes('Math.round(menuItemFontSize * 1.25)')
+  && qml.includes('font.pixelSize: root.menuItemIconSize')
+  && (qml.match(/width: root\.menuItemIconSize/g) || []).length === 2
+  && (qml.match(/height: root\.menuItemIconSize/g) || []).length === 2,
+'menu icons and image previews scale with the configured item font size')
+assert(qml.includes('property int baseRowHeight: Math.max(Style.space(28), Math.round(Style.space(44) * menuItemScale))')
+  && qml.includes('property int detailRowHeight: Math.max(Style.space(36), Math.round(Style.space(52) * menuItemScale))')
+  && qml.includes('Math.round(Style.space(18) * menuItemScale)')
+  && qml.includes('property int rowSpacing: Math.max(Style.space(1), Math.round(Style.spacing.xs * menuItemScale))'),
+'menu row padding and spacing scale with the configured item font size')
+assert(qml.includes('property string menuItemFontClass: "title"')
+  && qml.includes('? catalog.omalaunchConfig.menuItemFontClass : "title"'),
+'menu items use the title theme class when no font override is configured')
+assert((qml.match(/font\.pixelSize: root\.menuItemFontSize/g) || []).length === 6
+  && (qml.match(/font\.pixelSize: root\.menuSecondaryFontSize/g) || []).length === 3
+  && qml.includes('font.pixelSize: root.menuCaptionFontSize')
+  && qml.includes('property int headerHeight: Math.max(Style.space(28), Math.round(Style.space(34) * menuItemScale))')
+  && qml.includes('property int actionBarHeight: Math.max(Style.space(26), Math.round(Style.space(36) * menuItemScale))'),
+'search text, item details, and footer content scale with the configured item font size')
+assert(qml.includes('readonly property real actionBarFontScale: menuItemFontSize / Style.font.title')
+  && qml.includes('Math.round(Style.space(560) * Math.max(1, actionBarFontScale))'),
+'action bar compaction accounts for increased footer font sizes')
+assert(qml.includes('font.pixelSize: row.starred ? root.menuSecondaryFontSize : root.menuItemFontSize'),
+'trailing menu glyphs scale with the configured item font size')
+assert(qml.includes('width: Math.max(height, shortcutText.implicitWidth')
+  && qml.includes('Math.round(Style.space(10) * root.menuItemScale)')
+  && qml.includes('height: Math.max(Style.space(14), Math.round(Style.space(22) * root.menuItemScale),')
+  && qml.includes('Math.round(Style.space(6) * root.menuItemScale)'),
+'footer keycaps scale their padding and remain at least as wide as they are tall')
+assert(qml.includes('font.pixelSize: Math.max(1, Math.round(Style.font.displayLarge * root.menuItemScale))')
+  && qml.includes('font.pixelSize: Math.max(1, Math.round(Style.font.title * root.menuItemScale))')
+  && qml.includes('spacing: Math.max(Style.space(3), Math.round(Style.space(8) * root.menuItemScale))'),
+'empty-result icon, message, and spacing scale with the configured item font size')
 assert(qml.includes('readonly property color dialogBackground: Qt.rgba(background.r, background.g, background.b, 1)')
   && (qml.match(/background: root\.dialogBackground/g) || []).length === 3,
 'confirmation cards use one theme-compatible opaque surface')


### PR DESCRIPTION
## Summary

- add theme-class and explicit-size settings for menu item typography
- default menu items to the smaller `title` style and scale related icons, rows, search text, empty states, and footer controls
- validate explicit sizes from 8 to 24 pixels and reject invalid core configuration atomically
- compact footer actions when larger text needs more horizontal space

## Configuration

`menuItemFontClass` accepts Omarchy `Style.font` classes. An optional `menuItemFontSize` explicit override takes priority.

## Tests

- full test suite
- boundary and invalid font configuration coverage
- QML source-path coverage for proportional layout bindings