### PR TITLE
Fix helper paths with scoped plugin manifests

### DIFF
--- a/Menu.qml
+++ b/Menu.qml
@@ -30,7 +30,7 @@ Item {
 
   // Injected by omarchy-shell when this plugin is summoned.
   property string omarchyPath: Quickshell.env("OMARCHY_PATH")
-  readonly property string pluginPath: root.manifest && root.manifest.__sourceDir ? String(root.manifest.__sourceDir) : ""
+  readonly property string pluginPath: decodeURIComponent(String(Qt.resolvedUrl("."))).replace(/^file:\/\//, "").replace(/\/$/, "")
   property var shell: null
   property var manifest: null
 

--- a/tests/qml-extension-path-test.js
+++ b/tests/qml-extension-path-test.js
@@ -9,6 +9,19 @@ function assert(condition, message) {
 const qml = fs.readFileSync(path.join(__dirname, '..', 'Menu.qml'), 'utf8')
 const favoritesQml = fs.readFileSync(path.join(__dirname, '..', 'LauncherFavorites.qml'), 'utf8')
 
+const pluginPathExpression = qml.match(/readonly property string pluginPath: (.+)/)[1]
+for (const directory of ['/home/test/plugins/omalaunch', '/tmp/launcher with spaces/#100%']) {
+  const resolved = require('url').pathToFileURL(directory + '/').href
+  const actual = require('vm').runInNewContext(pluginPathExpression, {
+    Qt: { resolvedUrl: relative => {
+      if (relative !== '.') throw new Error('expected the component directory')
+      return resolved
+    } },
+    root: { manifest: { id: 'quantumfire.omalaunch' } }
+  })
+  assert(actual === directory, `helper paths resolve without private manifest fields: ${directory}`)
+}
+
 assert(favoritesQml.includes('Quickshell.env("XDG_STATE_HOME") || (Quickshell.env("HOME") + "/.local/state")')
   && favoritesQml.includes('root.stateHome + "/omarchy/starred-launcher-items.json"'),
 'legacy favorite compatibility reads the same XDG state root as startup migration')


### PR DESCRIPTION
## Summary

Resolve Omalaunch's helper directory from its own QML component URL instead of `manifest.__sourceDir`.

Omarchy now removes private fields from the manifest it gives third-party plugins. With Omalaunch 0.3.0 on `omarchy-dev 4.0.0.r2071.ga703092-1`, `pluginPath` became empty and opening the launcher logged:

```text
Process failed to start ... Command: QList("/libexec/load-extensions.py", "", "/usr/share/omarchy")
```

The same empty prefix affects provider configuration, agent, and file-index helper paths. `Qt.resolvedUrl(".")` locates the installed component without private host metadata or a hard-coded plugin directory. Decode URL escapes so paths containing spaces, `#`, and `%` remain usable.

## Validation

Passed:

- `node tests/qml-extension-path-test.js` — 80 assertions, including new cases without `__sourceDir` and with escaped path characters. The new regression fails on the original implementation.
- `node tests/menu-model-test.js` — 354 assertions.
- `PATH=/usr/bin:/bin /usr/bin/python3 tests/extension-loader-test.py` — 51 assertions. The explicit system PATH avoids a local mise shim rejecting the test's temporary HOME; no trust settings changed.
- `git diff --check`.

Applied the same one-line change to the installed plugin and restarted the shell: the helper resolves to the installed Omalaunch directory and the missing-executable error disappears. Settings were not reset.

## Companion host bug

The empty Apps menu also exposed a separate Omarchy bug: Qt's model conversion changes the nested manifest array's type, so the host fails its menu capability check and injects a null app library. It also omits the icon-refresh completion signal Omalaunch expects.

Companion fix and runtime regression: https://github.com/omacom/omarchy/pull/10671

This PR fixes helper lookup only. Restoring the app list on the affected host needs the companion fix as well. The patched full desktop has not yet been visually verified; the packaged Omarchy files remain unchanged.
