### PR TITLE
Improve Files actions and parent navigation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,11 @@ jobs:
 
       - name: Run Settings overlay navigation tests
         run: tests/settings-overlay-navigation-test.js
+      - name: Run Files action panel tests
+        run: node tests/files-action-panel-test.js
+
+      - name: Run Files parent navigation tests
+        run: node tests/file-parent-navigation-test.js
 
       - name: Run Quickshell live-query process harness when available
         run: bash tests/live-query-process-integration-test.sh

--- a/Menu.qml
+++ b/Menu.qml
@@ -7,6 +7,7 @@ import qs.Commons
 import qs.Ui
 import "MenuModel.js" as MenuModel
 import "MenuLayout.js" as MenuLayout
+import "MenuFiles.js" as MenuFiles
 import "MenuMarkdown.js" as MenuMarkdown
 import "extensions/currency" as CurrencyExtension
 
@@ -198,6 +199,7 @@ Item {
   readonly property string extensionLoaderHelper: root.pluginPath + "/libexec/load-extensions.py"
   readonly property string configHelper: root.pluginPath + "/libexec/omalaunch-config"
   readonly property string providerConfigHelper: root.pluginPath + "/libexec/provider-config"
+  readonly property string agentLauncher: root.pluginPath + "/libexec/omalaunch-launch-agent"
   readonly property string fileIndexInstanceId: Date.now() + "-" + Math.floor(Math.random() * 1000000000)
   readonly property string fileIndexPathPrefix: Quickshell.env("XDG_RUNTIME_DIR")
     ? Quickshell.env("XDG_RUNTIME_DIR") + "/omalaunch-file-index-" + root.fileIndexInstanceId
@@ -212,12 +214,15 @@ Item {
   property string fileCopyFeedbackPath: ""
   property string fileCopyFeedback: ""
   property bool actionPanelActive: false
+  property bool agentToolsAvailable: false
   property string settingsFeedback: ""
   property var actionPanelFile: null
   readonly property var selectedFileRow: root.fileBrowserActive && !root.actionPanelActive && root.cursorActive
     && root.selectedIndex >= 0 && root.selectedIndex < displayModel.count
     ? displayModel.get(root.selectedIndex) : null
   readonly property string selectedFilePath: root.selectedFileRow ? String(root.selectedFileRow.action || "") : ""
+  readonly property bool selectedFileNavigation: !!root.selectedFileRow
+    && root.selectedFileRow.itemId === "file.navigation.parent"
   readonly property bool imagePreviewActive: MenuModel.isImagePath(root.selectedFilePath)
   readonly property var selectedWorkflowNode: root.workflowActive && !root.fileBrowserActive
     && root.workflowNode && root.workflowNode.kind === "menu" && root.cursorActive
@@ -344,7 +349,8 @@ Item {
       : rowListHeight(layoutSerial, displayModel.count, filterText, searchDivider)))
   property int visibleRowsHeight: MenuLayout.imagePreviewRowsHeight(root.imagePreviewActive,
     root.naturalRowsHeight, root.imagePreviewMinRowsHeight, root.availableRowsHeight())
-  readonly property bool workflowFilterMenuActive: root.workflowActive && root.workflowNode && root.workflowNode.kind === "menu"
+  readonly property bool filterMenuHintActive: root.actionPanelActive
+    || (root.workflowActive && root.workflowNode && root.workflowNode.kind === "menu")
   readonly property bool canConfigureExtension: root.workflowActive && root.workflowExtension
     && root.workflowExtension.mode === "menu" && root.workflowNode && root.workflowNode.id === "root"
     && root.workflowExtension.configurationProvider === root.workflowExtension.id
@@ -353,7 +359,7 @@ Item {
     && (root.workflowNode.refreshable === true
       || (root.workflowNode.refreshable == null && root.workflowExtension.refreshable))
     && (root.workflowNode.id === "root" || root.workflowNode.reloadCommand)
-  property int workflowHintHeight: (root.workflowInputActive || root.workflowFilterMenuActive)
+  property int workflowHintHeight: (root.workflowInputActive || root.filterMenuHintActive)
     ? Math.max(Style.space(12), Math.round(Style.space(18) * menuItemScale)) : 0
   property int cardHeight: Math.min(contentMargin + actionBarBottomPadding + headerHeight + actionBarHeight + contentSpacing
     + (visibleRowsHeight > 0 ? contentSpacing + visibleRowsHeight : 0)
@@ -361,16 +367,19 @@ Item {
 
   readonly property var actionBarHints: MenuModel.actionBarHints({
     primaryActionLabel: MenuModel.selectedPrimaryActionLabel({
+      selectedFileNavigation: root.selectedFileNavigation,
       workflowInputActive: root.workflowInputActive,
       workflowNode: root.workflowNode,
       selectedWorkflowNode: root.selectedWorkflowNode,
-      selectedDynamicSearchNode: root.selectedDynamicSearchEntry ? root.selectedDynamicSearchEntry.node : null
+      selectedDynamicSearchNode: root.selectedDynamicSearchEntry
     }),
     dmenuActive: root.dmenuActive,
     dmenuInput: root.dmenuActive && root.mode === "input",
     workflowActive: root.workflowActive,
     workflowInputActive: root.workflowInputActive,
     fileBrowserActive: root.fileBrowserActive,
+    fileSelectionType: root.selectedFileRow && root.selectedFileRow.itemId.indexOf("file.item.") === 0
+      ? "file" : "directory",
     directoryPickerActive: root.directoryPickerActive,
     actionPanelActive: root.actionPanelActive,
     canRefresh: root.canRefreshWorkflow,
@@ -382,7 +391,9 @@ Item {
       || (root.selectedDynamicSearchEntry && root.selectedDynamicSearchEntry.node.actions.length > 0),
     focusedExtension: !!root.focusedExtension,
     hasSelection: displayModel.count > 0 && root.cursorActive,
-    canStar: (!root.dmenuActive && !root.workflowActive && !root.actionPanelActive) || !!root.selectedWorkflowStarAction || !!root.selectedDynamicStarAction
+    fileActionsAvailable: !root.selectedFileNavigation,
+    canStar: !root.selectedFileNavigation
+      && ((!root.dmenuActive && !root.workflowActive && !root.actionPanelActive) || !!root.selectedWorkflowStarAction || !!root.selectedDynamicStarAction)
       && displayModel.count > 0 && root.cursorActive && root.selectedIndex >= 0
       && root.selectedIndex < displayModel.count
       && (root.fileBrowserActive || (displayModel.get(root.selectedIndex).itemId !== "omarchy"
@@ -477,7 +488,7 @@ Item {
       if (!root.workflowActive && root.selectedDynamicSearchEntry) root.openDynamicSearchActions()
       else if (root.workflowActive && !root.fileBrowserActive) root.openWorkflowActions()
       else if (root.fileBrowserActive) root.openActionPanel()
-    } else if (id === "copy") root.copySelectedFilePath()
+    } else if (id === "copy") root.copySelectedFile()
     else if (id === "star") {
       if (root.workflowActive) root.toggleSelectedWorkflowStar()
       else if (root.selectedDynamicStarAction) root.toggleSelectedDynamicStar()
@@ -1500,6 +1511,14 @@ Item {
     return slash <= 0 ? "/" : value.substring(0, slash)
   }
 
+  function navigateFileBrowserParent() {
+    root.fileBrowserPath = root.parentPath(root.fileBrowserPath)
+    root.filterText = ""
+    root.fileEntries = []
+    root.selectedIndex = 0
+    root.scheduleFileScan()
+  }
+
   function removeFileIndex(path) {
     if (path) Quickshell.execDetached(["rm", "-f", "--", path])
   }
@@ -1584,6 +1603,21 @@ Item {
       })
       displayModel.append(root.displayRow(selectItem, root.fileBrowserPath, -1))
     }
+    var homePath = Quickshell.env("HOME")
+    if (MenuModel.isHomeOrAncestorPath(root.fileBrowserPath, homePath)) {
+      var parentItem = root.normalizeItem("file.navigation.parent", {
+        icon: "󱧰",
+        label: "Parent directory",
+        description: root.parentPath(root.fileBrowserPath),
+        action: root.parentPath(root.fileBrowserPath)
+      })
+      var parentQuery = MenuModel.prepareSearchQuery(root.filterText.trim())
+      if (!parentQuery || MenuModel.matchesQuery(parentItem, parentQuery, true)) {
+        var parentRow = root.displayRow(parentItem, parentItem.description, -2)
+        parentRow.starred = false
+        displayModel.append(parentRow)
+      }
+    }
     for (var i = 0; i < root.fileEntries.length; i++) {
       var entry = root.fileEntries[i]
       var isDirectory = entry.type === "directory"
@@ -1608,60 +1642,52 @@ Item {
   function rebuildActionPanel() {
     displayModel.clear()
     if (!root.actionPanelFile || !root.fileBrowserExtension) return
-    var actions = root.actionPanelFile.type === "directory"
-      ? [
-          { id: "open-files", icon: "󰉋", label: "Open in Files" },
-          { id: "open-terminal", icon: "", label: "Open in terminal" }
-        ]
-      : [{ id: "open", icon: "󰈔", label: "Open" }]
-    actions = actions.concat([
-      {
-        id: "toggle-star",
-        icon: "★",
-        label: root.isFileFavoriteStarred(root.actionPanelFile.path, root.actionPanelFile.type)
-          ? "Unstar" : "Star"
-      },
-      { id: "copy-path", icon: "󰆏", label: "Copy path" },
-      { id: "copy-file", icon: "󰆏", label: "Copy file to clipboard" }
-    ])
+    var actions = MenuFiles.actionDefinitions(root.actionPanelFile.type,
+      root.isFileFavoriteStarred(root.actionPanelFile.path, root.actionPanelFile.type),
+      root.agentToolsAvailable)
+    var actionQuery = MenuModel.prepareSearchQuery(root.filterText.trim())
     for (var i = 0; i < actions.length; i++) {
       var action = actions[i]
       var item = root.normalizeItem("file.action." + action.id, {
         icon: action.icon,
         label: action.label,
-        description: root.actionPanelFile.path,
+        description: "",
         action: action.id
       })
+      if (actionQuery && !MenuModel.matchesQuery(item, actionQuery, true)) continue
       var row = root.displayRow(item, root.actionPanelFile.path, i)
       row.starred = false
       displayModel.append(row)
     }
     root.layoutSerial += 1
     root.selectedIndex = 0
-    root.cursorActive = true
-    Qt.callLater(function() { root.revealCursor() })
+    root.cursorActive = displayModel.count > 0
+    Qt.callLater(function() { if (displayModel.count > 0) root.revealCursor() })
   }
 
   function openActionPanel() {
     if (!root.fileBrowserActive || root.selectedIndex < 0 || root.selectedIndex >= displayModel.count) return
     var row = displayModel.get(root.selectedIndex)
-    if (!row || row.itemId.indexOf("file.") !== 0 || row.itemId.indexOf("file.action.") === 0) return
+    if (!row || (row.itemId.indexOf("file.item.") !== 0 && row.itemId.indexOf("file.directory.") !== 0)) return
     root.actionPanelFile = {
       index: root.selectedIndex,
       itemId: row.itemId,
       path: row.action,
       name: row.label,
-      type: row.itemId.indexOf("file.directory.") === 0 ? "directory" : "file"
+      type: row.itemId.indexOf("file.directory.") === 0 ? "directory" : "file",
+      filter: root.filterText
     }
+    root.filterText = ""
     root.actionPanelActive = true
     root.rebuildActionPanel()
   }
 
   function closeActionPanel() {
-    var previousIndex = root.actionPanelFile ? root.actionPanelFile.index : 0
+    var restored = MenuFiles.restoredBrowserState(root.actionPanelFile)
     root.actionPanelActive = false
     root.actionPanelFile = null
-    root.selectedIndex = previousIndex
+    root.filterText = restored.filter
+    root.selectedIndex = restored.index
     root.rebuildFileDisplay()
   }
 
@@ -1673,25 +1699,25 @@ Item {
     fileCopyProc.running = true
   }
 
-  function copySelectedFilePath() {
+  function copySelectedFile() {
     if (!root.fileBrowserActive || root.selectedIndex < 0 || root.selectedIndex >= displayModel.count) return
     var row = displayModel.get(root.selectedIndex)
-    if (!row || !root.fileBrowserExtension) return
-    root.startFileCopy(row.action, root.fileBrowserExtension.copyCommand, "Copied path")
+    if (!row || !root.fileBrowserExtension
+        || (row.itemId.indexOf("file.item.") !== 0 && row.itemId.indexOf("file.directory.") !== 0)) return
+    var isFile = row.itemId.indexOf("file.item.") === 0
+    root.startFileCopy(row.action,
+      isFile ? root.fileBrowserExtension.copyFileCommand : root.fileBrowserExtension.copyCommand,
+      isFile ? "Copied file" : "Copied path")
   }
 
   function activateFileAction(action) {
     if (!root.actionPanelFile || !root.fileBrowserExtension) return
     var path = root.actionPanelFile.path
     if (action === "toggle-star") {
-      var selectedItemId = root.actionPanelFile.itemId
-      var selectedType = root.actionPanelFile.type
-      var previousIndex = root.actionPanelFile.index
-      root.actionPanelActive = false
-      root.actionPanelFile = null
-      root.selectedIndex = previousIndex
-      root.pendingStarSelectionId = selectedItemId
-      root.toggleFileFavorite(path, selectedType)
+      var restored = MenuFiles.restoredBrowserState(root.actionPanelFile)
+      root.closeActionPanel()
+      root.pendingStarSelectionId = restored.itemId
+      root.toggleFileFavorite(restored.path, restored.type)
       return
     }
     if (action === "copy-path" || action === "copy-file") {
@@ -1702,10 +1728,18 @@ Item {
       return
     }
 
+    var actionDirectory = root.actionPanelFile.type === "directory" ? path : root.parentPath(path)
     var commandToRun = action === "open-terminal"
       ? root.fileBrowserExtension.terminalCommand
-      : (action === "open-files" ? root.fileBrowserExtension.directoryCommand : root.fileBrowserExtension.command)
-    var shellAction = root.shellCommand(commandToRun, { path: path })
+      : (action === "open-files" || action === "show-files"
+        ? root.fileBrowserExtension.directoryCommand
+        : (action === "start-agent"
+          ? [root.agentLauncher, "--dir", "{directory}"]
+          : root.fileBrowserExtension.command))
+    var shellAction = root.shellCommand(commandToRun, {
+      path: action === "show-files" ? actionDirectory : path,
+      directory: actionDirectory
+    })
     root.actionPanelActive = false
     root.fileBrowserActive = false
     root.resetFileIndex()
@@ -2552,7 +2586,14 @@ Item {
   }
 
   function setFilter(nextFilter) {
-    if (root.actionPanelActive) return
+    if (root.actionPanelActive) {
+      root.filterText = nextFilter
+      root.selectedIndex = 0
+      root.cursorActive = true
+      root.disarmPointer()
+      root.rebuildActionPanel()
+      return
+    }
     if (root.workflowActive && root.workflowNode && root.workflowNode.kind === "input")
       nextFilter = String(nextFilter || "").substring(0, root.workflowNode.maxLength)
     root.filterText = nextFilter
@@ -2749,6 +2790,10 @@ Item {
     }
     if (root.directoryPickerActive && row.itemId === "workflow.directory.select") {
       root.selectWorkflowDirectory(row.action)
+      return
+    }
+    if (root.fileBrowserActive && row.itemId === "file.navigation.parent") {
+      root.navigateFileBrowserParent()
       return
     }
     if (root.fileBrowserActive && row.itemId.indexOf("file.") === 0) {
@@ -3060,6 +3105,16 @@ Item {
       root.fileCopyFeedbackPath = ""
       root.fileCopyFeedback = ""
       if (root.fileBrowserActive) root.rebuildFileDisplay()
+    }
+  }
+
+  Process {
+    id: agentToolsCheckProc
+    command: ["python", "-c", "import shutil,sys; sys.exit(0 if shutil.which('omarchy-agent') and shutil.which('omarchy-default-agent') else 1)"]
+    running: true
+    onExited: function(exitCode) {
+      root.agentToolsAvailable = exitCode === 0
+      if (root.actionPanelActive) root.rebuildActionPanel()
     }
   }
 
@@ -4216,13 +4271,23 @@ Item {
           } else if (event.key === Qt.Key_Delete) {
             root.requestDeleteSelected()
             event.accepted = true
-          } else if (event.key === Qt.Key_Escape) {
-            if (root.actionPanelActive) root.closeActionPanel()
-            else if (root.workflowInputActive) root.workflowBack()
+          } else if (event.key === Qt.Key_Escape && event.modifiers === Qt.NoModifier) {
+            if (root.fileBrowserActive) {
+              var fileEscape = MenuModel.fileEscapeAction({
+                actionPanelActive: root.actionPanelActive,
+                hasFilter: !!root.filterText,
+                path: root.fileBrowserPath,
+                home: Quickshell.env("HOME"),
+                directoryPickerActive: root.directoryPickerActive
+              })
+              if (fileEscape === "close-actions") root.closeActionPanel()
+              else if (fileEscape === "clear-search") root.setFilter("")
+              else if (fileEscape === "parent") root.navigateFileBrowserParent()
+              else if (fileEscape === "leave-picker") root.workflowBack()
+              else root.leaveFileBrowser()
+            } else if (root.workflowInputActive) root.workflowBack()
             else if (root.focusedExtension) root.leaveFocusedExtension()
             else if (root.filterText) root.setFilter("")
-            else if (root.directoryPickerActive) root.workflowBack()
-            else if (root.fileBrowserActive) root.leaveFileBrowser()
             else if (root.workflowActive) root.workflowBack()
             else if (root.activeMenu !== "root") root.goBack()
             else root.cancel()
@@ -4245,17 +4310,14 @@ Item {
           } else if (!root.documentActive && Util.editsFilter(event, root.filterText)) {
             root.setFilter(Util.editedFilter(event, root.filterText))
             event.accepted = true
-          } else if ((event.key === Qt.Key_Backspace || event.key === Qt.Key_Left) && !root.filterText) {
+          } else if (event.key === Qt.Key_Left && !root.filterText) {
             if (root.actionPanelActive) root.closeActionPanel()
             else if (root.fileBrowserActive) {
               if (root.fileBrowserPath === "/") {
                 if (root.directoryPickerActive) root.workflowBack()
                 else root.leaveFileBrowser()
               } else {
-                root.fileBrowserPath = root.parentPath(root.fileBrowserPath)
-                root.fileEntries = []
-                root.selectedIndex = 0
-                root.scheduleFileScan()
+                root.navigateFileBrowserParent()
               }
             } else if (root.workflowActive) root.workflowBack()
             else if (root.focusedExtension) root.leaveFocusedExtension()
@@ -4274,12 +4336,7 @@ Item {
             root.select(6)
             event.accepted = true
           } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter || event.key === Qt.Key_Right) {
-            if (root.workflowInputActive) root.submitWorkflowInput()
-            else if (root.dmenuActive) {
-              if (root.mode === "input") root.applyDmenuSelection(root.filterText)
-              else if (displayModel.count > 0) root.activateIndex(root.cursorActive ? root.selectedIndex : 0)
-            } else if (root.cursorActive) root.activateIndex(root.selectedIndex)
-            else if (displayModel.count > 0) root.cursorActive = true
+            if (!root.triggerFooterAction("primary") && displayModel.count > 0) root.cursorActive = true
             event.accepted = true
           } else if (!root.documentActive && event.text && event.text.length === 1 && event.text.charCodeAt(0) >= 32 && event.text.charCodeAt(0) !== 127 && (event.modifiers === Qt.NoModifier || event.modifiers === Qt.ShiftModifier)) {
             root.setFilter(root.filterText + event.text)
@@ -4390,7 +4447,7 @@ Item {
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
             text: root.actionPanelActive
-              ? ("Actions for " + ((root.actionPanelFile && root.actionPanelFile.name) || "file"))
+              ? root.filterText
               : root.fileBrowserActive
                 ? (root.fileBrowserPath + (root.filterText ? "  ›  " + root.filterText : ""))
               : root.documentActive
@@ -4426,12 +4483,14 @@ Item {
         Text {
           width: parent.width
           height: root.workflowHintHeight
-          visible: root.workflowInputActive || root.workflowFilterMenuActive
+          visible: root.workflowInputActive || root.filterMenuHintActive
           text: root.workflowInputActive
             ? root.workflowText(root.workflowNode ? (root.workflowNode.prompt || root.workflowNode.label) : "")
-            : root.workflowText(root.workflowNode
-                ? root.workflowNode.label
-                : (root.workflowExtension ? root.workflowExtension.label : "Select an item"))
+            : (root.actionPanelActive
+              ? ((root.actionPanelFile && root.actionPanelFile.name) || "File")
+              : root.workflowText(root.workflowNode
+                  ? root.workflowNode.label
+                  : (root.workflowExtension ? root.workflowExtension.label : "Select an item")))
           color: root.foreground
           opacity: 0.58
           font.family: root.fontFamily

--- a/Menu.qml
+++ b/Menu.qml
@@ -371,7 +371,7 @@ Item {
       workflowInputActive: root.workflowInputActive,
       workflowNode: root.workflowNode,
       selectedWorkflowNode: root.selectedWorkflowNode,
-      selectedDynamicSearchNode: root.selectedDynamicSearchEntry
+      selectedDynamicSearchNode: root.selectedDynamicSearchEntry ? root.selectedDynamicSearchEntry.node : null
     }),
     dmenuActive: root.dmenuActive,
     dmenuInput: root.dmenuActive && root.mode === "input",

--- a/MenuFiles.js
+++ b/MenuFiles.js
@@ -1,0 +1,37 @@
+function actionDefinitions(type, starred, agentToolsAvailable) {
+  var actions = type === "directory"
+    ? [
+        { id: "open-files", icon: "󰉋", label: "Open in Files" },
+        { id: "open-terminal", icon: "", label: "Open in terminal" }
+      ]
+    : [
+        { id: "open", icon: "󰈔", label: "Open" },
+        { id: "show-files", icon: "󰉋", label: "Show in Files" }
+      ]
+
+  if (agentToolsAvailable)
+    actions.push({ id: "start-agent", icon: "󰚩", label: "Start Agent Here" })
+
+  actions.push({ id: "toggle-star", icon: "★", label: starred ? "Unstar" : "Star" })
+  actions.push({ id: "copy-path", icon: "󰆏", label: "Copy path" })
+  if (type === "file")
+    actions.push({ id: "copy-file", icon: "󰆏", label: "Copy file to clipboard" })
+  return actions
+}
+
+function restoredBrowserState(panelFile) {
+  return {
+    filter: panelFile ? String(panelFile.filter || "") : "",
+    index: panelFile ? Number(panelFile.index || 0) : 0,
+    itemId: panelFile ? String(panelFile.itemId || "") : "",
+    path: panelFile ? String(panelFile.path || "") : "",
+    type: panelFile ? String(panelFile.type || "") : ""
+  }
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    actionDefinitions: actionDefinitions,
+    restoredBrowserState: restoredBrowserState
+  }
+}

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -1904,8 +1904,28 @@ function footerActionDefinition(id) {
   return null
 }
 
+// Keep the footer limited to actions that the current launcher state accepts.
+function fileEscapeAction(state) {
+  var value = state || ({})
+  if (value.actionPanelActive) return "close-actions"
+  if (value.hasFilter) return "clear-search"
+  var path = normalizeFavoritePath(value.path)
+  var home = normalizeFavoritePath(value.home)
+  if (path === "/" || (home && path === home))
+    return value.directoryPickerActive ? "leave-picker" : "leave-files"
+  return path ? "parent" : "leave-files"
+}
+
+function isHomeOrAncestorPath(path, home) {
+  var value = normalizeFavoritePath(path)
+  var homePath = normalizeFavoritePath(home)
+  return !!value && value !== "/" && !!homePath
+    && (value === homePath || homePath.indexOf(value + "/") === 0)
+}
+
 function selectedPrimaryActionLabel(state) {
   var value = state || ({})
+  if (value.selectedFileNavigation) return "Go up"
   if (value.workflowInputActive && value.workflowNode) return value.workflowNode.primaryActionLabel || ""
   if (value.selectedWorkflowNode) return value.selectedWorkflowNode.primaryActionLabel || ""
   if (value.selectedDynamicSearchNode) return value.selectedDynamicSearchNode.primaryActionLabel || ""
@@ -1924,8 +1944,9 @@ function actionBarHints(state) {
 
   if (value.canRefresh) labels.refresh = "Refresh"
   var fileActionsAvailable = value.fileBrowserActive && value.hasSelection
+    && value.fileActionsAvailable !== false
     && !value.directoryPickerActive && !value.actionPanelActive
-  if (fileActionsAvailable) labels.copy = "Copy Path"
+  if (fileActionsAvailable) labels.copy = value.fileSelectionType === "file" ? "Copy" : "Copy Path"
   if (value.canStar) labels.star = value.starred ? "Unstar" : "Star"
   if (value.canContextActions || fileActionsAvailable) labels.actions = "Actions"
   if (value.canConfigure || value.canSettings) labels.settings = "Settings"
@@ -2046,6 +2067,8 @@ if (typeof module !== "undefined") {
     fileFavoriteLabel: fileFavoriteLabel,
     fileFavoriteItem: fileFavoriteItem,
     matchesFileFavoriteQuery: matchesFileFavoriteQuery,
+    fileEscapeAction: fileEscapeAction,
+    isHomeOrAncestorPath: isHomeOrAncestorPath,
     displayRow: displayRow,
     footerActionDefinitions: footerActionDefinitions,
     footerActionIdForShortcut: footerActionIdForShortcut,

--- a/libexec/omalaunch-launch-agent
+++ b/libexec/omalaunch-launch-agent
@@ -18,10 +18,10 @@ def fail(message: str) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--dir", required=True, dest="directory")
-    parser.add_argument("--prompt", required=True)
+    parser.add_argument("--prompt")
     args = parser.parse_args()
 
-    if not args.prompt.strip():
+    if args.prompt is not None and not args.prompt.strip():
         fail("--prompt must not be empty")
     expanded = os.path.expandvars(os.path.expanduser(args.directory))
     directory = Path(expanded)
@@ -41,7 +41,9 @@ def main() -> int:
 
     try:
         os.chdir(directory)
-        os.execvp("omarchy-agent", ["omarchy-agent", "--prompt", args.prompt])
+        command = ["omarchy-agent"]
+        if args.prompt is not None: command.extend(["--prompt", args.prompt])
+        os.execvp("omarchy-agent", command)
     except OSError as error:
         fail(f"cannot open the default agent: {error}")
 

--- a/tests/create-extension-agent-test.py
+++ b/tests/create-extension-agent-test.py
@@ -112,3 +112,22 @@ with tempfile.TemporaryDirectory() as temporary:
     check(result.returncode != 0
           and (home / ".config/omarchy/plugins" / f"{getpass.getuser()}.no-agent").is_dir(),
           "the shared launcher reports an unset default agent after workspace preparation")
+
+with tempfile.TemporaryDirectory() as temporary:
+    base = Path(temporary)
+    bin_dir = base / "bin"
+    workspace = base / "workspace"
+    record = base / "agent.json"
+    bin_dir.mkdir(); workspace.mkdir()
+    executable(bin_dir / "omarchy-default-agent", "#!/bin/sh\nprintf 'pi\\n'\n")
+    executable(bin_dir / "omarchy-agent", f'''#!/usr/bin/env python3
+import json, os, sys
+from pathlib import Path
+Path({str(record)!r}).write_text(json.dumps({{"cwd": os.getcwd(), "args": sys.argv[1:]}}))
+''')
+    env = dict(os.environ, PATH=f"{bin_dir}:{os.environ['PATH']}")
+    result = subprocess.run([str(ROOT / "libexec/omalaunch-launch-agent"), "--dir", str(workspace)],
+                            env=env, capture_output=True, text=True)
+    started = json.loads(record.read_text())
+    check(result.returncode == 0 and started == {"cwd": str(workspace), "args": []},
+          "the shared launcher can start an agent without an initial prompt")

--- a/tests/file-parent-navigation-test.js
+++ b/tests/file-parent-navigation-test.js
@@ -1,0 +1,90 @@
+const fs = require('fs')
+const path = require('path')
+const MenuModel = require('../MenuModel.js')
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+  console.log(`ok - ${message}`)
+}
+
+const qml = fs.readFileSync(path.join(__dirname, '..', 'Menu.qml'), 'utf8')
+
+function qmlFunction(name, arguments_) {
+  const marker = `function ${name}(`
+  const start = qml.indexOf(marker)
+  if (start < 0) throw new Error(`missing ${name}`)
+  const bodyStart = qml.indexOf('{', start)
+  let depth = 0
+  let end = bodyStart
+  for (; end < qml.length; end++) {
+    if (qml[end] === '{') depth++
+    else if (qml[end] === '}' && --depth === 0) break
+  }
+  return new Function(...arguments_, qml.slice(bodyStart + 1, end))
+}
+
+const navigateParent = qmlFunction('navigateFileBrowserParent', ['root'])
+const activateIndex = qmlFunction('activateIndex', ['root', 'displayModel', 'MenuModel', 'usage', 'Qt', 'keyCatcher', 'index', 'fromPointer'])
+const footerActionAvailable = qmlFunction('footerActionAvailable', ['root', 'id'])
+const triggerFooterAction = qmlFunction('triggerFooterAction', ['root', 'displayModel', 'id'])
+
+function navigationState() {
+  const root = {
+    fileBrowserPath: '/home/test',
+    filterText: 'parent',
+    fileEntries: [{ name: 'stale' }],
+    selectedIndex: 0,
+    fileBrowserActive: true,
+    directoryPickerActive: false,
+    workflowActive: false,
+    actionPanelActive: false,
+    deleteConfirmOpen: false,
+    dmenuActive: false,
+    cursorActive: true,
+    dynamicMenuSearchEntry: () => null,
+    extensionForRootId: () => null,
+    parentPath: value => value.substring(0, value.lastIndexOf('/')) || '/',
+    scheduleFileScan() {
+      this.scan = { path: this.fileBrowserPath, filter: this.filterText }
+    }
+  }
+  root.navigateFileBrowserParent = () => navigateParent(root)
+  return root
+}
+
+const parentItem = MenuModel.normalizeItem('file.navigation.parent', {
+  icon: '󱧰', label: 'Parent directory', description: '/home', action: '/home'
+})
+const parentRow = MenuModel.displayRow({}, [], {}, parentItem, parentItem.description, -2, '', {})
+assert(parentRow.itemId === 'file.navigation.parent' && parentRow.kind === 'action',
+  'the parent result is an actionable row')
+
+const displayModel = { count: 1, get: index => index === 0 ? parentRow : null }
+const usage = { record() { throw new Error('parent navigation must not record usage') } }
+
+const clickRoot = navigationState()
+activateIndex(clickRoot, displayModel, MenuModel, usage, {}, {}, 0, true)
+assert(clickRoot.fileBrowserPath === '/home' && clickRoot.filterText === ''
+  && clickRoot.fileEntries.length === 0 && clickRoot.scan.path === '/home' && clickRoot.scan.filter === '',
+  'click activation navigates up and scans the parent without the old filter')
+
+const enterRoot = navigationState()
+enterRoot.actionBarHints = MenuModel.actionBarHints({
+  fileBrowserActive: true,
+  fileSelectionType: 'directory',
+  hasSelection: true,
+  fileActionsAvailable: false,
+  primaryActionLabel: 'Go up'
+})
+enterRoot.footerActionAvailable = id => footerActionAvailable(enterRoot, id)
+enterRoot.activateIndex = index => activateIndex(enterRoot, displayModel, MenuModel, usage, {}, {}, index, false)
+assert(enterRoot.actionBarHints.map(hint => hint.id).join(',') === 'primary'
+  && enterRoot.actionBarHints[0].label === 'Go up',
+  'the selected parent row has only an available primary footer action')
+assert(triggerFooterAction(enterRoot, displayModel, 'primary') === true
+  && enterRoot.fileBrowserPath === '/home' && enterRoot.filterText === ''
+  && enterRoot.scan.path === '/home' && enterRoot.scan.filter === '',
+  'Enter activation uses the primary action, navigates up, and clears the scan filter')
+
+assert(parentItem.icon.codePointAt(0) === 0xF19F0,
+  'the parent row uses Nerd Font md-folder_arrow_up at U+F19F0')

--- a/tests/files-action-panel-test.js
+++ b/tests/files-action-panel-test.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const path = require('path')
+const files = require('../MenuFiles.js')
+const menu = require('../MenuModel.js')
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+  console.log(`ok - ${message}`)
+}
+
+const fileActions = files.actionDefinitions('file', false, true)
+assert(fileActions.map(action => action.id).join(',') === 'open,show-files,start-agent,toggle-star,copy-path,copy-file',
+  'file actions keep their activation identities and copy-file operation')
+assert(files.actionDefinitions('directory', true, true).find(action => action.id === 'toggle-star').label === 'Unstar',
+  'directory actions expose the current unstar activation')
+
+const actionItem = action => menu.normalizeItem(`file.action.${action.id}`, {
+  label: action.label,
+  description: '',
+  action: action.id
+})
+const pathQuery = menu.prepareSearchQuery('projects')
+assert(!fileActions.some(action => menu.matchesQuery(actionItem(action), pathQuery, true)),
+  'action search does not match the selected file path')
+const copyQuery = menu.prepareSearchQuery('copy path')
+assert(fileActions.filter(action => menu.matchesQuery(actionItem(action), copyQuery, true)).map(action => action.id).join(',') === 'copy-path',
+  'action search matches action labels and keeps the correct activation ID')
+
+const saved = { index: 7, itemId: 'file.item.6', path: '/home/test/projects/report.txt', type: 'file', filter: 'report' }
+const restored = files.restoredBrowserState(saved)
+assert(restored.filter === 'report' && restored.index === 7 && restored.itemId === 'file.item.6'
+  && restored.path === saved.path && restored.type === 'file',
+  'Star and Unstar restore the saved Files search and selected row')
+
+const withoutAgent = files.actionDefinitions('directory', false, false)
+assert(!withoutAgent.some(action => action.id === 'start-agent')
+  && withoutAgent.some(action => action.id === 'open-files')
+  && withoutAgent.some(action => action.id === 'copy-path'),
+  'missing optional agent tools remove only Start Agent Here')
+
+const qml = fs.readFileSync(path.join(__dirname, '..', 'Menu.qml'), 'utf8')
+assert(qml.includes('root.closeActionPanel()')
+  && qml.includes('root.pendingStarSelectionId = restored.itemId')
+  && qml.includes('description: ""'),
+  'QML uses the tested restoration and label-only action search paths')
+assert(qml.includes("shutil.which('omarchy-agent')")
+  && qml.includes("shutil.which('omarchy-default-agent')")
+  && qml.includes('root.agentToolsAvailable = exitCode === 0'),
+  'QML checks both optional agent tools without changing Files availability')

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -678,6 +678,17 @@ assert(fileActionHints.map(hint => hint.id).join(',') === 'primary,copy,star,act
 assert(fileActionHints.map(hint => `${hint.label}:${hint.shortcut}`).join(',')
   === 'Open:Enter,Copy Path:Ctrl C,Star:Ctrl S,Actions:Ctrl K',
   'the action bar lists every available file shortcut in registry order')
+const individualFileActionHints = menu.actionBarHints({
+  fileBrowserActive: true, fileSelectionType: 'file', hasSelection: true
+})
+assert(individualFileActionHints.some(hint => hint.id === 'copy' && hint.label === 'Copy' && hint.shortcut === 'Ctrl C'),
+  'the individual-file action bar offers Copy instead of Copy Path')
+const parentFileHints = menu.actionBarHints({
+  fileBrowserActive: true, fileSelectionType: 'directory', hasSelection: true,
+  fileActionsAvailable: false, primaryActionLabel: 'Go up'
+})
+assert(parentFileHints.map(hint => hint.id).join(',') === 'primary' && parentFileHints[0].label === 'Go up',
+  'the parent navigation row offers only its primary action')
 assert(menu.actionBarHints({ hasSelection: true, workflowActive: true, primaryActionLabel: dynamicMenu.items[0].primaryActionLabel })[0].label === 'Open',
   'dynamic rows can replace the default Continue footer label')
 assert(menu.selectedPrimaryActionLabel({ workflowInputActive: true, workflowNode: { primaryActionLabel: 'Create' } }) === 'Create',
@@ -726,6 +737,24 @@ assert(menu.compactActionBarHints(starredActionHints).map(hint => hint.label).jo
 const resetOpenState = menu.openStateReset({ workflowActive: true, fileBrowserActive: true })
 assert(resetOpenState.workflowActive === false && resetOpenState.workflowNode === null && resetOpenState.workflowStack.length === 0, 'new opens reset workflow state')
 assert(resetOpenState.fileBrowserActive === false && resetOpenState.directoryPickerActive === false && resetOpenState.fileBrowserExtension === null, 'new opens reset file browser and directory picker state')
+assert(menu.fileEscapeAction({ actionPanelActive: true, hasFilter: true, path: '/home/test/docs', home: '/home/test' }) === 'close-actions',
+  'Escape closes Files actions before it changes their saved search')
+assert(menu.fileEscapeAction({ hasFilter: true, path: '/home/test/docs', home: '/home/test' }) === 'clear-search',
+  'Escape clears a Files search before it navigates')
+assert(menu.fileEscapeAction({ path: '/home/test/docs', home: '/home/test' }) === 'parent',
+  'Escape below home navigates to the parent directory')
+assert(menu.fileEscapeAction({ path: '/home/test', home: '/home/test' }) === 'leave-files'
+  && menu.fileEscapeAction({ path: '/', home: '/home/test' }) === 'leave-files',
+  'Escape leaves Files at home and at the filesystem root')
+assert(menu.fileEscapeAction({ path: '/home', home: '/home/test' }) === 'parent',
+  'Escape continues parent navigation above home')
+assert(menu.fileEscapeAction({ path: '/', home: '/home/test', directoryPickerActive: true }) === 'leave-picker',
+  'Escape at the directory-picker root returns to its workflow')
+assert(menu.isHomeOrAncestorPath('/home/test', '/home/test')
+  && menu.isHomeOrAncestorPath('/home', '/home/test')
+  && !menu.isHomeOrAncestorPath('/home/test/docs', '/home/test')
+  && !menu.isHomeOrAncestorPath('/', '/home/test'),
+  'parent directory rows appear only at home and its non-root ancestors')
 assert(resetOpenState.focusedExtension === null && resetOpenState.actionPanelActive === false && resetOpenState.resultExtension === null, 'new opens reset focused and action-panel state')
 
 const bundledMissingQalc = menu.parseExtensions(JSON.stringify([{

--- a/tests/qml-extension-path-test.js
+++ b/tests/qml-extension-path-test.js
@@ -188,7 +188,7 @@ assert(qml.includes('id: dynamicMenuSearchKillTimer')
 'global menu preload cancellation escalates SIGTERM safely and disarms stale escalation on exit')
 assert(qml.includes(': root.workflowActive\n                ? root.filterText')
   && qml.includes('height: root.workflowHintHeight')
-  && qml.includes('visible: root.workflowInputActive || root.workflowFilterMenuActive')
+  && qml.includes('visible: root.workflowInputActive || root.filterMenuHintActive')
   && qml.includes('root.workflowNode ? (root.workflowNode.prompt || root.workflowNode.label)')
   && qml.includes('? root.workflowNode.label')
   && qml.includes(': "Select an item"'),


### PR DESCRIPTION
## Scope
- Make Files actions searchable by label with consistent header presentation.
- Restore file search and selection after action navigation and Star changes.
- Copy files to the clipboard; copy directory paths.
- Add Show in Files and unprompted Start Agent Here with optional-tool checks.
- Use Esc to clear search, then navigate up; leave Files at home or filesystem root.
- Add a safe Parent directory row at home and its ancestors. Backspace only edits text.

## Dependency
Stacked on pr/footer-actions. After that PR merges, rebase and retarget this PR to master. Settings, preview height, and screen selection are excluded. Shared-file conflicts with Settings were resolved and tested in a separate combined verification branch.

## Validation
Full isolated and combined test suites passed. Includes action search/state and parent-row click/Enter regression tests. Local navigation and action behavior was tested during development.

No release or version change is included.