### PR TITLE
Keep image previews usable in short file lists

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Run model tests
         run: node tests/menu-model-test.js
 
+      - name: Run menu layout tests
+        run: node tests/menu-layout-test.js
+
       - name: Test opening screen selection
         run: node tests/opening-screen-test.js
 

--- a/Menu.qml
+++ b/Menu.qml
@@ -6,6 +6,7 @@ import QtQuick
 import qs.Commons
 import qs.Ui
 import "MenuModel.js" as MenuModel
+import "MenuLayout.js" as MenuLayout
 import "MenuMarkdown.js" as MenuMarkdown
 import "extensions/currency" as CurrencyExtension
 
@@ -325,6 +326,7 @@ Item {
   property int rowSpacing: Math.max(Style.space(1), Math.round(Style.spacing.xs * menuItemScale))
   property int dividerHeight: Style.space(17)
   readonly property int emptyStateHeight: Math.max(Style.space(108), Math.round(Style.space(132) * menuItemScale))
+  readonly property int imagePreviewMinRowsHeight: Style.space(340)
   property bool searchDivider: false
   property int layoutSerial: 0
   property int cardWidth: Math.min(root.dmenuActive
@@ -332,12 +334,14 @@ Item {
     : Style.space(root.imagePreviewActive ? 900 : (root.documentActive ? 760 : 600)), panel.width - Style.gapsOut * 2)
   readonly property bool emptyRoot: !root.dmenuActive && !root.workflowActive
     && root.activeMenu === "root" && !root.filterText && displayModel.count === 0
-  property int visibleRowsHeight: root.emptyRoot || root.workflowInputActive ? 0
+  readonly property int naturalRowsHeight: root.emptyRoot || root.workflowInputActive ? 0
     : (root.documentActive ? Math.min(Style.space(520), Math.max(Style.space(260), panel.height - panel.pinnedTop
       - Style.gapsOut - root.contentMargin - root.actionBarBottomPadding - root.headerHeight
       - root.actionBarHeight - root.contentSpacing * 2))
     : (root.dmenuActive ? dmenuRowListHeight(layoutSerial, displayModel.count, filterText)
       : rowListHeight(layoutSerial, displayModel.count, filterText, searchDivider)))
+  property int visibleRowsHeight: MenuLayout.imagePreviewRowsHeight(root.imagePreviewActive,
+    root.naturalRowsHeight, root.imagePreviewMinRowsHeight, root.availableRowsHeight())
   readonly property bool workflowFilterMenuActive: root.workflowActive && root.workflowNode && root.workflowNode.kind === "menu"
   property int workflowHintHeight: (root.workflowInputActive || root.workflowFilterMenuActive)
     ? Math.max(Style.space(12), Math.round(Style.space(18) * menuItemScale)) : 0

--- a/MenuLayout.js
+++ b/MenuLayout.js
@@ -1,0 +1,12 @@
+function imagePreviewRowsHeight(imagePreviewActive, naturalHeight, minimumHeight, availableHeight) {
+  if (!imagePreviewActive) return naturalHeight
+
+  var available = Math.max(0, availableHeight)
+  return Math.min(available, Math.max(naturalHeight, minimumHeight))
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    imagePreviewRowsHeight: imagePreviewRowsHeight
+  }
+}

--- a/tests/menu-layout-test.js
+++ b/tests/menu-layout-test.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const path = require('path')
+const layout = require('../MenuLayout.js')
+
+function assertEqual(actual, expected, message) {
+  if (actual !== expected) throw new Error(`${message}: expected ${expected}, got ${actual}`)
+  console.log(`ok - ${message}`)
+}
+
+assertEqual(layout.imagePreviewRowsHeight(true, 92, 340, 480), 340,
+  'few image rows use the theme-scaled preview minimum')
+assertEqual(layout.imagePreviewRowsHeight(true, 430, 340, 480), 430,
+  'many image rows keep their natural height')
+assertEqual(layout.imagePreviewRowsHeight(true, 92, 340, 236), 236,
+  'a small screen bounds the preview above the footer')
+assertEqual(layout.imagePreviewRowsHeight(false, 92, 340, 480), 92,
+  'a non-image selection keeps its compact natural height')
+
+const qml = fs.readFileSync(path.join(__dirname, '..', 'Menu.qml'), 'utf8')
+if (!qml.includes('readonly property int imagePreviewMinRowsHeight: Style.space(340)')
+    || !qml.includes('MenuLayout.imagePreviewRowsHeight(root.imagePreviewActive,')) {
+  throw new Error('Menu.qml does not use the shared theme-scaled image preview layout rule')
+}
+console.log('ok - Menu.qml uses the tested image preview layout rule')


### PR DESCRIPTION
## Scope
- Give image previews a theme-scaled minimum height of 340 logical pixels.
- Bound the height by available panel space.
- Keep non-image views compact.

## Validation
Full isolated and combined test suites passed. Behavioral layout tests cover short lists, long lists, small screens, and non-image states; CI runs them. The preview size was confirmed during local testing.

Independent of the footer, Settings, and Files PRs. Shared layout conflicts may need resolution if those merge first. No release or version change is included.