### PR TITLE
Add an Omalaunch settings menu

### DIFF
--- a/Menu.qml
+++ b/Menu.qml
@@ -164,6 +164,7 @@ Item {
   property int fileScanSerial: 0
   readonly property string fileIndexHelper: root.pluginPath + "/extensions/files/file-index.py"
   readonly property string extensionLoaderHelper: root.pluginPath + "/libexec/load-extensions.py"
+  readonly property string configHelper: root.pluginPath + "/libexec/omalaunch-config"
   readonly property string fileIndexInstanceId: Date.now() + "-" + Math.floor(Math.random() * 1000000000)
   readonly property string fileIndexPathPrefix: Quickshell.env("XDG_RUNTIME_DIR")
     ? Quickshell.env("XDG_RUNTIME_DIR") + "/omalaunch-file-index-" + root.fileIndexInstanceId
@@ -177,6 +178,7 @@ Item {
   property string fileCopyFeedbackPath: ""
   property string fileCopyFeedback: ""
   property bool actionPanelActive: false
+  property string settingsFeedback: ""
   property var actionPanelFile: null
   readonly property var selectedFileRow: root.fileBrowserActive && !root.actionPanelActive && root.cursorActive
     && root.selectedIndex >= 0 && root.selectedIndex < displayModel.count
@@ -1414,14 +1416,48 @@ Item {
       label: "Extensions",
       title: "Extensions"
     })
+    nextItems.settings = root.normalizeItem("settings", {
+      icon: "󰒓",
+      label: "Omalaunch Settings",
+      title: "Omalaunch Settings"
+    })
+    nextItems["settings.font-size"] = root.normalizeItem("settings.font-size", {
+      parent: "settings",
+      kind: "menu",
+      icon: "󰛖",
+      label: "Font Size",
+      title: "Font Size"
+    })
+    var fontOptions = [
+      ["compact", "Compact", "bodySmall"],
+      ["small", "Small", "body"],
+      ["default", "Default", "title"],
+      ["large", "Large", "heading"],
+      ["extra-large", "Extra Large", "display"]
+    ]
+    for (var optionIndex = 0; optionIndex < fontOptions.length; optionIndex++) {
+      var option = fontOptions[optionIndex]
+      nextItems["settings.font-size." + option[0]] = root.normalizeItem("settings.font-size." + option[0], {
+        parent: "settings.font-size",
+        kind: "action",
+        icon: "·",
+        label: option[1],
+        description: option[2],
+        action: option[2]
+      })
+    }
     for (var id in nextItems) {
-      if (id === "root" || id === "omarchy" || id === "extensions") continue
+      if (id === "root" || id === "omarchy" || id === "extensions" || id === "settings") continue
       if (nextItems[id].parent === "root") nextItems[id] = Object.assign({}, nextItems[id], { parent: "omarchy" })
     }
-    var nextOrder = mergedMenu.itemOrder.filter(function(id) { return id !== "omarchy" && id !== "extensions" })
+    var nextOrder = mergedMenu.itemOrder.filter(function(id) {
+      return id !== "omarchy" && id !== "extensions" && id !== "settings"
+    })
     var rootIndex = nextOrder.indexOf("root")
     var insertAt = rootIndex >= 0 ? rootIndex + 1 : 0
-    nextOrder.splice(insertAt, 0, "omarchy", "extensions")
+    nextOrder.splice(insertAt, 0, "omarchy", "extensions", "settings", "settings.font-size")
+    for (var fontOptionIndex = 0; fontOptionIndex < fontOptions.length; fontOptionIndex++)
+      nextOrder.splice(insertAt + 4 + fontOptionIndex, 0, "settings.font-size." + fontOptions[fontOptionIndex][0])
     root.items = nextItems
     root.itemOrder = nextOrder
     root.rebuildItemMetadata()
@@ -1804,12 +1840,13 @@ Item {
     if (query) {
       var diagnosticRows = []
       var preparedQuery = MenuModel.prepareSearchQuery(query)
-      var liveResult = root.extensionQuery === root.effectiveExtensionQuery() ? root.extensionResult : ""
+      var settingsSearchScoped = root.settingsPageActive()
+      var liveResult = !settingsSearchScoped && root.extensionQuery === root.effectiveExtensionQuery() ? root.extensionResult : ""
       for (var i = 0; !root.focusedExtension && i < root.itemOrder.length; i++) {
         var entry = root.item(root.itemOrder[i])
         if (!entry || entry.id === "root") continue
         if (MenuModel.isSearchExcluded(root.items, entry.id, root.searchExcludedRoots, root.itemMetadata)) continue
-        if (!root.isDescendantOf(entry.id, active)) continue
+        if (settingsSearchScoped ? entry.parent !== active : !root.isDescendantOf(entry.id, active)) continue
         if (!root.matchesQuery(entry, preparedQuery)) continue
 
         var detail = root.parentPathFor(entry.id)
@@ -1888,7 +1925,8 @@ Item {
         }
       }
 
-      var activeExtensionCatalog = root.focusedExtension ? [root.focusedExtension] : root.extensions
+      var activeExtensionCatalog = settingsSearchScoped ? []
+        : (root.focusedExtension ? [root.focusedExtension] : root.extensions)
       // A focused prefix extension has a hidden global prefix and one literal
       // prompt action. It must not rediscover its own root/suggestion rows.
       var focusedPrefix = MenuModel.focusedPrefixMatch(root.focusedExtension, query)
@@ -1950,7 +1988,7 @@ Item {
         else diagnosticRows.push(extensionRow)
       }
 
-      if (root.unavailableResultExtension) {
+      if (!settingsSearchScoped && root.unavailableResultExtension) {
         var unavailableDetail = MenuModel.unavailableExtensionDetail(root.unavailableResultExtension)
         var unavailableItem = root.normalizeItem("extension.unavailable." + root.unavailableResultExtension.id, {
           icon: root.unavailableResultExtension.icon,
@@ -2144,6 +2182,10 @@ Item {
     revealCursor()
   }
 
+  function settingsPageActive() {
+    return root.activeMenu === "settings" || root.activeMenu.indexOf("settings.") === 0
+  }
+
   function setFilter(nextFilter) {
     if (root.actionPanelActive) return
     if (root.workflowActive && root.workflowNode && root.workflowNode.kind === "input")
@@ -2159,9 +2201,30 @@ Item {
       root.scheduleFileScan()
       return
     }
-    if (!root.dmenuActive && root.filterText.trim()) root.loadProvidersForSearch()
+    if (!root.dmenuActive && root.filterText.trim() && !root.settingsPageActive()) root.loadProvidersForSearch()
     root.rebuildDisplay()
-    root.scheduleExtensionQuery()
+    if (root.settingsPageActive()) root.invalidateExtensionQuery("settings search is locally scoped")
+    else root.scheduleExtensionQuery()
+  }
+
+  function openSettings() {
+    root.resetForOpen()
+    root.openRoute("settings")
+  }
+
+  function isFontSizeSetting(id) {
+    return String(id || "").indexOf("settings.font-size.") === 0
+  }
+
+  function setMenuItemFontClass(fontClass) {
+    root.settingsFeedback = "Saving…"
+    if (settingsProc.running) {
+      settingsProc.queuedFontClass = fontClass
+      return
+    }
+    settingsProc.pendingFontClass = fontClass
+    settingsProc.command = [root.configHelper, "set-font-class", fontClass]
+    settingsProc.running = true
   }
 
   function setActiveMenu(id, pushHistory, fromPointer) {
@@ -2306,6 +2369,10 @@ Item {
         root.opened = false
         root.runAction(openCommand)
       }
+      return
+    }
+    if (root.isFontSizeSetting(row.itemId)) {
+      root.setMenuItemFontClass(row.action)
       return
     }
     if (row.itemId !== "extension.result") usage.record(row.itemId)
@@ -3426,6 +3493,28 @@ Item {
   }
 
   Process {
+    id: settingsProc
+    property string pendingFontClass: ""
+    property string queuedFontClass: ""
+    onExited: function(exitCode) {
+      if (exitCode === 0 && pendingFontClass) {
+        root.menuItemFontClass = pendingFontClass
+        root.configuredMenuItemFontSize = 0
+        root.settingsFeedback = ""
+        root.rebuildDisplay()
+        root.loadExtensions(true)
+      } else root.settingsFeedback = "Could not save font size"
+      pendingFontClass = ""
+      if (queuedFontClass) {
+        var nextFontClass = queuedFontClass
+        queuedFontClass = ""
+        Qt.callLater(function() { root.setMenuItemFontClass(nextFontClass) })
+      }
+      Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+    }
+  }
+
+  Process {
     id: guardProc
     property string collected: ""
     stdout: SplitParser {
@@ -3527,7 +3616,10 @@ Item {
             return
           }
 
-          if (root.workflowInputActive
+          if (!root.dmenuActive && event.key === Qt.Key_Comma && (event.modifiers & Qt.ControlModifier)) {
+            root.openSettings()
+            event.accepted = true
+          } else if (root.workflowInputActive
               && ((event.key === Qt.Key_V && (event.modifiers & Qt.ControlModifier))
                 || (event.key === Qt.Key_Insert && (event.modifiers & Qt.ShiftModifier)))) {
             if (!pasteProc.running) pasteProc.running = true
@@ -3825,7 +3917,8 @@ Item {
               Text {
                 id: iconText
                 visible: row.hasIcon && !row.isApp && !row.isImageFile
-                text: row.icon
+                text: root.isFontSizeSetting(row.itemId) && root.configuredMenuItemFontSize === 0
+                  && row.action === root.menuItemFontClass ? "✓" : row.icon
                 color: row.hasCursor ? root.selectedText : root.foreground
                 font.family: row.iconFont.length > 0 ? row.iconFont : root.fontFamily
                 font.pixelSize: root.menuItemIconSize
@@ -3899,8 +3992,11 @@ Item {
 
                 Text {
                   width: parent.width
-                  text: row.detail
-                  visible: (root.filterText || row.kind === "dmenu" || row.itemId === "extension.result.pending") && row.detail.length > 0
+                  text: root.isFontSizeSetting(row.itemId) && row.index === root.selectedIndex
+                    && root.settingsFeedback ? root.settingsFeedback : row.detail
+                  visible: (root.filterText || row.kind === "dmenu" || row.itemId === "extension.result.pending"
+                    || (root.isFontSizeSetting(row.itemId) && row.index === root.selectedIndex && root.settingsFeedback))
+                    && text.length > 0
                   color: root.foreground
                   opacity: 0.52
                   font.family: root.fontFamily

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ Omalaunch core settings live in the dedicated `~/.config/omarchy/omalaunch/confi
 
 `menuItemFontClass` accepts `caption`, `bodySmall`, `body`, `subtitle`, `title`, `heading`, `display`, or `displayLarge`. It defaults to `title`. If `menuItemFontSize` is set, its explicit pixel size takes priority over the theme class.
 
+Press `Ctrl+,` in Omalaunch to open **Omalaunch Settings**. The **Font Size** menu provides Compact, Small, Default, Large, and Extra Large theme-aware presets. Selecting a preset removes an explicit `menuItemFontSize` override so the chosen theme class can take effect.
+
 Bundled provider settings use provider-ID JSONC files under the configuration directory. Interactive data uses provider-ID JSON state under `${XDG_STATE_HOME:-~/.local/state}`. Replacement providers do not inherit either namespace. See [PROVIDER-CONFIGURATION.md](PROVIDER-CONFIGURATION.md) for the separate version-1 schemas and migration rules. Quicklinks does not import external or unreleased data.
 
 If a preferred provider is missing or unavailable, Omalaunch reports a diagnostic and uses its normal provider selection rules.

--- a/libexec/omalaunch-config
+++ b/libexec/omalaunch-config
@@ -103,14 +103,9 @@ def update_text(text: str, font_class: str) -> str:
         if top_level_keys.count(setting) > 1:
             raise ValueError(f"duplicate {setting} setting")
     text = remove_member(text, "menuItemFontSize")
+    text = remove_member(text, "menuItemFontClass")
     found, closing = members(text)
     encoded = json.dumps(font_class)
-    if "menuItemFontClass" in found:
-        start, _, _ = found["menuItemFontClass"]
-        token_list = list(tokens(text))
-        key_index = next(i for i, token in enumerate(token_list) if token[2] == start)
-        value_token = token_list[key_index + 2]
-        return text[:value_token[2]] + encoded + text[value_token[3]:]
     line_start = text.rfind("\n", 0, closing) + 1
     closing_indent = text[line_start:closing] if not text[line_start:closing].strip() else ""
     indent = "  "

--- a/libexec/omalaunch-config
+++ b/libexec/omalaunch-config
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Set Omalaunch's menu font class without normalizing its JSONC file."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+from pathlib import Path
+import stat
+import sys
+import tempfile
+
+FONT_CLASSES = ("caption", "bodySmall", "body", "subtitle", "title", "heading", "display", "displayLarge")
+MAX_BYTES = 64 * 1024
+
+
+def tokens(text: str):
+    """Yield (kind, value, start, end, depth) tokens outside JSONC comments."""
+    index = depth = 0
+    while index < len(text):
+        if text.startswith("//", index):
+            end = text.find("\n", index + 2); index = len(text) if end < 0 else end; continue
+        if text.startswith("/*", index):
+            end = text.find("*/", index + 2)
+            if end < 0: raise ValueError("unterminated block comment")
+            index = end + 2; continue
+        char = text[index]
+        if char == '"':
+            start = index; index += 1; escaped = False
+            while index < len(text):
+                char = text[index]; index += 1
+                if escaped: escaped = False
+                elif char == "\\": escaped = True
+                elif char == '"': break
+            else: raise ValueError("unterminated string")
+            raw = text[start:index]
+            yield "string", json.loads(raw), start, index, depth
+            continue
+        if char in "{[":
+            yield char, char, index, index + 1, depth; depth += 1
+        elif char in "}]":
+            depth -= 1; yield char, char, index, index + 1, depth
+        elif char in ":,": yield char, char, index, index + 1, depth
+        elif not char.isspace():
+            start = index
+            while index + 1 < len(text) and not text[index + 1].isspace() and text[index + 1] not in '{}[],:"': index += 1
+            yield "atom", text[start:index + 1], start, index + 1, depth
+        index += 1
+
+
+def members(text: str) -> tuple[dict[str, tuple[int, int, int | None]], int]:
+    items = list(tokens(text))
+    if not items or items[0][0] != "{" or items[-1][0] != "}" or items[-1][4] != 0:
+        raise ValueError("configuration must be one JSON object")
+    result: dict[str, tuple[int, int, int | None]] = {}
+    for position, token in enumerate(items):
+        kind, key, start, _, depth = token
+        if kind != "string" or depth != 1 or position + 1 >= len(items) or items[position + 1][0] != ":": continue
+        next_key = items[-1]
+        for next_position in range(position + 2, len(items) - 1):
+            candidate = items[next_position]
+            if (candidate[0] == "string" and candidate[4] == 1
+                    and items[next_position + 1][0] == ":"):
+                next_key = candidate
+                break
+        comma = None
+        for candidate in items[position + 2:]:
+            if candidate[2] >= next_key[2]: break
+            if candidate[0] == "," and candidate[4] == 1: comma = candidate[2]
+        result[key] = (start, next_key[2], comma)
+    return result, items[-1][2]
+
+
+def remove_member(text: str, name: str) -> str:
+    found, _ = members(text)
+    if name not in found: return text
+    start, end, comma = found[name]
+    line_start = text.rfind("\n", 0, start) + 1
+    if text[line_start:start].strip(): line_start = start
+    if comma is not None:
+        end = comma + 1
+        while end < len(text) and text[end] in " \t": end += 1
+        if end < len(text) and text[end] == "\n": end += 1
+        return text[:line_start] + text[end:]
+    # This is the last member. Remove the preceding top-level comma when needed.
+    previous_comma = max((token[2] for token in tokens(text[:start]) if token[0] == "," and token[4] == 1), default=None)
+    if previous_comma is not None:
+        start = previous_comma
+    return text[:start] + text[end:]
+
+
+def update_text(text: str, font_class: str) -> str:
+    # Parse first. This prevents a write when unrelated JSONC is malformed.
+    from load_extensions_compat import parse_jsonc
+    value = parse_jsonc(text)
+    if not isinstance(value, dict): raise ValueError("configuration must be one JSON object")
+    token_list = list(tokens(text))
+    top_level_keys = [token[1] for position, token in enumerate(token_list[:-1])
+                      if token[0] == "string" and token[4] == 1
+                      and token_list[position + 1][0] == ":"]
+    for setting in ("menuItemFontClass", "menuItemFontSize"):
+        if top_level_keys.count(setting) > 1:
+            raise ValueError(f"duplicate {setting} setting")
+    text = remove_member(text, "menuItemFontSize")
+    found, closing = members(text)
+    encoded = json.dumps(font_class)
+    if "menuItemFontClass" in found:
+        start, _, _ = found["menuItemFontClass"]
+        token_list = list(tokens(text))
+        key_index = next(i for i, token in enumerate(token_list) if token[2] == start)
+        value_token = token_list[key_index + 2]
+        return text[:value_token[2]] + encoded + text[value_token[3]:]
+    line_start = text.rfind("\n", 0, closing) + 1
+    closing_indent = text[line_start:closing] if not text[line_start:closing].strip() else ""
+    indent = "  "
+    if found:
+        first = min(item[0] for item in found.values())
+        first_line = text.rfind("\n", 0, first) + 1
+        if not text[first_line:first].strip(): indent = text[first_line:first]
+    prefix = text[:closing]
+    has_members = bool(found)
+    if has_members and not prefix.rstrip().endswith(","): prefix = prefix.rstrip() + "," + prefix[len(prefix.rstrip()):]
+    if not prefix.endswith("\n"): prefix += "\n"
+    return prefix + f'{indent}"menuItemFontClass": {encoded}\n{closing_indent}' + text[closing:]
+
+
+def parse_jsonc(text: str):
+    # Keep line positions while removing comments, then remove trailing commas.
+    chars = list(text); index = 0; string = escaped = False
+    while index < len(chars):
+        if string:
+            if escaped: escaped = False
+            elif chars[index] == "\\": escaped = True
+            elif chars[index] == '"': string = False
+            index += 1; continue
+        if chars[index] == '"': string = True; index += 1; continue
+        if text.startswith("//", index):
+            end = text.find("\n", index + 2); end = len(text) if end < 0 else end
+            for pos in range(index, end): chars[pos] = " "
+            index = end; continue
+        if text.startswith("/*", index):
+            end = text.find("*/", index + 2)
+            if end < 0: raise ValueError("unterminated block comment")
+            for pos in range(index, end + 2):
+                if chars[pos] != "\n": chars[pos] = " "
+            index = end + 2; continue
+        index += 1
+    cleaned = "".join(chars)
+    punctuation = list(tokens(cleaned))
+    for position, token in enumerate(punctuation[:-1]):
+        if token[0] == "," and punctuation[position + 1][0] in ("}", "]"):
+            chars[token[2]] = " "
+    return json.loads("".join(chars))
+
+
+# Alias used by update_text without depending on a hyphenated module name.
+sys.modules["load_extensions_compat"] = sys.modules[__name__]
+
+
+def file_identity(value: os.stat_result) -> tuple[int, int, int, int]:
+    return value.st_dev, value.st_ino, value.st_size, value.st_mtime_ns
+
+
+def read_existing(path: Path) -> tuple[str, tuple[int, int, int, int] | None]:
+    try:
+        descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+    except FileNotFoundError:
+        return "{}\n", None
+    with os.fdopen(descriptor, "rb") as source:
+        before = os.fstat(source.fileno())
+        if not stat.S_ISREG(before.st_mode):
+            raise ValueError("configuration must be a regular file")
+        raw = source.read(MAX_BYTES + 1)
+        after = os.fstat(source.fileno())
+    if file_identity(before) != file_identity(after):
+        raise ValueError("configuration changed while it was read")
+    if len(raw) > MAX_BYTES:
+        raise ValueError(f"configuration exceeds {MAX_BYTES} bytes")
+    return raw.decode("utf-8"), file_identity(after)
+
+
+def atomic_write(path: Path, data: str, expected: tuple[int, int, int, int] | None) -> None:
+    encoded = data.encode("utf-8")
+    if len(encoded) > MAX_BYTES: raise ValueError(f"result exceeds {MAX_BYTES} bytes")
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "wb") as output:
+            output.write(encoded); output.flush(); os.fsync(output.fileno())
+        try:
+            current = file_identity(path.lstat())
+        except FileNotFoundError:
+            current = None
+        if current != expected:
+            raise ValueError("configuration changed before it could be saved")
+        os.replace(temporary, path)
+        directory = os.open(path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        try: os.fsync(directory)
+        finally: os.close(directory)
+    except Exception:
+        try: os.unlink(temporary)
+        except FileNotFoundError: pass
+        raise
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3 or argv[1] != "set-font-class" or argv[2] not in FONT_CLASSES:
+        print(f"usage: {Path(argv[0]).name} set-font-class {{{','.join(FONT_CLASSES)}}}", file=sys.stderr)
+        return 2
+    path = Path(os.environ.get("HOME", str(Path.home()))) / ".config/omarchy/omalaunch/config.jsonc"
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    lock_path = path.with_name(path.name + ".lock")
+    descriptor = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW, 0o600)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor) as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX)
+            text, expected = read_existing(path)
+            atomic_write(path, update_text(text, argv[2]), expected)
+    except (OSError, UnicodeError, ValueError, json.JSONDecodeError) as error:
+        print(f"{Path(argv[0]).name}: {error}", file=sys.stderr); return 1
+    return 0
+
+
+if __name__ == "__main__": raise SystemExit(main(sys.argv))

--- a/tests/menu-font-class-settings-test.py
+++ b/tests/menu-font-class-settings-test.py
@@ -47,6 +47,17 @@ with tempfile.TemporaryDirectory() as temporary:
     check(stat.S_IMODE(config.stat().st_mode) == 0o600, "configuration is private")
     check(stat.S_IMODE(config.with_name("config.jsonc.lock").stat().st_mode) == 0o600, "lock is private")
 
+for invalid_existing_value in ('{"bad":true}', '["bad"]'):
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary); config = root / ".config/omarchy/omalaunch/config.jsonc"
+        config.parent.mkdir(parents=True)
+        config.write_text('{"version":1,"menuItemFontClass":' + invalid_existing_value + ',"capabilities":{}}')
+        result = run(root, "title")
+        check(result.returncode == 0, result.stderr)
+        parsed = PARSE_JSONC(config.read_text())
+        check(parsed == {"version": 1, "menuItemFontClass": "title", "capabilities": {}},
+              f"complete {invalid_existing_value[0]} font-class value is replaced")
+
 with tempfile.TemporaryDirectory() as temporary:
     root = Path(temporary)
     result = run(root, "caption")

--- a/tests/menu-font-class-settings-test.py
+++ b/tests/menu-font-class-settings-test.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+import os
+from pathlib import Path
+import runpy
+import stat
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+COMMAND = ROOT / "libexec/omalaunch-config"
+PARSE_JSONC = runpy.run_path(str(COMMAND))["parse_jsonc"]
+
+
+def run(home: Path, value: str):
+    env = os.environ.copy(); env["HOME"] = str(home)
+    return subprocess.run([str(COMMAND), "set-font-class", value], env=env, text=True, capture_output=True)
+
+
+def check(condition, message):
+    if not condition: raise AssertionError(message)
+
+
+with tempfile.TemporaryDirectory() as temporary:
+    root = Path(temporary); config = root / ".config/omarchy/omalaunch/config.jsonc"
+    config.parent.mkdir(parents=True)
+    original = '''{
+  // Keep this provider choice.
+  "version": 1,
+  "menuItemFontClass": "body",
+  "menuItemFontSize": 17, // explicit override
+  "capabilities": {
+    "files": { "provider": "example.files" },
+  },
+}
+'''
+    config.write_text(original)
+    result = run(root, "displayLarge")
+    check(result.returncode == 0, result.stderr)
+    changed = config.read_text()
+    check('"menuItemFontClass": "displayLarge"' in changed, "class is changed")
+    check("menuItemFontSize" not in changed, "pixel override is removed")
+    parsed = PARSE_JSONC(changed)
+    check(parsed["menuItemFontClass"] == "displayLarge" and "menuItemFontSize" not in parsed,
+          "updated configuration remains valid JSONC")
+    check("// Keep this provider choice." in changed and '"files": { "provider": "example.files" },' in changed,
+          "unrelated comments and formatting remain")
+    check(stat.S_IMODE(config.stat().st_mode) == 0o600, "configuration is private")
+    check(stat.S_IMODE(config.with_name("config.jsonc.lock").stat().st_mode) == 0o600, "lock is private")
+
+with tempfile.TemporaryDirectory() as temporary:
+    root = Path(temporary)
+    result = run(root, "caption")
+    check(result.returncode == 0, result.stderr)
+    config = root / ".config/omarchy/omalaunch/config.jsonc"
+    check(config.read_text() == '{\n  "menuItemFontClass": "caption"\n}\n', "missing configuration is created")
+
+with tempfile.TemporaryDirectory() as temporary:
+    root = Path(temporary); config = root / ".config/omarchy/omalaunch/config.jsonc"
+    config.parent.mkdir(parents=True); malformed = '{ "version": 1, /* broken'
+    config.write_text(malformed)
+    result = run(root, "title")
+    check(result.returncode == 1 and config.read_text() == malformed, "malformed input is not changed")
+
+with tempfile.TemporaryDirectory() as temporary:
+    root = Path(temporary); config = root / ".config/omarchy/omalaunch/config.jsonc"
+    config.parent.mkdir(parents=True)
+    duplicate = '{"version":1,"menuItemFontSize":12,"menuItemFontSize":13}'
+    config.write_text(duplicate)
+    result = run(root, "body")
+    check(result.returncode == 1 and config.read_text() == duplicate,
+          "duplicate font settings are rejected without changing configuration")
+
+with tempfile.TemporaryDirectory() as temporary:
+    root = Path(temporary); config = root / ".config/omarchy/omalaunch/config.jsonc"
+    config.parent.mkdir(parents=True)
+    target = root / "target.jsonc"; target.write_text('{"version":1}')
+    config.symlink_to(target)
+    result = run(root, "body")
+    check(result.returncode == 1 and target.read_text() == '{"version":1}',
+          "symbolic-link configuration is rejected without reading or changing its target")
+
+with tempfile.TemporaryDirectory() as temporary:
+    root = Path(temporary)
+    result = run(root, "large")
+    check(result.returncode == 2, "unsupported class is rejected")
+    check(not (root / ".config/omarchy/omalaunch/config.jsonc").exists(), "invalid input does not create configuration")
+
+print("menu font class settings tests passed")

--- a/tests/qml-extension-path-test.js
+++ b/tests/qml-extension-path-test.js
@@ -176,6 +176,32 @@ assert(qml.includes('property int baseRowHeight: Math.max(Style.space(28), Math.
 assert(qml.includes('property string menuItemFontClass: "title"')
   && qml.includes('? catalog.omalaunchConfig.menuItemFontClass : "title"'),
 'menu items use the title theme class when no font override is configured')
+assert(qml.includes('event.key === Qt.Key_Comma && (event.modifiers & Qt.ControlModifier)')
+  && qml.includes('root.openRoute("settings")')
+  && qml.includes('label: "Omalaunch Settings"')
+  && qml.includes('label: "Font Size"'),
+'Ctrl+Comma opens the built-in Omalaunch font settings menu')
+assert(qml.includes('function settingsPageActive()')
+  && qml.includes('var settingsSearchScoped = root.settingsPageActive()')
+  && qml.includes('settingsSearchScoped ? entry.parent !== active : !root.isDescendantOf(entry.id, active)')
+  && qml.includes('var activeExtensionCatalog = settingsSearchScoped ? []')
+  && qml.includes('if (!settingsSearchScoped && root.unavailableResultExtension)')
+  && qml.includes('root.invalidateExtensionQuery("settings search is locally scoped")'),
+'settings searches include only direct children and suppress global extension results')
+assert(qml.includes('["compact", "Compact", "bodySmall"]')
+  && qml.includes('["small", "Small", "body"]')
+  && qml.includes('["default", "Default", "title"]')
+  && qml.includes('["large", "Large", "heading"]')
+  && qml.includes('["extra-large", "Extra Large", "display"]'),
+'font settings expose friendly names for theme font classes')
+assert(qml.includes('settingsProc.command = [root.configHelper, "set-font-class", fontClass]')
+  && qml.includes('root.configuredMenuItemFontSize = 0')
+  && qml.includes('root.settingsFeedback = "Saving…"')
+  && qml.includes('root.settingsFeedback = "Could not save font size"')
+  && qml.includes('settingsProc.queuedFontClass = fontClass')
+  && qml.includes('root.configuredMenuItemFontSize === 0')
+  && qml.includes('row.action === root.menuItemFontClass ? "✓" : row.icon'),
+'font settings save through the bounded helper and mark the active class')
 assert((qml.match(/font\.pixelSize: root\.menuItemFontSize/g) || []).length === 6
   && (qml.match(/font\.pixelSize: root\.menuSecondaryFontSize/g) || []).length === 3
   && qml.includes('font.pixelSize: root.menuCaptionFontSize')


### PR DESCRIPTION
## Summary

- add an Omalaunch Settings area available with `Ctrl+,`
- add theme-aware Font Size presets with active-state indicators and immediate updates
- preserve JSONC configuration while removing explicit pixel overrides when a preset is selected
- show save progress and failures, and queue repeated selections
- scope search results to the current settings page

## Font size presets

- Compact
- Small
- Default
- Large
- Extra Large

## Safety

- use locked, atomic, private configuration writes
- reject symlinks, malformed JSONC, duplicate settings, and concurrent file changes

## Tests

- full test suite
- configuration mutation, validation, symlink, and duplicate-setting coverage
- QML routing, search scope, persistence, feedback, and preset coverage