### PR TITLE
Add trusted GitHub CLI dependency setup

### DIFF
--- a/Menu.qml
+++ b/Menu.qml
@@ -2525,7 +2525,7 @@ Item {
           var setupItem = root.normalizeItem("dependency.setup." + setupExtension.id, {
             icon: setupExtension.icon,
             iconFont: setupExtension.iconFont,
-            label: "Enable Calculator & Currency",
+            label: dependencySetup.label,
             description: "Install " + dependencySetup.packageName + " · Press Enter to review"
           })
           rows.push(root.displayRow(setupItem, setupItem.description, -1))

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -462,6 +462,7 @@ function stringArray(value) {
 var DEPENDENCY_SETUPS = {
   qalc: {
     executable: "qalc",
+    label: "Enable Calculator & Currency",
     packageName: "libqalculate",
     reason: "arithmetic, unit conversion, and currency conversion",
     installCommand: ["omarchy", "pkg", "add", "libqalculate"],
@@ -469,6 +470,7 @@ var DEPENDENCY_SETUPS = {
   },
   gh: {
     executable: "gh",
+    label: "Enable GitHub Extensions",
     packageName: "github-cli",
     reason: "GitHub extensions",
     installCommand: ["omarchy", "pkg", "add", "github-cli"]
@@ -479,8 +481,10 @@ function dependencySetup(extension) {
   if (!extension) return null
   var missing = Array.isArray(extension.missingRequires) ? extension.missingRequires : []
   for (var i = 0; i < missing.length; i++) {
-    var setup = DEPENDENCY_SETUPS[String(missing[i])]
-    if (setup && (!setup.bundledOnly || extension.bundled)) return setup
+    var executable = String(missing[i])
+    if (!Object.prototype.hasOwnProperty.call(DEPENDENCY_SETUPS, executable)) continue
+    var setup = DEPENDENCY_SETUPS[executable]
+    if (!setup.bundledOnly || extension.bundled) return setup
   }
   return null
 }

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -464,16 +464,23 @@ var DEPENDENCY_SETUPS = {
     executable: "qalc",
     packageName: "libqalculate",
     reason: "arithmetic, unit conversion, and currency conversion",
-    installCommand: ["omarchy", "pkg", "add", "libqalculate"]
+    installCommand: ["omarchy", "pkg", "add", "libqalculate"],
+    bundledOnly: true
+  },
+  gh: {
+    executable: "gh",
+    packageName: "github-cli",
+    reason: "GitHub extensions",
+    installCommand: ["omarchy", "pkg", "add", "github-cli"]
   }
 }
 
 function dependencySetup(extension) {
-  if (!extension || !extension.bundled) return null
+  if (!extension) return null
   var missing = Array.isArray(extension.missingRequires) ? extension.missingRequires : []
   for (var i = 0; i < missing.length; i++) {
     var setup = DEPENDENCY_SETUPS[String(missing[i])]
-    if (setup) return setup
+    if (setup && (!setup.bundledOnly || extension.bundled)) return setup
   }
   return null
 }

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -839,6 +839,7 @@ const bundledMissingQalc = menu.parseExtensions(JSON.stringify([{
   _missingRequires: ['qalc']
 }]))[0]
 const qalcSetup = menu.dependencySetup(bundledMissingQalc)
+assert(qalcSetup.label === 'Enable Calculator & Currency', 'bundled qalc setup keeps its root presentation label')
 assert(qalcSetup.packageName === 'libqalculate', 'bundled qalc requirements map to libqalculate setup')
 assert(qalcSetup.installCommand.join(' ') === 'omarchy pkg add libqalculate', 'dependency setup exposes the exact supported install command')
 assert(menu.unavailableExtensionDetail(bundledMissingQalc).indexOf('Press Enter to install') >= 0, 'known bundled dependencies are actionable')
@@ -849,11 +850,26 @@ assert(menu.firstSetupExtension(unavailableCatalog.extensions) === null, 'unknow
 assert(menu.unavailableExtensionDetail(unavailableCatalog.extensions[0]) === 'Missing dependency: missing-tool', 'unknown dependencies retain diagnostic-only messaging')
 const externalMissingGh = Object.assign({}, unavailableCatalog.extensions[0], { missingRequires: ['gh'] })
 const ghSetup = menu.dependencySetup(externalMissingGh)
+assert(ghSetup.label === 'Enable GitHub Extensions', 'external gh setup has a core-owned root presentation label')
 assert(ghSetup.packageName === 'github-cli', 'the core allow-list maps external gh requirements to github-cli')
 assert(ghSetup.installCommand.join(' ') === 'omarchy pkg add github-cli', 'external setup cannot control the trusted install command')
 assert(menu.unavailableExtensionDetail(externalMissingGh).indexOf('Press Enter to install') >= 0, 'allow-listed external dependencies are actionable')
+for (const inheritedName of ['constructor', 'toString', '__proto__']) {
+  const hostileExternal = Object.assign({}, unavailableCatalog.extensions[0], { missingRequires: [inheritedName] })
+  assert(menu.dependencySetup(hostileExternal) === null, `inherited ${inheritedName} keys cannot authorize package installation`)
+}
 const externalMissingQalc = Object.assign({}, unavailableCatalog.extensions[0], { missingRequires: ['qalc'] })
 assert(menu.dependencySetup(externalMissingQalc) === null, 'bundled-only setup entries remain unavailable to external plugins')
+const externalMultipleMissing = Object.assign({}, unavailableCatalog.extensions[0], {
+  missingRequires: ['missing-tool', 'qalc', 'gh'],
+  packageName: 'hostile-package',
+  installCommand: ['hostile-command']
+})
+assert(menu.dependencySetup(externalMultipleMissing) === ghSetup,
+  'multiple external requirements skip unknown and bundled-only entries before trusted gh setup')
+const bundledMultipleMissing = Object.assign({}, bundledMissingQalc, { missingRequires: ['missing-tool', 'qalc', 'gh'] })
+assert(menu.dependencySetup(bundledMultipleMissing) === qalcSetup,
+  'multiple bundled requirements use the first eligible core-owned setup')
 
 const searchTree = {
   setup: { id: 'setup', parent: 'root' },

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -844,9 +844,16 @@ assert(qalcSetup.installCommand.join(' ') === 'omarchy pkg add libqalculate', 'd
 assert(menu.unavailableExtensionDetail(bundledMissingQalc).indexOf('Press Enter to install') >= 0, 'known bundled dependencies are actionable')
 assert(menu.firstSetupExtension([bundledMissingQalc]) === bundledMissingQalc, 'missing bundled dependencies produce a root setup extension')
 assert(menu.firstSetupExtension(bundledExtensions) === null, 'available bundled dependencies do not produce root setup')
-assert(menu.dependencySetup(unavailableCatalog.extensions[0]) === null, 'external extensions cannot authorize package installation')
-assert(menu.firstSetupExtension(unavailableCatalog.extensions) === null, 'external dependencies cannot produce root package setup')
+assert(menu.dependencySetup(unavailableCatalog.extensions[0]) === null, 'unknown external dependencies cannot authorize package installation')
+assert(menu.firstSetupExtension(unavailableCatalog.extensions) === null, 'unknown external dependencies cannot produce root package setup')
 assert(menu.unavailableExtensionDetail(unavailableCatalog.extensions[0]) === 'Missing dependency: missing-tool', 'unknown dependencies retain diagnostic-only messaging')
+const externalMissingGh = Object.assign({}, unavailableCatalog.extensions[0], { missingRequires: ['gh'] })
+const ghSetup = menu.dependencySetup(externalMissingGh)
+assert(ghSetup.packageName === 'github-cli', 'the core allow-list maps external gh requirements to github-cli')
+assert(ghSetup.installCommand.join(' ') === 'omarchy pkg add github-cli', 'external setup cannot control the trusted install command')
+assert(menu.unavailableExtensionDetail(externalMissingGh).indexOf('Press Enter to install') >= 0, 'allow-listed external dependencies are actionable')
+const externalMissingQalc = Object.assign({}, unavailableCatalog.extensions[0], { missingRequires: ['qalc'] })
+assert(menu.dependencySetup(externalMissingQalc) === null, 'bundled-only setup entries remain unavailable to external plugins')
 
 const searchTree = {
   setup: { id: 'setup', parent: 'root' },

--- a/tests/qml-extension-path-test.js
+++ b/tests/qml-extension-path-test.js
@@ -38,6 +38,11 @@ assert(resetBody.includes('if (root.dmenuActive && root.requestActive) root.fini
 assert(resetBody.includes('MenuModel.openStateReset()') && resetBody.includes('root.resetFileIndex()'),
 'menu and dmenu opens share the centralized workflow, picker, file, focus, and action-panel reset path')
 
+assert(qml.includes('label: dependencySetup.label')
+  && qml.includes('description: "Install " + dependencySetup.packageName + " · Press Enter to review"')
+  && !qml.includes('label: "Enable Calculator & Currency"'),
+  'root setup rows use the selected core-owned dependency label and package')
+
 assert(qml.includes('MenuModel.focusedPrefixMatch(root.focusedExtension, query)')
   && qml.includes('"extension.focused.prefix"'),
 'focused prefix QML path builds one dedicated action row')


### PR DESCRIPTION
## Summary

- add a core-owned trusted dependency setup for `gh` through `github-cli`
- keep package names and installation commands outside external manifests
- reuse the existing confirmation and visible held-terminal flow
- show dependency-specific setup labels while preserving qalc behavior
- reject inherited and hostile dependency names at the allow-list boundary

## Validation

- complete core CI test sequence passed during final review
- dependency setup, QML path, manifest, extension loader, and menu layout tests passed
- independent review found no actionable issues after fixes
