### PR TITLE
Add Kagi as a default web search engine

### DIFF
--- a/PROVIDER-CONFIGURATION.md
+++ b/PROVIDER-CONFIGURATION.md
@@ -69,7 +69,7 @@ The array defaults to `[]` and has at most 256 unique values. A replacement prov
 
 ## Web Search
 
-The optional `omalaunch.web-search.jsonc` configuration defines 1 to 32 search engines. A missing file supplies Google, DuckDuckGo, Bing, Brave Search, and Ecosia. Each engine has a stable `id`, display `name`, and absolute HTTP(S) `url` template with exactly one `{query}` placeholder:
+The optional `omalaunch.web-search.jsonc` configuration defines 1 to 32 search engines. A missing file supplies Google, DuckDuckGo, Bing, Brave Search, Ecosia, and Kagi. Each engine has a stable `id`, display `name`, and absolute HTTP(S) `url` template with exactly one `{query}` placeholder:
 
 ```jsonc
 {

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This workaround can be removed once Omarchy supports setting a widget’s sectio
 - Copy calculation results directly to the clipboard
 - Browse, recursively search, open, copy paths, and star local files and directories
 - Look up current times and convert times across DST-aware timezones
-- Search with Google, DuckDuckGo, Bing, Brave Search, or Ecosia
+- Search with Google, DuckDuckGo, Bing, Brave Search, Ecosia, or Kagi
 - Accept dmenu-style select and input requests
 - Load extensions contributed by enabled Omarchy plugins
 - Launch agent prompts such as Pi and Codex through optional extensions

--- a/libexec/provider_config.py
+++ b/libexec/provider_config.py
@@ -15,6 +15,7 @@ DEFAULT_SEARCH_ENGINES=[
     {"id":"bing","name":"Bing","url":"https://www.bing.com/search?q={query}"},
     {"id":"brave","name":"Brave Search","url":"https://search.brave.com/search?q={query}"},
     {"id":"ecosia","name":"Ecosia","url":"https://www.ecosia.org/search?q={query}"},
+    {"id":"kagi","name":"Kagi","url":"https://kagi.com/search?q={query}"},
 ]
 
 

--- a/tests/provider-config-runtime-test.py
+++ b/tests/provider-config-runtime-test.py
@@ -11,7 +11,7 @@ with tempfile.TemporaryDirectory() as raw:
     for provider in pc.PROVIDERS: check(pc.load_state(provider,home)==pc.state_default(provider),provider+" has missing-state defaults")
     check(pc.load_config("omalaunch.files",home)=={"version":1,"includeGitIgnored":False},"Files has a missing-config default")
     check(pc.load_config("omalaunch.quicklinks",home)=={"version":1,"rankByUsage":True},"Quicklinks has an enabled missing-config default")
-    check(len(pc.load_config("omalaunch.web-search",home)["engines"])==5,"Web Search has default engines")
+    check(len(pc.load_config("omalaunch.web-search",home)["engines"])==6,"Web Search has default engines")
     for provider in ("omalaunch.apps","omalaunch.extensions"):
         check(not pc.config_path(provider,home).exists(),provider+" has no meaningless config file")
     config=pc.config_path("omalaunch.files",home); config.parent.mkdir(parents=True)
@@ -31,7 +31,7 @@ with tempfile.TemporaryDirectory() as raw:
     check(pc.load_state("omalaunch.web-search",home)=={"version":1,"globalSearchExcludedEngines":["bing"],"starredEngines":["google"]},"Web Search stores global search exclusions and stars in state")
     web_search=subprocess.run([ROOT/"extensions/web-search/web-search","menu"],env=env,check=True,capture_output=True,text=True)
     search_items=json.loads(web_search.stdout)["items"]
-    check([item["id"] for item in search_items]==["search-brave","search-duckduckgo","search-ecosia","search-google","search-bing"],"Web Search sorts global engines by name before excluded engines")
+    check([item["id"] for item in search_items]==["search-brave","search-duckduckgo","search-ecosia","search-google","search-kagi","search-bing"],"Web Search sorts global engines by name before excluded engines")
     check(search_items[-1]["globalSearch"] is False and search_items[-1]["description"]=="Web Search menu","excluded engines remain usable in the Web Search menu")
     check(search_items[0]["trailingIcon"] and search_items[-1]["trailingIcon"]=="","only global engines receive the trailing globe icon")
     google=next(item for item in search_items if item["id"]=="search-google")

--- a/tests/provider-config-schema-test.py
+++ b/tests/provider-config-schema-test.py
@@ -38,7 +38,7 @@ for provider,value in valid.items():
 check(pc.validate_config("omalaunch.files",{"version":1,"includeGitIgnored":True})["includeGitIgnored"],"valid Files JSONC shape passes")
 check(pc.validate_config("omalaunch.quicklinks",{"version":1})["rankByUsage"],"Quicklinks usage ranking defaults to true")
 check(not pc.validate_config("omalaunch.quicklinks",{"version":1,"rankByUsage":False})["rankByUsage"],"Quicklinks usage ranking can be disabled")
-check(len(pc.config_default("omalaunch.web-search")["engines"])==5 and pc.config_default("omalaunch.web-search")["rankByUsage"] is True,"Web Search supplies five default engines and enables usage ranking")
+check(len(pc.config_default("omalaunch.web-search")["engines"])==6 and pc.config_default("omalaunch.web-search")["rankByUsage"] is True,"Web Search supplies six default engines and enables usage ranking")
 check(pc.validate_config("omalaunch.web-search",{"version":1,"engines":[{"id":"example","name":"Example","url":"https://example.test/?q={query}"}]})["engines"][0]["id"]=="example","Web Search accepts a safe engine template")
 check(pc.validate_config("omalaunch.web-search",{"version":1,"rankByUsage":False,"engines":[{"id":"example","name":"Example","url":"https://example.test/?q={query}"}]})["rankByUsage"] is False,"Web Search usage ranking can be disabled")
 try: pc.validate_state("omalaunch.web-search",{"version":1,"globalSearchExcludedEngines":["google"],"starredEngines":["google"]},Path("/home/test"))


### PR DESCRIPTION
## Summary

Adds [Kagi](https://kagi.com/) to the bundled Web Search engine defaults, alongside Google, DuckDuckGo, Bing, Brave Search, and Ecosia. Kagi is a popular paid, ad-free search engine and a natural fit for the existing list.

- `libexec/provider_config.py` — add `{"id":"kagi","name":"Kagi","url":"https://kagi.com/search?q={query}"}` to `DEFAULT_SEARCH_ENGINES`
- `README.md` / `PROVIDER-CONFIGURATION.md` — mention Kagi in the engine list
- `tests/provider-config-schema-test.py`, `tests/provider-config-runtime-test.py` — update the default engine count (5 → 6) and the sorted menu-order assertion

Users who define their own `omalaunch.web-search.jsonc` are unaffected; this only changes the missing-file defaults.

## Testing

```
python tests/provider-config-schema-test.py
python tests/provider-config-runtime-test.py
python tests/provider-config-migration-test.py
node tests/menu-model-test.js
python -m py_compile libexec/provider_config.py
```

All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)