### PR TITLE
Select the focused screen before opening Omalaunch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Run model tests
         run: node tests/menu-model-test.js
 
+      - name: Test opening screen selection
+        run: node tests/opening-screen-test.js
+
       - name: Run QML extension path tests
         run: node tests/qml-extension-path-test.js
 

--- a/Menu.qml
+++ b/Menu.qml
@@ -1,6 +1,7 @@
 import Quickshell
 import Quickshell.Io
 import Quickshell.Wayland
+import Quickshell.Hyprland
 import QtQuick
 import qs.Commons
 import qs.Ui
@@ -10,6 +11,20 @@ import "extensions/currency" as CurrencyExtension
 
 Item {
   id: root
+  property var openingScreen: null
+
+  function selectOpeningScreen() {
+    if (root.opened) return
+    var name = Hyprland.focusedMonitor ? Hyprland.focusedMonitor.name : ""
+    var screens = Quickshell.screens
+    for (var i = 0; i < screens.length; i++) {
+      if (screens[i].name === name) {
+        root.openingScreen = screens[i]
+        return
+      }
+    }
+    root.openingScreen = screens.length ? screens[0] : null
+  }
 
   // Injected by omarchy-shell when this plugin is summoned.
   property string omarchyPath: Quickshell.env("OMARCHY_PATH")
@@ -2795,6 +2810,7 @@ Item {
     cursorActive = true
     root.disarmPointer()
     root.evaluateGuards(false)
+    root.selectOpeningScreen()
     opened = true
     rebuildDisplay()
     invalidateVolatileProvider(activeMenu)
@@ -2841,6 +2857,7 @@ Item {
     selectedIndex = 0
     cursorActive = mode !== "input"
     root.disarmPointer()
+    root.selectOpeningScreen()
     opened = true
     rebuildDisplay()
 
@@ -3991,6 +4008,7 @@ Item {
 
   PanelWindow {
     id: panel
+    screen: root.openingScreen
     visible: root.opened && root.rowsLoaded
     anchors { top: true; bottom: true; left: true; right: true }
     color: "transparent"

--- a/tests/opening-screen-test.js
+++ b/tests/opening-screen-test.js
@@ -1,0 +1,30 @@
+const fs = require('fs')
+const vm = require('vm')
+const assert = require('assert')
+const qml = fs.readFileSync(require('path').join(__dirname, '../Menu.qml'), 'utf8')
+const start = qml.indexOf('  function selectOpeningScreen() {')
+const end = qml.indexOf('\n  }', start) + 4
+const screens = [{name: 'laptop'}, {name: 'external'}]
+const root = {opened: false, openingScreen: null}
+const Hyprland = {focusedMonitor: {name: 'external'}}
+const context = {root, Hyprland, Quickshell: {screens}}
+vm.createContext(context)
+vm.runInContext(qml.slice(start, end), context)
+context.selectOpeningScreen()
+assert.strictEqual(root.openingScreen, screens[1])
+root.opened = true
+Hyprland.focusedMonitor.name = 'laptop'
+context.selectOpeningScreen()
+assert.strictEqual(root.openingScreen, screens[1], 'do not move an open overlay')
+root.opened = false
+context.selectOpeningScreen()
+assert.strictEqual(root.openingScreen, screens[0])
+Hyprland.focusedMonitor = null
+context.selectOpeningScreen()
+assert.strictEqual(root.openingScreen, screens[0])
+context.Quickshell.screens = []
+context.selectOpeningScreen()
+assert.strictEqual(root.openingScreen, null)
+assert.strictEqual((qml.match(/root\.selectOpeningScreen\(\)\n    opened = true/g) || []).length, 2)
+assert(qml.includes('screen: root.openingScreen'))
+console.log('Opening screen tests passed')


### PR DESCRIPTION
## Problem
Intermittent opening showed a larger ghost menu near the top right. Geometry logging showed 21 opens initially reporting the laptop screen before changing to the external screen, with different screen scales.

## Change
Select the focused screen before making the overlay visible. Keep the selected screen stable while the overlay is open. Diagnostic logging is not included.

## Validation
After the change, 20 logged opens started on the correct screen without subsequent screen changes. Repeated local use showed no further ghost menu. Full isolated and combined suites passed. Added screen-selection regression tests and CI coverage.

Independent of the other PRs. No release or version change is included.