### PR TITLE
Fix dynamic root loading empty states

### DIFF
--- a/Menu.qml
+++ b/Menu.qml
@@ -5275,7 +5275,21 @@ Item {
             anchors.centerIn: parent
             width: Math.max(0, Math.min(parent.width - Style.space(32), Style.space(420)))
             spacing: Math.max(Style.space(4), Math.round(Style.space(7) * root.menuItemScale))
-            visible: !root.documentActive && !root.focusedExtension && displayModel.count === 0 && root.mode !== "input" && !root.workflowInputActive && (root.filterText || root.activeMenu !== "root") && !root.isPotentialExtensionQuery(root.filterText)
+            readonly property bool loading: root.workflowActive
+              && (root.dynamicMenuLoading || root.submenuLoading)
+            visible: MenuLayout.emptyStateVisible({
+              documentActive: root.documentActive,
+              focusedExtension: root.focusedExtension,
+              displayCount: displayModel.count,
+              mode: root.mode,
+              workflowInputActive: root.workflowInputActive,
+              actionPanelActive: root.actionPanelActive,
+              dialogOpen: root.workflowConfirmOpen || root.deleteConfirmOpen || root.dependencyConfirmOpen,
+              potentialExtensionQuery: root.isPotentialExtensionQuery(root.filterText),
+              filterText: root.filterText,
+              activeMenu: root.activeMenu,
+              workflowMenuActive: root.workflowActive && root.workflowNode && root.workflowNode.kind === "menu"
+            })
 
             Rectangle {
               anchors.horizontalCenter: parent.horizontalCenter
@@ -5288,7 +5302,7 @@ Item {
 
               Text {
                 anchors.centerIn: parent
-                text: root.filterText ? "󰍉" : "󰅖"
+                text: parent.parent.loading ? "󰔟" : (root.filterText ? "󰍉" : "󰅖")
                 color: root.foreground
                 opacity: 0.56
                 font.family: root.fontFamily
@@ -5298,7 +5312,7 @@ Item {
 
             Text {
               width: parent.width
-              text: root.filterText ? "No results found" : "Nothing here yet"
+              text: parent.loading ? "Loading…" : (root.filterText ? "No results found" : "Nothing here yet")
               color: root.foreground
               opacity: 0.86
               font.family: root.fontFamily
@@ -5309,9 +5323,10 @@ Item {
 
             Text {
               width: parent.width
-              text: root.filterText ? "Try another search, or press Esc to clear"
-                : (root.workflowActive && root.workflowNode && root.workflowNode.description
-                  ? root.workflowNode.description : "Items will appear here when available")
+              text: parent.loading ? "Please wait"
+                : (root.filterText ? "Try another search, or press Esc to clear"
+                  : (root.workflowActive && root.workflowNode && root.workflowNode.description
+                    ? root.workflowNode.description : "Items will appear here when available"))
               color: root.foreground
               opacity: 0.48
               font.family: root.fontFamily

--- a/Menu.qml
+++ b/Menu.qml
@@ -5285,7 +5285,7 @@ Item {
               workflowInputActive: root.workflowInputActive,
               actionPanelActive: root.actionPanelActive,
               dialogOpen: root.workflowConfirmOpen || root.deleteConfirmOpen || root.dependencyConfirmOpen,
-              potentialExtensionQuery: root.isPotentialExtensionQuery(root.filterText),
+              potentialExtensionQuery: !root.actionPanelActive && root.isPotentialExtensionQuery(root.filterText),
               filterText: root.filterText,
               activeMenu: root.activeMenu,
               workflowMenuActive: root.workflowActive && root.workflowNode && root.workflowNode.kind === "menu"

--- a/MenuLayout.js
+++ b/MenuLayout.js
@@ -1,3 +1,11 @@
+function emptyStateVisible(state) {
+  if (state.documentActive || state.focusedExtension || state.displayCount !== 0
+      || state.mode === "input" || state.workflowInputActive || state.actionPanelActive
+      || state.dialogOpen || state.potentialExtensionQuery) return false
+
+  return !!state.filterText || state.activeMenu !== "root" || state.workflowMenuActive
+}
+
 function imagePreviewRowsHeight(imagePreviewActive, naturalHeight, minimumHeight, availableHeight) {
   if (!imagePreviewActive) return naturalHeight
 
@@ -7,6 +15,7 @@ function imagePreviewRowsHeight(imagePreviewActive, naturalHeight, minimumHeight
 
 if (typeof module !== "undefined") {
   module.exports = {
+    emptyStateVisible: emptyStateVisible,
     imagePreviewRowsHeight: imagePreviewRowsHeight
   }
 }

--- a/MenuLayout.js
+++ b/MenuLayout.js
@@ -1,7 +1,9 @@
 function emptyStateVisible(state) {
   if (state.documentActive || state.focusedExtension || state.displayCount !== 0
-      || state.mode === "input" || state.workflowInputActive || state.actionPanelActive
+      || state.mode === "input" || state.workflowInputActive
       || state.dialogOpen || state.potentialExtensionQuery) return false
+
+  if (state.actionPanelActive && !state.filterText) return false
 
   return !!state.filterText || state.activeMenu !== "root" || state.workflowMenuActive
 }

--- a/tests/menu-layout-test.js
+++ b/tests/menu-layout-test.js
@@ -9,6 +9,34 @@ function assertEqual(actual, expected, message) {
   console.log(`ok - ${message}`)
 }
 
+const emptyState = {
+  documentActive: false,
+  focusedExtension: null,
+  displayCount: 0,
+  mode: 'menu',
+  workflowInputActive: false,
+  actionPanelActive: false,
+  dialogOpen: false,
+  potentialExtensionQuery: false,
+  filterText: '',
+  activeMenu: 'root',
+  workflowMenuActive: false
+}
+assertEqual(layout.emptyStateVisible(emptyState), false,
+  'an ordinary empty root does not show an empty-state panel')
+assertEqual(layout.emptyStateVisible({ ...emptyState, workflowMenuActive: true }), true,
+  'a loading dynamic provider root can show its empty-state panel')
+assertEqual(layout.emptyStateVisible({ ...emptyState, workflowMenuActive: true, activeMenu: 'submenu' }), true,
+  'a loading dynamic submenu can show its empty-state panel')
+assertEqual(layout.emptyStateVisible({ ...emptyState, filterText: 'missing' }), true,
+  'an ordinary filtered root keeps its no-results panel')
+assertEqual(layout.emptyStateVisible({ ...emptyState, workflowMenuActive: true, actionPanelActive: true }), false,
+  'an action panel hides the underlying workflow empty state')
+assertEqual(layout.emptyStateVisible({ ...emptyState, workflowMenuActive: true, documentActive: true }), false,
+  'document loading hides the menu empty state')
+assertEqual(layout.emptyStateVisible({ ...emptyState, workflowMenuActive: true, potentialExtensionQuery: true }), false,
+  'a potential extension query hides the menu empty state')
+
 assertEqual(layout.imagePreviewRowsHeight(true, 92, 340, 480), 340,
   'few image rows use the theme-scaled preview minimum')
 assertEqual(layout.imagePreviewRowsHeight(true, 430, 340, 480), 430,
@@ -24,3 +52,10 @@ if (!qml.includes('readonly property int imagePreviewMinRowsHeight: Style.space(
   throw new Error('Menu.qml does not use the shared theme-scaled image preview layout rule')
 }
 console.log('ok - Menu.qml uses the tested image preview layout rule')
+if (!qml.includes('visible: MenuLayout.emptyStateVisible({')
+    || !qml.includes('workflowMenuActive: root.workflowActive && root.workflowNode && root.workflowNode.kind === "menu"')
+    || !qml.includes('text: parent.loading ? "Loading…" : (root.filterText ? "No results found" : "Nothing here yet")')
+    || !qml.includes('root.dynamicMenuLoading || root.submenuLoading')) {
+  throw new Error('Menu.qml does not show distinct loading feedback for empty dynamic menus')
+}
+console.log('ok - Menu.qml uses the tested dynamic-menu empty-state rule')

--- a/tests/menu-layout-test.js
+++ b/tests/menu-layout-test.js
@@ -44,10 +44,12 @@ assertEqual(layout.emptyStateVisible({ ...emptyState, actionPanelActive: true, f
   'a dialog still hides the filtered action-panel empty state')
 assertEqual(layout.emptyStateVisible({ ...emptyState, workflowMenuActive: true, documentActive: true }), false,
   'document loading hides the menu empty state')
-assertEqual(layout.emptyStateVisible({ ...emptyState, workflowMenuActive: true, potentialExtensionQuery: true }), false,
-  'a potential extension query hides the menu empty state')
-assertEqual(layout.emptyStateVisible({ ...emptyState, actionPanelActive: true, filterText: 'missing', potentialExtensionQuery: true }), false,
-  'a potential extension query still hides the filtered action-panel empty state')
+assertEqual(layout.emptyStateVisible({ ...emptyState, workflowMenuActive: true, filterText: '+missing', potentialExtensionQuery: true }), false,
+  'a potential extension query hides the menu empty state outside an action panel')
+assertEqual(layout.emptyStateVisible({ ...emptyState, actionPanelActive: true, filterText: '+missing', potentialExtensionQuery: false }), true,
+  'an extension-prefix-like filter shows no results in a normal action panel')
+assertEqual(layout.emptyStateVisible({ ...emptyState, activeMenu: 'settings', actionPanelActive: true, filterText: '+missing', potentialExtensionQuery: false }), true,
+  'an extension-prefix-like filter shows no results in a settings action panel')
 
 assertEqual(layout.imagePreviewRowsHeight(true, 92, 340, 480), 340,
   'few image rows use the theme-scaled preview minimum')
@@ -65,7 +67,7 @@ if (!qml.includes('readonly property int imagePreviewMinRowsHeight: Style.space(
 }
 console.log('ok - Menu.qml uses the tested image preview layout rule')
 if (!qml.includes('visible: MenuLayout.emptyStateVisible({')
-    || !qml.includes('actionPanelActive: root.actionPanelActive,\n              dialogOpen: root.workflowConfirmOpen || root.deleteConfirmOpen || root.dependencyConfirmOpen,\n              potentialExtensionQuery: root.isPotentialExtensionQuery(root.filterText),\n              filterText: root.filterText,')
+    || !qml.includes('actionPanelActive: root.actionPanelActive,\n              dialogOpen: root.workflowConfirmOpen || root.deleteConfirmOpen || root.dependencyConfirmOpen,\n              potentialExtensionQuery: !root.actionPanelActive && root.isPotentialExtensionQuery(root.filterText),\n              filterText: root.filterText,')
     || !qml.includes('workflowMenuActive: root.workflowActive && root.workflowNode && root.workflowNode.kind === "menu"')
     || !qml.includes('text: parent.loading ? "Loading…" : (root.filterText ? "No results found" : "Nothing here yet")')
     || !qml.includes('root.dynamicMenuLoading || root.submenuLoading')) {

--- a/tests/menu-layout-test.js
+++ b/tests/menu-layout-test.js
@@ -31,11 +31,23 @@ assertEqual(layout.emptyStateVisible({ ...emptyState, workflowMenuActive: true, 
 assertEqual(layout.emptyStateVisible({ ...emptyState, filterText: 'missing' }), true,
   'an ordinary filtered root keeps its no-results panel')
 assertEqual(layout.emptyStateVisible({ ...emptyState, workflowMenuActive: true, actionPanelActive: true }), false,
-  'an action panel hides the underlying workflow empty state')
+  'an unfiltered action-panel transition hides the underlying workflow empty state')
+assertEqual(layout.emptyStateVisible({ ...emptyState, activeMenu: 'settings', actionPanelActive: true }), false,
+  'an unfiltered settings action panel hides its empty state')
+assertEqual(layout.emptyStateVisible({ ...emptyState, actionPanelActive: true, filterText: 'missing' }), true,
+  'a filtered action panel shows its no-results state')
+assertEqual(layout.emptyStateVisible({ ...emptyState, activeMenu: 'settings', actionPanelActive: true, filterText: 'missing' }), true,
+  'a filtered settings action panel shows its no-results state')
+assertEqual(layout.emptyStateVisible({ ...emptyState, actionPanelActive: true, filterText: 'missing', focusedExtension: {} }), false,
+  'a focused extension still hides the filtered action-panel empty state')
+assertEqual(layout.emptyStateVisible({ ...emptyState, actionPanelActive: true, filterText: 'missing', dialogOpen: true }), false,
+  'a dialog still hides the filtered action-panel empty state')
 assertEqual(layout.emptyStateVisible({ ...emptyState, workflowMenuActive: true, documentActive: true }), false,
   'document loading hides the menu empty state')
 assertEqual(layout.emptyStateVisible({ ...emptyState, workflowMenuActive: true, potentialExtensionQuery: true }), false,
   'a potential extension query hides the menu empty state')
+assertEqual(layout.emptyStateVisible({ ...emptyState, actionPanelActive: true, filterText: 'missing', potentialExtensionQuery: true }), false,
+  'a potential extension query still hides the filtered action-panel empty state')
 
 assertEqual(layout.imagePreviewRowsHeight(true, 92, 340, 480), 340,
   'few image rows use the theme-scaled preview minimum')
@@ -53,6 +65,7 @@ if (!qml.includes('readonly property int imagePreviewMinRowsHeight: Style.space(
 }
 console.log('ok - Menu.qml uses the tested image preview layout rule')
 if (!qml.includes('visible: MenuLayout.emptyStateVisible({')
+    || !qml.includes('actionPanelActive: root.actionPanelActive,\n              dialogOpen: root.workflowConfirmOpen || root.deleteConfirmOpen || root.dependencyConfirmOpen,\n              potentialExtensionQuery: root.isPotentialExtensionQuery(root.filterText),\n              filterText: root.filterText,')
     || !qml.includes('workflowMenuActive: root.workflowActive && root.workflowNode && root.workflowNode.kind === "menu"')
     || !qml.includes('text: parent.loading ? "Loading…" : (root.filterText ? "No results found" : "Nothing here yet")')
     || !qml.includes('root.dynamicMenuLoading || root.submenuLoading')) {

--- a/tests/qml-extension-path-test.js
+++ b/tests/qml-extension-path-test.js
@@ -336,7 +336,8 @@ assert(qml.includes('function openWorkflowActions()')
 assert(qml.includes('text: MenuMarkdown.colorizeLinks(modelData.html, root.foreground)')
   && qml.includes('linkColor: root.foreground'),
 'document links use the normal foreground color')
-assert(qml.includes('visible: !root.documentActive && !root.focusedExtension && displayModel.count === 0'),
+assert(qml.includes('visible: MenuLayout.emptyStateVisible({')
+  && qml.includes('documentActive: root.documentActive,'),
 'document pages suppress the empty menu state')
 assert(qml.includes('? Math.max(root.menuItemFontSize, Style.font.heading)')
   && qml.includes('font.weight: root.documentActive ? Font.DemiBold : Font.Normal'),
@@ -424,8 +425,8 @@ assert(qml.includes('readonly property int emptyStateHeight:')
   && qml.includes('if (displayModel.count === 0) return Math.max(0, Math.min(root.emptyStateHeight, available))')
   && qml.includes('height: root.visibleRowsHeight\n          clip: true')
   && qml.includes('width: Math.max(0, Math.min(parent.width - Style.space(32), Style.space(420)))')
-  && qml.includes('text: root.filterText ? "No results found" : "Nothing here yet"')
-  && qml.includes('text: root.filterText ? "Try another search, or press Esc to clear"'),
+  && qml.includes('root.filterText ? "No results found" : "Nothing here yet"')
+  && qml.includes('root.filterText ? "Try another search, or press Esc to clear"'),
 'empty results use a clear, bounded, helpful state')
 assert(qml.includes('font.pixelSize: row.starred ? root.menuSecondaryFontSize : root.menuItemFontSize'),
 'trailing menu glyphs scale with the configured item font size')


### PR DESCRIPTION
## Summary

- show the empty-state panel while dynamic root menus load
- keep filtered action panels visible when no actions match
- treat extension-like action-panel filters as normal no-result searches

## Tests

- all JavaScript tests in `tests/`
- all Python tests in `tests/`
- all shell tests in `tests/`
- `/usr/lib/qt6/bin/qmllint` on root and test QML files (existing warnings only)
- `git diff --check origin/master...HEAD`