### PR TITLE
Fix interpolation and map-key safety for hostile data

### DIFF
--- a/LauncherUsage.qml
+++ b/LauncherUsage.qml
@@ -13,6 +13,14 @@ Item {
 
   signal changed()
 
+  function keyIn(map, id) {
+    return Object.prototype.hasOwnProperty.call(map, String(id))
+  }
+  function storeId(map, id, value) {
+    Object.defineProperty(map, String(id), { value: value, writable: true, enumerable: true, configurable: true })
+    return map
+  }
+
   function load(rawText) {
     var next = ({})
     try {
@@ -22,7 +30,7 @@ Item {
         var record = source[id]
         var count = Math.max(0, Number(record && record.count) || 0)
         var lastUsedAt = Math.max(0, Number(record && record.lastUsedAt) || 0)
-        if (id && count > 0) next[id] = { count: count, lastUsedAt: lastUsedAt }
+        if (id && count > 0 && keyIn(source, id)) storeId(next, id, { count: count, lastUsedAt: lastUsedAt })
       }
     } catch (e) {
       next = ({})
@@ -50,11 +58,11 @@ Item {
     var id = String(itemId || "")
     if (!root.loaded || !id) return
     var next = Object.assign({}, root.records)
-    var previous = next[id] || ({})
-    next[id] = {
+    var previous = keyIn(next, id) ? next[id] : ({})
+    storeId(next, id, {
       count: Math.max(0, Number(previous.count) || 0) + 1,
       lastUsedAt: Date.now()
-    }
+    })
     root.records = next
     root.save(next)
     root.changed()

--- a/Menu.qml
+++ b/Menu.qml
@@ -597,7 +597,7 @@ Item {
   }
 
   function item(id) {
-    return root.items[id] || null
+    return root.items && Object.prototype.hasOwnProperty.call(root.items, String(id)) ? root.items[id] : null
   }
 
   // ------------------------------------------------------------------
@@ -622,7 +622,7 @@ Item {
     for (var i = 0; i < command.length; i++) {
       var argument = String(command[i])
       for (var key in replacements)
-        argument = argument.replace(new RegExp("\\{" + key + "\\}", "g"), String(replacements[key]))
+        argument = argument.replace(new RegExp("\\{" + key + "\\}", "g"), (function(value) { return function() { return value } })(String(replacements[key])))
       parts.push(argument)
     }
     return parts

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -86,13 +86,13 @@ function mergeMenuSources(defaultItems, userItems) {
     for (var i = 0; i < src.length; i++) {
       var entry = src[i]
       if (!entry || !entry.id) continue
-      if (!nextItems[entry.id]) nextOrder.push(entry.id)
-      var prior = nextItems[entry.id] || {}
+      if (!keyIn(nextItems, entry.id)) nextOrder.push(entry.id)
+      var prior = keyIn(nextItems, entry.id) ? nextItems[entry.id] : {}
       var merged = {}
       for (var k in prior) merged[k] = prior[k]
       for (var k2 in entry) merged[k2] = entry[k2]
       merged.id = entry.id
-      nextItems[entry.id] = merged
+      putKey(nextItems, entry.id, merged)
     }
   }
 
@@ -127,19 +127,19 @@ function mergeAppRows(items, itemOrder, appRows) {
 
   for (var i = 0; i < order.length; i++) {
     var id = order[i]
-    var existing = source[id]
+    var existing = keyIn(source, id) ? source[id] : null
     // Orphans (an id with no item) are dropped rather than carried forward,
     // so a single lost write cannot compound into a duplicate row.
     if (!existing || existing.kind === "app") continue
-    nextItems[id] = existing
+    putKey(nextItems, id, existing)
     nextOrder.push(id)
   }
 
   for (var j = 0; j < rows.length; j++) {
     var row = rows[j]
-    if (!row || !row.id || nextItems[row.id]) continue
+    if (!row || !row.id || keyIn(nextItems, row.id)) continue
     row.order = nextOrder.length
-    nextItems[row.id] = row
+    putKey(nextItems, row.id, row)
     nextOrder.push(row.id)
   }
 
@@ -159,18 +159,18 @@ function swapProviderRows(items, itemOrder, menuId, rows) {
 
   for (var i = 0; i < order.length; i++) {
     var id = order[i]
-    var existing = source[id]
+    var existing = keyIn(source, id) ? source[id] : null
     if (!existing || existing.providerMenu === menuId) continue
-    nextItems[id] = existing
+    putKey(nextItems, id, existing)
     nextOrder.push(id)
   }
 
   for (var j = 0; j < incoming.length; j++) {
     var row = incoming[j]
-    if (!row || !row.id || nextItems[row.id]) continue
+    if (!row || !row.id || keyIn(nextItems, row.id)) continue
     row.providerMenu = menuId
     row.order = nextOrder.length
-    nextItems[row.id] = row
+    putKey(nextItems, row.id, row)
     nextOrder.push(row.id)
   }
 
@@ -178,7 +178,7 @@ function swapProviderRows(items, itemOrder, menuId, rows) {
 }
 
 function item(items, id) {
-  return items && items[id] ? items[id] : null
+  return keyIn(items, id) ? items[id] : null
 }
 
 // Structural IDs are supplied by menu authors. Prefix them before using plain
@@ -186,6 +186,20 @@ function item(items, id) {
 // collide with Object.prototype.
 function structuralKey(value) {
   return "$" + String(value || "")
+}
+
+// Plain objects serve as id -> row maps in the merges below. Guard both reads
+// and writes so hostile ids such as __proto__, constructor, or toString cannot
+// collide with Object.prototype: assigning an object to __proto__ re-points the
+// map's prototype, primitive writes are silently ignored, and prototype members
+// otherwise read as "already present". Keys are written as ordinary own
+// enumerable data properties, which shadow inherited accessors on lookup.
+function keyIn(map, id) {
+  return map !== null && typeof map === "object" && Object.prototype.hasOwnProperty.call(map, String(id))
+}
+function putKey(map, id, value) {
+  Object.defineProperty(map, String(id), { value: value, writable: true, enumerable: true, configurable: true })
+  return map
 }
 
 // Routes may name a real id (`system`, `setup.power`) or an alias declared in

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -999,3 +999,48 @@ const missingProviderCatalog = menu.parseExtensionCatalog(JSON.stringify({
 }))
 assert(missingProviderCatalog.extensions[0].id === 'fallback' && missingProviderCatalog.diagnostics.some(value => value.indexOf("is missing; normal provider resolution was used") >= 0),
   'a missing configured provider falls back with a diagnostic')
+
+// Hostile object-property names must stay ordinary merge keys: __proto__ must
+// not re-point the map's prototype, prototype members must not read as
+// "already present", and duplicates must be dropped exactly once.
+const hostileDefaultItems = [
+  { id: 'constructor', kind: 'menu', label: 'Constructor' },
+  { id: '__proto__', kind: 'menu', label: 'Proto' },
+  { id: 'toString', kind: 'menu', label: 'String' }
+]
+const hostileUserItems = [
+  { id: 'constructor', kind: 'menu', label: 'Constructor (custom)' },
+  { id: '__proto__', kind: 'menu', label: 'Proto (custom)' },
+  { id: 'root', kind: 'menu', label: 'Custom root' }
+]
+let hostileMerged = menu.mergeMenuSources(hostileDefaultItems, hostileUserItems)
+const hostileOrder = hostileMerged.itemOrder
+assert(hostileOrder.filter(id => id === 'constructor').length === 1, 'prototype-object names merge to a single row')
+assert(hostileOrder.filter(id => id === '__proto__').length === 1, '__proto__ merges to a single row')
+assert(hostileMerged.items['constructor'].label === 'Constructor (custom)', 'prototype-object names receive user overrides')
+assert(hostileMerged.items['toString'].label === 'String', 'prototype members do not block first-seen original names')
+assert(Object.getOwnPropertyDescriptor(hostileMerged.items, '__proto__') !== undefined, '__proto__ becomes an ordinary own key')
+assert(menu.item(hostileMerged.items, '__proto__') !== null, '__proto__ reads back through item()')
+const hostileRealmProto = Object.getPrototypeOf(menu.mergeMenuSources([], []).items)
+assert(Object.getPrototypeOf(hostileMerged.items) === hostileRealmProto, 'merging hostile names does not re-point the map prototype')
+assert(menu.item(hostileMerged.items, 'hasOwnProperty') === null, 'item() ignores inherited prototype members')
+
+let hostileApps = menu.mergeAppRows(hostileMerged.items, hostileMerged.itemOrder, [
+  { id: 'apps.__proto__', kind: 'app', label: 'App proto' },
+  { id: 'apps.constructor', kind: 'app', label: 'App constructor' },
+  { id: 'constructor', kind: 'menu', label: 'Dup' }
+])
+assert(hostileApps.items['apps.__proto__'].kind === 'app' && hostileApps.items['apps.constructor'].kind === 'app', 'app scans keep hostile object-property names')
+assert(hostileApps.itemOrder.filter(id => id === 'apps.__proto__').length === 1, 'hostile app rows are listed once')
+assert(hostileApps.items['constructor'].label === 'Constructor (custom)', 'mergeAppRows preserves hostile non-app rows')
+
+let hostileSwapped = menu.swapProviderRows(hostileApps.items, hostileApps.itemOrder, 'hostile-menu', [
+  { id: 'constructor.child', kind: 'action', label: 'Child' },
+  { id: '__proto__.child', kind: 'action', label: 'Proto child' }
+])
+assert(hostileSwapped.itemOrder.indexOf('constructor.child') >= 0 && hostileSwapped.itemOrder.indexOf('__proto__.child') >= 0,
+  'provider swaps retain rows whose ids collide with object properties')
+assert(menu.item(hostileSwapped.items, '__proto__.child').kind === 'action', 'hostile provider rows are retrievable through item()')
+
+const hostileRoot = menu.mergeMenuSources([{ id: 'root', kind: 'menu', label: 'Go' }], [])
+assert(menu.item(hostileRoot.items, 'root') === hostileRoot.items.root, 'item() resolves real ids through own keys')


### PR DESCRIPTION
## Summary

Two hardening/correctness fixes for data that flows from user input, filesystems, and extension plugins.

### 1. `commandArguments` no longer mangles `$` sequences

`String.prototype.replace` treats `$&`, `$'`, `` $` ``, `$$`, and `$n` specially in **string** replacements. `commandArguments` interpolated `{prompt}`, `{path}`, `{query}`, `{result}`, etc. with `replace(regex, String(value))`, so any typed query or file path containing a `$` sequence was silently corrupted before reaching `qalc`, `xdg-open`, `wl-copy`, or an extension command (e.g. opening `/tmp/a$&b.txt`). Uses a replacer function so replacement text stays literal — the same approach `workflowInterpolate` already uses in `MenuModel.js`.

### 2. Menu maps and launcher state survive hostile object-property names

The menu merges, `item()`, and the usage-record map key plain objects by raw ids. An id such as `__proto__`, `constructor`, or `toString` (possible via menu JSONC, `.desktop` filenames, provider rows, or an edited state file) could:
- re-point a map's `[[Prototype]]`, dropping the row (`nextItems["__proto__"] = {...}`),
- read prototype members as "already present" (`!nextItems["constructor"]` is always false),
- silently drop favorite/usage records written under those names.

Reads are now own-property checked and writes use `Object.defineProperty` so the keys land as ordinary enumerable data properties that shadow inherited accessors.

## Tests

- Adds hostile-name coverage for `mergeMenuSources`, `mergeAppRows`, `swapProviderRows`, and `item()` in `menu-model-test.js`.
- Full local suite passes: `menu-model`, `qml-extension-path`, `manifest`, `extension-loader`, `file-index`, `timezone`, and `qalc`.

Verified live against v0.3.0 with the plugin reloaded and the launcher toggling cleanly (no QML errors).