### PR TITLE
Add safe file-picker confirmation flows for extensions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Run Quickshell live-query process harness when available
         run: bash tests/live-query-process-integration-test.sh
 
+      - name: Run Quickshell confirmation-menu harness when available
+        run: bash tests/confirmation-menu-integration-test.sh
+
       - name: Run extension loader tests
         run: python tests/extension-loader-test.py
 

--- a/ConfirmationMenu.qml
+++ b/ConfirmationMenu.qml
@@ -1,0 +1,193 @@
+import QtQuick
+import qs.Commons
+import qs.Ui
+
+// Omalaunch-local confirmation and result content. The host replaces its normal
+// content with this item, so this is a menu view and not a dialog overlay.
+Item {
+  id: control
+
+  property bool opened: false
+  property string heading: "Confirm"
+  property string headingIcon: ""
+  property color headingColor: foreground
+  property real messageOpacity: 0.58
+  property string message: ""
+  property string cancelText: "Cancel"
+  property string actionText: "Continue"
+  property bool resultOnly: false
+  property bool actionFirst: false
+  property string defaultChoice: "cancel"
+  property string actionTone: "neutral"
+  property string actionIcon: ""
+  property string cancelIcon: "󰁍"
+  property int selectedIndex: 0
+
+  property color foreground: "white"
+  property color selectedBackground: "#404040"
+  property color selectedText: "white"
+  property color mutedText: Qt.rgba(foreground.r, foreground.g, foreground.b, 0.64)
+  property color accentText: Color.accent
+  property color dangerText: Color.urgent
+  property var selectedBorderSpec: Border.none()
+  property string fontFamily: "sans-serif"
+  property int cornerRadius: Style.cornerRadius
+  property int itemFontSize: Style.font.title
+  property int secondaryFontSize: Style.font.bodySmall
+  property int rowHeight: Style.space(44)
+  property int headerHeight: Style.space(44)
+  property int contentSpacing: Style.spacing.md
+  property real maximumHeight: Number.POSITIVE_INFINITY
+
+  signal canceled()
+  signal confirmed()
+
+  visible: opened
+  enabled: opened
+  implicitHeight: Math.min(content.implicitHeight, maximumHeight > 0 ? maximumHeight : content.implicitHeight)
+
+  onOpenedChanged: if (opened) { selectedIndex = defaultIndex(); Qt.callLater(ensureChoiceVisible) }
+  onResultOnlyChanged: if (opened) { selectedIndex = defaultIndex(); Qt.callLater(ensureChoiceVisible) }
+  onSelectedIndexChanged: Qt.callLater(ensureChoiceVisible)
+
+  function optionCount() { return resultOnly ? 1 : 2 }
+  function actionIndex() { return resultOnly || actionFirst ? 0 : 1 }
+  function cancelIndex() { return actionFirst ? 1 : 0 }
+  function defaultIndex() { return resultOnly ? 0 : (defaultChoice === "action" ? actionIndex() : cancelIndex()) }
+  function optionAt(index) {
+    if (resultOnly || index === actionIndex())
+      return { role: "action", text: actionText, icon: actionIcon }
+    return { role: "cancel", text: cancelText, icon: cancelIcon }
+  }
+  function optionColor(option, selected) {
+    if (selected) return selectedText
+    if (option.role === "cancel") return mutedText
+    if (actionTone === "danger") return dangerText
+    if (actionTone === "accent") return accentText
+    return foreground
+  }
+  function moveSelection(delta) {
+    var count = optionCount()
+    selectedIndex = (selectedIndex + delta + count) % count
+  }
+  function activateSelection() {
+    if (!resultOnly && selectedIndex === cancelIndex()) canceled()
+    else confirmed()
+  }
+  function ensureChoiceVisible() {
+    if (!opened || choices.y === undefined) return
+    var top = choices.y + selectedIndex * (rowHeight + Style.spacing.xs)
+    var bottom = top + rowHeight
+    if (top < viewport.contentY) viewport.contentY = top
+    else if (bottom > viewport.contentY + viewport.height) viewport.contentY = bottom - viewport.height
+  }
+  function handleKey(event) {
+    if (!opened) return false
+    if (event.key === Qt.Key_Escape) canceled()
+    else if (event.key === Qt.Key_Up || (event.key === Qt.Key_K && event.modifiers === Qt.NoModifier)) moveSelection(-1)
+    else if (event.key === Qt.Key_Down || (event.key === Qt.Key_J && event.modifiers === Qt.NoModifier)) moveSelection(1)
+    else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) activateSelection()
+    return true
+  }
+
+  // Consume pointer input in blank content. Only a choice can cause an action.
+  MouseArea { anchors.fill: parent }
+
+  Flickable {
+    id: viewport
+    anchors.fill: parent
+    contentWidth: width
+    contentHeight: content.implicitHeight
+    clip: true
+    boundsBehavior: Flickable.StopAtBounds
+
+    Column {
+      id: content
+      width: viewport.width
+      spacing: control.contentSpacing
+
+    Item {
+      width: parent.width
+      height: control.headerHeight
+
+      Text {
+        anchors.fill: parent
+        text: (control.headingIcon ? control.headingIcon + "  " : "") + control.heading
+        color: control.headingColor
+        font.family: control.fontFamily
+        font.pixelSize: control.itemFontSize
+        font.weight: Font.Medium
+        verticalAlignment: Text.AlignVCenter
+        elide: Text.ElideRight
+      }
+    }
+
+    Text {
+      width: parent.width
+      text: control.message
+      color: control.foreground
+      opacity: control.messageOpacity
+      font.family: control.fontFamily
+      font.pixelSize: control.secondaryFontSize
+      wrapMode: Text.Wrap
+    }
+
+    Column {
+      id: choices
+      width: parent.width
+      spacing: Style.spacing.xs
+
+      Repeater {
+        model: control.optionCount()
+
+        BorderSurface {
+          required property int index
+          property var option: control.optionAt(index)
+          width: parent.width
+          height: control.rowHeight
+          radius: control.cornerRadius
+          color: control.selectedIndex === index ? control.selectedBackground : "transparent"
+          borderSpec: control.selectedIndex === index ? control.selectedBorderSpec : Border.none()
+
+          Row {
+            anchors.left: parent.left
+            anchors.leftMargin: Style.space(8)
+            anchors.right: parent.right
+            anchors.rightMargin: Style.space(8)
+            anchors.verticalCenter: parent.verticalCenter
+            spacing: Style.space(6)
+
+            Text {
+              width: Style.space(36)
+              visible: option.icon.length > 0
+              text: option.icon
+              color: control.optionColor(option, control.selectedIndex === index)
+              font.family: "omarchy"
+              font.pixelSize: control.itemFontSize
+              horizontalAlignment: Text.AlignHCenter
+            }
+
+            Text {
+              width: parent.width - (option.icon.length > 0 ? Style.space(42) : Style.space(10))
+              text: option.text
+              color: control.optionColor(option, control.selectedIndex === index)
+              font.family: control.fontFamily
+              font.pixelSize: control.itemFontSize
+              font.weight: Font.Medium
+              elide: Text.ElideRight
+            }
+          }
+
+          MouseArea {
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onEntered: control.selectedIndex = index
+            onClicked: control.activateSelection()
+          }
+        }
+      }
+    }
+    }
+  }
+}

--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -173,7 +173,7 @@ Workflow extensions contribute a launcher entry and a bounded tree of host-rende
 }
 ```
 
-Supported node kinds are `menu`, `directoryPicker`, `input`, `action`, and `confirm`. Menus contain `items`; a directory picker requires a `next` node; an input may run `command` and then enter `next`. Action and confirmation nodes run a direct command; confirmation nodes use `confirm` and optional `confirmLabel` text. Directory selection supplies `{path}` and `{basename}`. Input supplies `{input}`. `{extensionDir}` is the contributing extension's source directory. A node's bounded string-only `context` is inherited by its descendants. `default` initializes an input, `maxLength` bounds it, and `allowEmpty` permits submission without text. `emptyCommand` selects a distinct argument array for empty input. `refreshExtensions` reloads dynamic catalogs after a successful action. `nextBackSteps` can collapse transient input/picker history after a successful save.
+Supported node kinds are `menu`, `directoryPicker`, `filePicker`, `input`, `action`, and `confirm`. Menus contain `items`; each picker requires a `next` node; an input may run `command` and then enter `next`. Action and confirmation nodes run a direct command; confirmation nodes use `confirm` and optional `confirmLabel` text. A confirmation can set `confirmActionFirst` to place its action before Cancel, and `confirmDefault` to `cancel` or `action`. These settings are independent. Their safe defaults are `false` and `cancel`. Set `confirmTone` to `neutral`, `accent`, or `danger`, and set `confirmIcon` to a bounded Omarchy-font glyph. The defaults are `neutral` and no action icon. Cancel always uses its standard muted icon, and Escape always cancels. Directory and file selection supply `{path}` and `{basename}`. Input supplies `{input}`. `{extensionDir}` is the contributing extension's source directory. A node's bounded string-only `context` is inherited by its descendants. `default` initializes an input, `maxLength` bounds it, and `allowEmpty` permits submission without text. `emptyCommand` selects a distinct argument array for empty input. `refreshExtensions` reloads dynamic catalogs after a successful action. `nextBackSteps` can collapse transient input/picker history after a successful save.
 
 Commands are executed directly as argument arrays. Placeholder substitution never invokes a shell, so paths, names, and prompts remain literal arguments. Workflow trees are capped at 256 nodes and eight levels. Extensions cannot contribute QML. Escape returns through workflow stages. The directory picker reuses the Files index/browse implementation but selects directories instead of opening them. Contextual workflow Ctrl+K actions are intentionally left as a future extension point; workflow definitions do not opt into the global Files Action Panel.
 
@@ -271,7 +271,29 @@ The detail command uses the row context and writes one structured JSON object:
 
 Omalaunch runs the detail provider only after activation. It receives no stdin, has a five-second timeout, and has a 256 KiB limit on each output stream. Leaving the document, closing the launcher, replacing its session, or changing its provider invalidates the request. Cancellation sends SIGTERM and then sends SIGKILL to the same direct child after a 500 ms grace period. Detail commands run directly as argument arrays and support the row context plus `{extensionDir}` placeholders.
 
-A row can ask for confirmation before dispatch:
+A top-level row, contextual action, or document action can use the Files browser to select one file before a next confirmation or action. Directories navigate; a file selects it. Escape goes to the parent directory, then returns to the source menu at the filesystem root. File open, copy, star, and Action Panel operations are not available while selection is active. The row's bounded string context is retained, and `{path}` and `{basename}` are passed as literal values to the next node:
+
+```json
+{
+  "id": "send-file",
+  "label": "Send file…",
+  "context": { "peerId": "machine-7" },
+  "filePicker": {
+    "next": {
+      "id": "send-confirm",
+      "kind": "confirm",
+      "label": "Send file",
+      "confirm": "Send {basename} to machine-7?",
+      "confirmLabel": "Send",
+      "command": ["helper", "send", "{peerId}", "{path}"]
+    }
+  }
+}
+```
+
+`filePicker` must be an object that contains only `next`. It cannot be combined with `command`, `confirm`, `input`, `submenu`, or `document` on the same row. Its `next` value uses the normal workflow-node schema. A static workflow uses the equivalent node form: `{ "id": "choose", "kind": "filePicker", "label": "Choose file", "next": { ... } }`.
+
+A row can ask for confirmation before dispatch. Dynamic rows and their contextual actions use the same bounded `confirmActionFirst`, `confirmDefault`, `confirmTone`, and `confirmIcon` fields as workflow confirmation nodes:
 
 ```json
 {
@@ -299,7 +321,7 @@ A row can open a host-rendered text input form. The input object supports the wo
 }
 ```
 
-A row can include up to 16 `actions`. Press Ctrl+K on that row to open its contextual action list. Each contextual action has the same direct command, confirmation, input, and refresh fields as a row, but actions cannot contain more nested actions. A row can set `starAction` to the ID of one direct contextual action; Ctrl+S then runs that action through the normal tracked lifecycle. Providers should update the row's `starred` value and the action label/command in the next snapshot. Set `starredLabel` when a starred shortcut needs more context than its menu label. The menu continues to show `label`; the top-level and global-search snapshot uses `starredLabel` only while the row is starred.
+A row can include up to 16 `actions`. Press Ctrl+K on that row to open its contextual action list. Each contextual action has the same direct command, confirmation, input, file-picker, and refresh fields as a row, but actions cannot contain more nested actions. A row can set `starAction` to the ID of one direct contextual action; Ctrl+S then runs that action through the normal tracked lifecycle. Providers should update the row's `starred` value and the action label/command in the next snapshot. Set `starredLabel` when a starred shortcut needs more context than its menu label. The menu continues to show `label`; the top-level and global-search snapshot uses `starredLabel` only while the row is starred.
 
 Menu and action commands use the workflow action lifecycle. A non-terminal direct child runs for at most 30 seconds. Cancellation sends SIGTERM and then sends SIGKILL to the same direct child after one second. Stale generation checks prevent old exits from changing a new session. A successful menu mutation reloads the provider so the visible rows show current state. `refreshExtensions: true` also reloads the extension catalog after success. Failed commands leave the current menu open and do not refresh it.
 

--- a/Menu.qml
+++ b/Menu.qml
@@ -4490,7 +4490,7 @@ Item {
                 hasFilter: !!root.filterText,
                 path: root.fileBrowserPath,
                 home: Quickshell.env("HOME"),
-                directoryPickerActive: root.directoryPickerActive
+                directoryPickerActive: root.workflowPickerActive
               })
               if (fileEscape === "close-actions") root.closeActionPanel()
               else if (fileEscape === "clear-search") root.setFilter("")

--- a/Menu.qml
+++ b/Menu.qml
@@ -150,6 +150,8 @@ Item {
   readonly property int extensionQueryTerminationGraceMs: 500
   property bool fileBrowserActive: false
   property bool directoryPickerActive: false
+  property bool filePickerActive: false
+  readonly property bool workflowPickerActive: directoryPickerActive || filePickerActive
   property var fileBrowserExtension: null
   property string fileBrowserPath: ""
   property var fileEntries: []
@@ -176,6 +178,11 @@ Item {
   readonly property var activeDocument: root.documentActive ? root.workflowNode.document : null
   property var workflowConfirmNode: null
   property bool workflowConfirmOpen: false
+  property bool workflowResultOpen: false
+  property string workflowResultMessage: ""
+  property bool workflowResultSucceeded: false
+  property string workflowResultTitle: ""
+  property var workflowPendingSuccess: null
   property int dynamicMenuGeneration: 0
   readonly property int dynamicMenuTimeoutMs: 5000
   readonly property int dynamicMenuTerminationGraceMs: 500
@@ -226,7 +233,9 @@ Item {
   readonly property string selectedFilePath: root.selectedFileRow ? String(root.selectedFileRow.action || "") : ""
   readonly property bool selectedFileNavigation: !!root.selectedFileRow
     && root.selectedFileRow.itemId === "file.navigation.parent"
-  readonly property bool imagePreviewActive: MenuModel.isImagePath(root.selectedFilePath)
+  readonly property bool confirmationContentActive: root.workflowResultOpen || root.workflowConfirmOpen
+    || root.deleteConfirmOpen || root.dependencyConfirmOpen
+  readonly property bool imagePreviewActive: !root.confirmationContentActive && MenuModel.isImagePath(root.selectedFilePath)
   readonly property var selectedWorkflowNode: root.workflowActive && !root.fileBrowserActive
     && root.workflowNode && root.workflowNode.kind === "menu" && root.cursorActive
     && root.selectedIndex >= 0 && root.selectedIndex < displayModel.count
@@ -300,9 +309,6 @@ Item {
   }
 
   property color background: Color.menu.background
-  // Menu theme surfaces can include alpha. Confirmation cards must be opaque
-  // because they are rendered over the menu card and its rows.
-  readonly property color dialogBackground: Qt.rgba(background.r, background.g, background.b, 1)
   property color foreground: Color.menu.text
   property color border: Color.menu.border
   property var borderSpec: Border.surfaceSpec("menu", "border", border, Math.max(1, Style.space(2)))
@@ -365,7 +371,13 @@ Item {
     && (root.workflowNode.id === "root" || root.workflowNode.reloadCommand)
   property int workflowHintHeight: (root.workflowInputActive || root.filterMenuHintActive)
     ? Math.max(Style.space(12), Math.round(Style.space(18) * menuItemScale)) : 0
-  property int cardHeight: Math.min(contentMargin + actionBarBottomPadding + headerHeight + actionBarHeight + contentSpacing
+  readonly property real confirmationContentHeight: root.workflowResultOpen ? workflowResult.implicitHeight
+    : root.workflowConfirmOpen ? workflowConfirm.implicitHeight
+    : root.deleteConfirmOpen ? deleteConfirm.implicitHeight
+    : dependencyConfirm.implicitHeight
+  property int cardHeight: root.confirmationContentActive
+    ? Math.ceil(root.confirmationContentHeight + card.contentTopInset + card.contentBottomInset)
+    : Math.min(contentMargin + actionBarBottomPadding + headerHeight + actionBarHeight + contentSpacing
     + (visibleRowsHeight > 0 ? contentSpacing + visibleRowsHeight : 0)
     + (workflowHintHeight > 0 ? contentSpacing + workflowHintHeight : 0), panel.height - Style.gapsOut * 2)
 
@@ -384,7 +396,7 @@ Item {
     fileBrowserActive: root.fileBrowserActive,
     fileSelectionType: root.selectedFileRow && root.selectedFileRow.itemId.indexOf("file.item.") === 0
       ? "file" : "directory",
-    directoryPickerActive: root.directoryPickerActive,
+    directoryPickerActive: root.workflowPickerActive,
     actionPanelActive: root.actionPanelActive,
     canRefresh: root.canRefreshWorkflow,
     canConfigure: root.canConfigureExtension,
@@ -1184,6 +1196,7 @@ Item {
     root.resetFileIndex()
     root.fileBrowserActive = false
     root.directoryPickerActive = false
+    root.filePickerActive = false
     root.fileBrowserExtension = null
     root.workflowActive = false
     root.workflowExtension = null
@@ -1211,6 +1224,7 @@ Item {
     root.resetFileIndex()
     root.fileBrowserActive = false
     root.directoryPickerActive = false
+    root.filePickerActive = false
     root.fileBrowserExtension = null
     root.workflowNode = node
     root.workflowContext = root.workflowNodeContext(node, context)
@@ -1218,7 +1232,8 @@ Item {
       ? MenuModel.workflowInitialInput(node, root.workflowValues()) : ""
     root.selectedIndex = 0
     root.cursorActive = node.kind !== "input"
-    if (node.kind === "directoryPicker") root.enterDirectoryPicker(root.workflowContext.path || "")
+    if (node.kind === "directoryPicker" || node.kind === "filePicker")
+      root.enterWorkflowPicker(node.kind, root.workflowContext.path || "")
     else root.rebuildDisplay()
   }
 
@@ -1230,6 +1245,7 @@ Item {
     root.resetFileIndex()
     root.fileBrowserActive = false
     root.directoryPickerActive = false
+    root.filePickerActive = false
     root.fileBrowserExtension = null
     if (root.workflowStack.length === 0) {
       root.leaveWorkflow()
@@ -1322,7 +1338,11 @@ Item {
 
   function boundedBackgroundDiagnostic(value) {
     var text = String(value || "").replace(/[\r\n\0]/g, " ")
-    return text.substring(0, root.backgroundDiagnosticTextLimit)
+    return MenuModel.boundedUtf8Prefix(text, root.backgroundDiagnosticTextLimit).text
+  }
+
+  function boundedDiagnostic(value, maxBytes) {
+    return MenuModel.boundedUtf8Prefix(String(value || "").replace(/\s+/g, " ").trim(), maxBytes).text
   }
 
   function dispatchBackgroundAction(extension, node, input) {
@@ -1381,6 +1401,12 @@ Item {
     workflowActionProc.nextNode = node.next
     workflowActionProc.nextContext = transition.context
     workflowActionProc.refreshExtensions = node.refreshExtensions
+    workflowActionProc.successMessage = root.workflowText(node.successMessage || "")
+    workflowActionProc.successTitle = root.workflowText(node.successTitle || "Completed")
+    workflowActionProc.failureTitle = root.workflowText(node.failureTitle || "Could not complete")
+    workflowActionProc.stderrText = ""
+    workflowActionProc.stderrBytes = 0
+    workflowActionProc.stderrOverflow = false
     workflowActionProc.refreshDynamicMenu = root.workflowExtension.mode === "menu" && !node.next && !node.refreshExtensions && !node.closeOnSuccess
     workflowActionProc.nextBackSteps = node.nextBackSteps
     workflowActionProc.closeAfter = node.closeOnSuccess || (root.workflowExtension.mode !== "menu" && !node.next)
@@ -1391,9 +1417,11 @@ Item {
     workflowActionTimeout.restart()
   }
 
-  function enterDirectoryPicker(startPath) {
+  function enterWorkflowPicker(kind, startPath) {
+    if (kind !== "directoryPicker" && kind !== "filePicker") return
     root.fileBrowserShowHidden = false
-    root.directoryPickerActive = true
+    root.directoryPickerActive = kind === "directoryPicker"
+    root.filePickerActive = kind === "filePicker"
     root.fileBrowserActive = true
     root.fileBrowserExtension = root.activeFilesExtension()
     var requestedPath = MenuModel.normalizeFavoritePath(startPath)
@@ -1405,10 +1433,18 @@ Item {
     root.scheduleFileScan()
   }
 
-  function selectWorkflowDirectory(path) {
-    if (!root.directoryPickerActive || !root.workflowNode || !root.workflowNode.next) return
-    var transition = MenuModel.workflowDirectoryTransition(root.workflowNode, path, root.workflowContext)
+  function selectWorkflowPath(path) {
+    if (!root.workflowPickerActive || !root.workflowNode || !root.workflowNode.next) return
+    var transition = root.filePickerActive
+      ? MenuModel.workflowFileTransition(root.workflowNode, path, root.workflowContext)
+      : MenuModel.workflowDirectoryTransition(root.workflowNode, path, root.workflowContext)
     if (!transition) return
+    if (transition.node.kind === "confirm") {
+      root.workflowContext = transition.context
+      root.workflowConfirmNode = transition.node
+      root.workflowConfirmOpen = true
+      return
+    }
     root.workflowStack = root.workflowStack.concat([{ node: root.workflowNode, context: transition.context }])
     root.showWorkflowNode(transition.node, transition.context, false)
   }
@@ -1429,6 +1465,9 @@ Item {
   }
 
   function invalidateWorkflowAction(reason) {
+    root.workflowPendingSuccess = null
+    root.workflowResultOpen = false
+    root.workflowResultMessage = ""
     if (workflowActionProc.stopping) return
     if (workflowActionProc.generation <= 0 && !workflowActionProc.running) return
     root.workflowGeneration += 1
@@ -1451,6 +1490,36 @@ Item {
       workflowActionProc.running = false
       workflowActionKillTimer.restart()
     }
+  }
+
+  function applyWorkflowSuccess(continuation) {
+    if (!continuation) return
+    if (continuation.usageItemId) usage.record(continuation.usageItemId)
+    if (continuation.returnToRoot) {
+      root.workflowActive = false; root.workflowExtension = null; root.workflowNode = null
+      root.workflowContext = ({}); root.workflowStack = []; root.filterText = ""
+      root.preloadDynamicMenuSearch(); root.rebuildDisplay(); return
+    }
+    if (root.workflowExtension && root.workflowExtension.mode === "menu") root.preloadDynamicMenuSearch()
+    if (continuation.refreshExtensions) root.loadExtensions(true)
+    if (continuation.refreshDynamicMenu) {
+      var extension = root.workflowExtension
+      root.enterDynamicMenu(extension, true)
+    }
+    else if (continuation.closeAfter) root.cancel()
+    else if (continuation.nextNode) {
+      if (continuation.nextBackSteps > 0) {
+        var removeCount = continuation.nextBackSteps - 1
+        root.workflowStack = root.workflowStack.slice(0, Math.max(0, root.workflowStack.length - removeCount))
+        root.showWorkflowNode(continuation.nextNode, continuation.nextContext, false)
+      } else root.showWorkflowNode(continuation.nextNode, continuation.nextContext, true)
+    }
+  }
+
+  function dismissWorkflowResult() {
+    var continuation = root.workflowResultSucceeded ? root.workflowPendingSuccess : null
+    root.workflowPendingSuccess = null; root.workflowResultOpen = false; root.workflowResultMessage = ""
+    if (continuation) root.applyWorkflowSuccess(continuation)
   }
 
   function closeWorkflowAfterDispatch() {
@@ -1527,6 +1596,7 @@ Item {
     root.actionPanelFile = null
     root.fileBrowserActive = false
     root.directoryPickerActive = false
+    root.filePickerActive = false
     root.fileBrowserExtension = null
     root.fileBrowserPath = ""
     root.fileEntries = []
@@ -1660,7 +1730,7 @@ Item {
         action: entry.path
       })
       var row = root.displayRow(item, item.description, i)
-      row.starred = !root.directoryPickerActive && root.isFileFavoriteStarred(entry.path, entry.type)
+      row.starred = !root.workflowPickerActive && root.isFileFavoriteStarred(entry.path, entry.type)
       displayModel.append(row)
     }
     root.layoutSerial += 1
@@ -1696,7 +1766,8 @@ Item {
   }
 
   function openActionPanel() {
-    if (!root.fileBrowserActive || root.selectedIndex < 0 || root.selectedIndex >= displayModel.count) return
+    if (!root.fileBrowserActive || root.workflowPickerActive
+        || root.selectedIndex < 0 || root.selectedIndex >= displayModel.count) return
     var row = displayModel.get(root.selectedIndex)
     if (!row || (row.itemId.indexOf("file.item.") !== 0 && row.itemId.indexOf("file.directory.") !== 0)) return
     root.actionPanelFile = {
@@ -1730,7 +1801,8 @@ Item {
   }
 
   function copySelectedFile() {
-    if (!root.fileBrowserActive || root.selectedIndex < 0 || root.selectedIndex >= displayModel.count) return
+    if (!root.fileBrowserActive || root.workflowPickerActive
+        || root.selectedIndex < 0 || root.selectedIndex >= displayModel.count) return
     var row = displayModel.get(root.selectedIndex)
     if (!row || !root.fileBrowserExtension
         || (row.itemId.indexOf("file.item.") !== 0 && row.itemId.indexOf("file.directory.") !== 0)) return
@@ -2679,6 +2751,8 @@ Item {
     root.fileBrowserShowHidden = false
     root.workflowConfirmOpen = false
     root.workflowConfirmNode = null
+    root.workflowResultOpen = false
+    root.workflowResultMessage = ""
     root.deleteConfirmOpen = false
     root.deleteTarget = null
     root.dependencyConfirmOpen = false
@@ -2839,7 +2913,7 @@ Item {
       return
     }
     if (root.directoryPickerActive && row.itemId === "workflow.directory.select") {
-      root.selectWorkflowDirectory(row.action)
+      root.selectWorkflowPath(row.action)
       return
     }
     if (root.fileBrowserActive && row.itemId === "file.navigation.parent") {
@@ -2853,6 +2927,8 @@ Item {
         root.fileEntries = []
         root.selectedIndex = 0
         root.scheduleFileScan()
+      } else if (root.filePickerActive) {
+        root.selectWorkflowPath(row.action)
       } else {
         var openCommand = root.shellCommand(root.fileBrowserExtension.command, { path: row.action })
         root.fileBrowserActive = false
@@ -2918,6 +2994,7 @@ Item {
     if (!row || row.itemId === "omarchy" || row.itemId === "extensions"
         || row.itemId === "extension.result" || row.itemId === "extension.result.pending" || !favorites.loaded) return
     if (root.fileBrowserActive) {
+      if (root.workflowPickerActive) return
       var fileType = row.itemId.indexOf("file.directory.") === 0 ? "directory"
         : (row.itemId.indexOf("file.item.") === 0 ? "file" : "")
       if (!fileType) return
@@ -2936,14 +3013,12 @@ Item {
     var row = displayModel.get(root.selectedIndex)
     if (!row || row.kind !== "app") return
     root.deleteTarget = { appId: row.appId, label: row.label }
-    deleteConfirm.selectedIndex = 1
     root.deleteConfirmOpen = true
   }
 
   function cancelDelete() {
     root.deleteConfirmOpen = false
     root.deleteTarget = null
-    deleteConfirm.selectedIndex = 1
     root.disarmPointer()
     Qt.callLater(function() { keyCatcher.forceActiveFocus() })
   }
@@ -2993,6 +3068,8 @@ Item {
     root.dmenuPrompt = ""
     root.dmenuOptions = []
     root.dmenuRows = []
+    root.workflowResultOpen = false
+    root.workflowResultMessage = ""
     root.navStack = []
     root.filterText = ""
     root.opened = false
@@ -3005,6 +3082,8 @@ Item {
     root.invalidateDynamicMenu()
     root.workflowConfirmOpen = false
     root.workflowConfirmNode = null
+    root.workflowResultOpen = false
+    root.workflowResultMessage = ""
     root.routePendingForMenuSources = false
     if (root.dmenuActive) root.finishRequest(null)
     root.resetFileIndex()
@@ -3012,6 +3091,7 @@ Item {
     root.actionPanelFile = null
     root.fileBrowserActive = false
     root.directoryPickerActive = false
+    root.filePickerActive = false
     root.fileBrowserExtension = null
     root.workflowActive = false
     root.workflowExtension = null
@@ -3429,7 +3509,7 @@ Item {
         if (root.fileBrowserActive) {
           var refreshedFiles = root.filesExtensionForCapability(fileCapability) || root.extensionById(fileId)
           if (refreshedFiles && refreshedFiles.available && refreshedFiles.mode === "files") root.fileBrowserExtension = refreshedFiles
-          else if (root.directoryPickerActive && root.workflowActive) root.workflowBack()
+          else if (root.workflowPickerActive && root.workflowActive) root.workflowBack()
           else root.leaveFileBrowser(false)
         }
         if (catalog.complete) root.extensionsLoadedAt = Date.now()
@@ -3938,6 +4018,30 @@ Item {
     property bool closeAfter: false
     property bool returnToRoot: false
     property string usageItemId: ""
+    property string successMessage: ""
+    property string successTitle: ""
+    property string failureTitle: ""
+    property string stderrText: ""
+    property int stderrBytes: 0
+    property bool stderrOverflow: false
+    stderr: SplitParser {
+      onRead: function(data) {
+        if (workflowActionProc.stderrOverflow) return
+        var remaining = root.dynamicMenuOutputBytes - workflowActionProc.stderrBytes
+        var chunk = MenuModel.boundedUtf8Prefix(data, remaining)
+        if (chunk.bytes > 0) {
+          workflowActionProc.stderrText += chunk.text
+          workflowActionProc.stderrBytes += chunk.bytes
+        }
+        if (!chunk.complete || workflowActionProc.stderrBytes >= root.dynamicMenuOutputBytes) {
+          workflowActionProc.stderrOverflow = true
+          workflowActionProc.signal(15)
+          return
+        }
+        workflowActionProc.stderrText += "\n"
+        workflowActionProc.stderrBytes += 1
+      }
+    }
     onExited: function(exitCode) {
       console.warn("Omalaunch action exit: " + exitCode + " command=" + JSON.stringify(workflowActionProc.command))
       workflowActionTimeout.stop()
@@ -3947,36 +4051,31 @@ Item {
       if (!MenuModel.workflowActionIsCurrent(workflowActionProc.generation, root.workflowGeneration,
           root.workflowActive, workflowActionProc.extensionCapability, root.workflowExtension)) return
       workflowActionProc.generation = 0
-      if (exitCode !== 0) { workflowActionProc.returnToRoot = false; workflowActionProc.usageItemId = ""; return }
-      var usageItemId = workflowActionProc.usageItemId
-      workflowActionProc.usageItemId = ""
-      if (usageItemId) usage.record(usageItemId)
-      if (workflowActionProc.returnToRoot) {
+      if (exitCode !== 0) {
+        root.workflowPendingSuccess = null
         workflowActionProc.returnToRoot = false
-        root.workflowActive = false
-        root.workflowExtension = null
-        root.workflowNode = null
-        root.workflowContext = ({})
-        root.workflowStack = []
-        root.filterText = ""
-        root.preloadDynamicMenuSearch()
-        root.rebuildDisplay()
+        workflowActionProc.usageItemId = ""
+        root.workflowResultTitle = workflowActionProc.failureTitle
+        root.workflowResultSucceeded = false
+        root.workflowResultMessage = root.boundedDiagnostic(workflowActionProc.stderrText || "Action failed", 512)
+        root.workflowResultOpen = true
         return
       }
-      if (root.workflowExtension.mode === "menu") root.preloadDynamicMenuSearch()
-      if (workflowActionProc.refreshExtensions) root.loadExtensions(true)
-      if (workflowActionProc.refreshDynamicMenu) {
-        var extension = root.workflowExtension
-        root.enterDynamicMenu(extension, true)
-      } else if (workflowActionProc.closeAfter) {
-        root.cancel()
-      } else if (workflowActionProc.nextNode) {
-        if (workflowActionProc.nextBackSteps > 0) {
-          var removeCount = workflowActionProc.nextBackSteps - 1
-          root.workflowStack = root.workflowStack.slice(0, Math.max(0, root.workflowStack.length - removeCount))
-          root.showWorkflowNode(workflowActionProc.nextNode, workflowActionProc.nextContext, false)
-        } else root.showWorkflowNode(workflowActionProc.nextNode, workflowActionProc.nextContext, true)
+      var continuation = { usageItemId: workflowActionProc.usageItemId,
+        returnToRoot: workflowActionProc.returnToRoot, refreshExtensions: workflowActionProc.refreshExtensions,
+        refreshDynamicMenu: workflowActionProc.refreshDynamicMenu, closeAfter: workflowActionProc.closeAfter,
+        nextNode: workflowActionProc.nextNode, nextContext: workflowActionProc.nextContext,
+        nextBackSteps: workflowActionProc.nextBackSteps }
+      workflowActionProc.usageItemId = ""; workflowActionProc.returnToRoot = false
+      if (workflowActionProc.successMessage) {
+        root.workflowPendingSuccess = continuation
+        root.workflowResultTitle = workflowActionProc.successTitle
+        root.workflowResultSucceeded = true
+        root.workflowResultMessage = workflowActionProc.successMessage
+        root.workflowResultOpen = true
+        return
       }
+      root.applyWorkflowSuccess(continuation)
     }
   }
 
@@ -4350,12 +4449,15 @@ Item {
       Item {
         id: keyCatcher
         anchors.fill: parent
-        z: (root.workflowConfirmOpen || root.deleteConfirmOpen || root.dependencyConfirmOpen) ? 20 : 0
+        z: (root.workflowResultOpen || root.workflowConfirmOpen || root.deleteConfirmOpen || root.dependencyConfirmOpen) ? 20 : 0
         focus: true
 
         Keys.priority: Keys.BeforeItem
         Keys.onPressed: function(event) {
-          if (root.workflowConfirmOpen) {
+          if (root.workflowResultOpen) {
+            if (workflowResult.handleKey(event)) event.accepted = true
+            return
+          } else if (root.workflowConfirmOpen) {
             if (workflowConfirm.handleKey(event)) event.accepted = true
             return
           }
@@ -4375,7 +4477,7 @@ Item {
                 || (event.key === Qt.Key_Insert && (event.modifiers & Qt.ShiftModifier)))) {
             if (!pasteProc.running) pasteProc.running = true
             event.accepted = true
-          } else if (root.fileBrowserActive && !root.directoryPickerActive && !root.actionPanelActive && event.key === Qt.Key_H && (event.modifiers & Qt.ControlModifier)) {
+          } else if (root.fileBrowserActive && !root.actionPanelActive && event.key === Qt.Key_H && (event.modifiers & Qt.ControlModifier)) {
             root.toggleHiddenFiles()
             event.accepted = true
           } else if (event.key === Qt.Key_Delete) {
@@ -4425,7 +4527,7 @@ Item {
             if (root.actionPanelActive) root.closeActionPanel()
             else if (root.fileBrowserActive) {
               if (root.fileBrowserPath === "/") {
-                if (root.directoryPickerActive) root.workflowBack()
+                if (root.workflowPickerActive) root.workflowBack()
                 else root.leaveFileBrowser()
               } else {
                 root.navigateFileBrowserParent()
@@ -4455,21 +4557,35 @@ Item {
           }
         }
 
-        ConfirmDialog {
+        ConfirmationMenu {
           id: workflowConfirm
           anchors.fill: parent
+          maximumHeight: Math.max(1, panel.height - Style.gapsOut * 2 - card.contentTopInset - card.contentBottomInset)
+          anchors.topMargin: card.contentTopInset
+          anchors.rightMargin: card.contentRightInset
+          anchors.bottomMargin: card.contentBottomInset
+          anchors.leftMargin: card.contentLeftInset
           opened: root.workflowConfirmOpen
           z: 10
-          message: root.workflowConfirmNode ? (root.workflowConfirmNode.confirm || "Do you want to run " + root.workflowConfirmNode.label + "?") : ""
-          confirmText: root.workflowConfirmNode ? root.workflowConfirmNode.confirmLabel : "Run"
-          background: root.dialogBackground
+          heading: root.workflowConfirmNode ? "Confirm: " + root.workflowText(root.workflowConfirmNode.confirmTitle || root.workflowConfirmNode.label) : "Confirm"
+          message: root.workflowConfirmNode ? root.workflowText(root.workflowConfirmNode.confirm || "Do you want to run " + root.workflowConfirmNode.label + "?") : ""
+          actionText: root.workflowConfirmNode ? root.workflowConfirmNode.confirmLabel : "Run"
+          actionFirst: root.workflowConfirmNode ? root.workflowConfirmNode.confirmActionFirst : false
+          defaultChoice: root.workflowConfirmNode ? root.workflowConfirmNode.confirmDefault : "cancel"
+          actionTone: root.workflowConfirmNode ? root.workflowConfirmNode.confirmTone : "neutral"
+          actionIcon: root.workflowConfirmNode ? root.workflowConfirmNode.confirmIcon : ""
           foreground: root.foreground
-          scrim: root.scrim
           selectedBackground: root.selectedBackground
           selectedText: root.selectedText
+          selectedBorderSpec: root.selectedBorderSpec
           fontFamily: root.fontFamily
           cornerRadius: root.cornerRadius
-          onOpenedChanged: if (opened) { selectedIndex = 1; keyCatcher.forceActiveFocus() }
+          itemFontSize: root.menuItemFontSize
+          secondaryFontSize: root.menuSecondaryFontSize
+          rowHeight: root.baseRowHeight
+          headerHeight: root.headerHeight
+          contentSpacing: root.contentSpacing
+          onOpenedChanged: if (opened) keyCatcher.forceActiveFocus()
           onCanceled: { root.workflowConfirmOpen = false; root.workflowConfirmNode = null }
           onConfirmed: {
             var node = root.workflowConfirmNode
@@ -4479,53 +4595,107 @@ Item {
           }
         }
 
-        ConfirmDialog {
-          id: deleteConfirm
-
+        ConfirmationMenu {
+          id: workflowResult
           anchors.fill: parent
-          opened: root.deleteConfirmOpen
-          z: 10
-          message: "Do you want to uninstall " + ((root.deleteTarget && root.deleteTarget.label) || "") + "?"
-          confirmText: "Uninstall"
-          background: root.dialogBackground
+          maximumHeight: Math.max(1, panel.height - Style.gapsOut * 2 - card.contentTopInset - card.contentBottomInset)
+          anchors.topMargin: card.contentTopInset
+          anchors.rightMargin: card.contentRightInset
+          anchors.bottomMargin: card.contentBottomInset
+          anchors.leftMargin: card.contentLeftInset
+          opened: root.workflowResultOpen
+          z: 11
+          resultOnly: true
+          heading: root.workflowResultTitle
+          headingIcon: root.workflowResultSucceeded ? "󰄬" : "󰅖"
+          headingColor: root.workflowResultSucceeded ? Color.accent : Color.urgent
+          messageOpacity: 1.0
+          message: root.workflowResultMessage
+          actionText: "OK"
           foreground: root.foreground
-          scrim: root.scrim
           selectedBackground: root.selectedBackground
           selectedText: root.selectedText
+          selectedBorderSpec: root.selectedBorderSpec
           fontFamily: root.fontFamily
           cornerRadius: root.cornerRadius
-          onOpenedChanged: if (opened) { selectedIndex = 1; keyCatcher.forceActiveFocus() }
+          itemFontSize: root.menuItemFontSize
+          secondaryFontSize: root.menuSecondaryFontSize
+          rowHeight: root.baseRowHeight
+          headerHeight: root.headerHeight
+          contentSpacing: root.contentSpacing
+          onOpenedChanged: if (opened) keyCatcher.forceActiveFocus()
+          onCanceled: root.dismissWorkflowResult()
+          onConfirmed: root.dismissWorkflowResult()
+        }
+
+        ConfirmationMenu {
+          id: deleteConfirm
+          anchors.fill: parent
+          anchors.topMargin: card.contentTopInset
+          anchors.rightMargin: card.contentRightInset
+          anchors.bottomMargin: card.contentBottomInset
+          anchors.leftMargin: card.contentLeftInset
+          opened: root.deleteConfirmOpen
+          z: 10
+          heading: "Uninstall application"
+          message: "Do you want to uninstall " + ((root.deleteTarget && root.deleteTarget.label) || "") + "?"
+          actionText: "Uninstall"
+          actionTone: "danger"
+          actionIcon: "󰆴"
+          foreground: root.foreground
+          selectedBackground: root.selectedBackground
+          selectedText: root.selectedText
+          selectedBorderSpec: root.selectedBorderSpec
+          fontFamily: root.fontFamily
+          cornerRadius: root.cornerRadius
+          itemFontSize: root.menuItemFontSize
+          secondaryFontSize: root.menuSecondaryFontSize
+          rowHeight: root.baseRowHeight
+          headerHeight: root.headerHeight
+          contentSpacing: root.contentSpacing
+          onOpenedChanged: if (opened) keyCatcher.forceActiveFocus()
           onCanceled: root.cancelDelete()
           onConfirmed: root.confirmDelete()
         }
 
-        ConfirmDialog {
+        ConfirmationMenu {
           id: dependencyConfirm
-
           anchors.fill: parent
+          anchors.topMargin: card.contentTopInset
+          anchors.rightMargin: card.contentRightInset
+          anchors.bottomMargin: card.contentBottomInset
+          anchors.leftMargin: card.contentLeftInset
           opened: root.dependencyConfirmOpen
           z: 11
+          heading: "Install dependency"
           message: root.dependencyTarget
             ? ("Install " + root.dependencyTarget.packageName + " for " + root.dependencyTarget.reason
               + "?\n\nCommand: " + root.dependencyTarget.installCommand.join(" ")
               + "\n\nThe command will run in a visible terminal. Reopen Omalaunch afterward to recheck.")
             : ""
-          cancelText: "Not now"
-          confirmText: "Install"
-          background: root.dialogBackground
+          cancelText: "Cancel"
+          actionText: "Install"
+          actionTone: "accent"
+          actionIcon: "󰏔"
           foreground: root.foreground
-          scrim: root.scrim
           selectedBackground: root.selectedBackground
           selectedText: root.selectedText
+          selectedBorderSpec: root.selectedBorderSpec
           fontFamily: root.fontFamily
           cornerRadius: root.cornerRadius
-          onOpenedChanged: if (opened) { selectedIndex = 1; keyCatcher.forceActiveFocus() }
+          itemFontSize: root.menuItemFontSize
+          secondaryFontSize: root.menuSecondaryFontSize
+          rowHeight: root.baseRowHeight
+          headerHeight: root.headerHeight
+          contentSpacing: root.contentSpacing
+          onOpenedChanged: if (opened) keyCatcher.forceActiveFocus()
           onCanceled: root.cancelDependencyInstall()
           onConfirmed: root.confirmDependencyInstall()
         }
       }
 
       Column {
+        visible: !root.confirmationContentActive
         anchors.fill: parent
         anchors.topMargin: card.contentTopInset
         anchors.rightMargin: card.contentRightInset

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -540,6 +540,45 @@ function utf8ByteLength(value) {
   return bytes
 }
 
+// Return at most maxBytes of valid Unicode. The scan stops at the first
+// code point that does not fit, so a very large input is not copied or scanned
+// past the configured bound. Invalid UTF-16 surrogates become U+FFFD.
+function boundedUtf8Prefix(value, maxBytes) {
+  var text = String(value || "")
+  var limit = Math.max(0, Number(maxBytes) || 0)
+  var bytes = 0
+  var index = 0
+  var cleanStart = 0
+  var parts = []
+  while (index < text.length) {
+    var code = text.charCodeAt(index)
+    var units = 1
+    var codeBytes = 3
+    var invalid = false
+    if (code <= 0x7f) codeBytes = 1
+    else if (code <= 0x7ff) codeBytes = 2
+    else if (code >= 0xd800 && code <= 0xdbff) {
+      if (index + 1 < text.length) {
+        var low = text.charCodeAt(index + 1)
+        if (low >= 0xdc00 && low <= 0xdfff) {
+          units = 2
+          codeBytes = 4
+        } else invalid = true
+      } else invalid = true
+    } else if (code >= 0xdc00 && code <= 0xdfff) invalid = true
+    if (bytes + codeBytes > limit) break
+    if (invalid) {
+      if (cleanStart < index) parts.push(text.substring(cleanStart, index))
+      parts.push("\ufffd")
+      cleanStart = index + 1
+    }
+    bytes += codeBytes
+    index += units
+  }
+  if (cleanStart < index) parts.push(text.substring(cleanStart, index))
+  return { text: parts.join(""), bytes: bytes, complete: index === text.length }
+}
+
 function finiteExtensionNumber(value, fallback) {
   if (value === undefined || value === null || value === "") return fallback
   var number = Number(value)
@@ -574,6 +613,10 @@ function openStateReset() {
 function boundedWorkflowText(value, limit) {
   var text = String(value === undefined || value === null ? "" : value)
   return text.length <= (limit || MAX_WORKFLOW_TEXT) ? text : ""
+}
+
+function validOptionalWorkflowText(value, limit) {
+  return value === undefined || (typeof value === "string" && value.length <= limit)
 }
 
 function workflowContext(value) {
@@ -640,11 +683,27 @@ function normalizeDocumentCommand(raw) {
   return { command: command, refreshCommand: refreshCommand }
 }
 
+function prepareDynamicAction(raw) {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null
+  var copy = Object.assign({}, raw)
+  if (copy.filePicker !== undefined) {
+    if (!copy.filePicker || typeof copy.filePicker !== "object" || Array.isArray(copy.filePicker)
+        || Object.keys(copy.filePicker).some(function(key) { return key !== "next" })
+        || copy.filePicker.next === undefined
+        || copy.input !== undefined || copy.confirm !== undefined || copy.command !== undefined
+        || copy.submenu !== undefined || copy.document !== undefined) return null
+  }
+  copy.kind = copy.confirm ? "confirm" : (copy.input ? "input" : (copy.filePicker ? "filePicker" : "action"))
+  if (copy.input) copy = Object.assign({}, copy, copy.input, { kind: "input", command: copy.input.command || copy.command })
+  if (copy.filePicker) copy = Object.assign({}, copy, copy.filePicker, { kind: "filePicker" })
+  return copy
+}
+
 function normalizeWorkflowNode(raw, state, depth) {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)
       || depth >= MAX_WORKFLOW_DEPTH || state.count >= MAX_WORKFLOW_NODES) return null
   var kind = String(raw.kind || "menu")
-  if (["menu", "directoryPicker", "input", "action", "confirm"].indexOf(kind) < 0) return null
+  if (["menu", "directoryPicker", "filePicker", "input", "action", "confirm"].indexOf(kind) < 0) return null
   var id = boundedWorkflowText(raw.id, 128).trim()
   var label = boundedWorkflowText(raw.label, 256).trim()
   if (!id || !label) return null
@@ -691,6 +750,14 @@ function normalizeWorkflowNode(raw, state, depth) {
     nextBackSteps: 0,
     confirm: boundedWorkflowText(raw.confirm, 512),
     confirmLabel: boundedWorkflowText(raw.confirmLabel, 64) || "Run",
+    confirmTitle: boundedWorkflowText(raw.confirmTitle, 128),
+    confirmActionFirst: raw.confirmActionFirst === true,
+    confirmDefault: raw.confirmDefault === "action" ? "action" : "cancel",
+    confirmTone: ["neutral", "accent", "danger"].indexOf(raw.confirmTone) >= 0 ? raw.confirmTone : "neutral",
+    confirmIcon: boundedWorkflowText(raw.confirmIcon, 32),
+    successMessage: boundedWorkflowText(raw.successMessage, 512),
+    successTitle: boundedWorkflowText(raw.successTitle, 128),
+    failureTitle: boundedWorkflowText(raw.failureTitle, 128),
     starAction: boundedWorkflowText(raw.starAction, 128),
     actions: []
   }
@@ -704,7 +771,15 @@ function normalizeWorkflowNode(raw, state, depth) {
       || (raw.topLevel !== undefined && typeof raw.topLevel !== "boolean")
       || (raw.globalSearch !== undefined && typeof raw.globalSearch !== "boolean")
       || (raw.refreshable !== undefined && typeof raw.refreshable !== "boolean")
-      || (raw.closeOnDispatch !== undefined && typeof raw.closeOnDispatch !== "boolean")) return null
+      || (raw.closeOnDispatch !== undefined && typeof raw.closeOnDispatch !== "boolean")
+      || (raw.confirmActionFirst !== undefined && typeof raw.confirmActionFirst !== "boolean")
+      || (raw.confirmDefault !== undefined && ["cancel", "action"].indexOf(raw.confirmDefault) < 0)
+      || (raw.confirmTone !== undefined && ["neutral", "accent", "danger"].indexOf(raw.confirmTone) < 0)
+      || (raw.confirmIcon !== undefined && typeof raw.confirmIcon !== "string")
+      || !validOptionalWorkflowText(raw.confirmTitle, 128)
+      || !validOptionalWorkflowText(raw.successMessage, 512)
+      || !validOptionalWorkflowText(raw.successTitle, 128)
+      || !validOptionalWorkflowText(raw.failureTitle, 128)) return null
   node.maxLength = Math.max(1, Math.min(MAX_WORKFLOW_TEXT, maxLength))
   node.nextBackSteps = Math.max(0, Math.min(MAX_WORKFLOW_DEPTH, nextBackSteps))
   node.defaultValue = boundedWorkflowText(raw.default, MAX_WORKFLOW_TEXT).substring(0, node.maxLength)
@@ -721,7 +796,7 @@ function normalizeWorkflowNode(raw, state, depth) {
     node.next = normalizeWorkflowNode(raw.next, state, depth + 1)
     if (!node.next) return null
   }
-  if (kind === "directoryPicker" && !node.next) return null
+  if ((kind === "directoryPicker" || kind === "filePicker") && !node.next) return null
   if (kind === "input" && node.command.length === 0 && !node.next) return null
   if (kind === "action" && node.command.length === 0 && node.documentCommand.length === 0
       && node.submenuCommand.length === 0) return null
@@ -729,10 +804,8 @@ function normalizeWorkflowNode(raw, state, depth) {
   if (Array.isArray(raw.actions) && kind !== "menu") {
     if (raw.actions.length > 16) return null
     node.actions = normalizeWorkflowChildren(raw.actions.map(function(action) {
-      var copy = Object.assign({}, action)
-      copy.kind = copy.confirm ? "confirm" : (copy.input ? "input" : "action")
-      if (copy.input) copy = Object.assign({}, copy, copy.input, { kind: "input", command: copy.input.command || copy.command })
-      delete copy.actions
+      var copy = prepareDynamicAction(action)
+      if (copy) delete copy.actions
       return copy
     }), state, depth + 1)
     if (!node.actions) return null
@@ -833,13 +906,8 @@ function normalizeDetailDocument(raw) {
   if (!Array.isArray(rawActions) || rawActions.length > 16) return null
   var actionState = { count: 0 }
   var actions = normalizeWorkflowChildren(rawActions.map(function(action) {
-    if (!action || typeof action !== "object" || Array.isArray(action)) return null
-    var copy = Object.assign({}, action)
-    copy.kind = copy.confirm ? "confirm" : (copy.input ? "input" : "action")
-    if (copy.input) copy = Object.assign({}, copy, copy.input,
-      { kind: "input", command: copy.input.command || copy.command })
-    delete copy.actions
-    delete copy.document
+    var copy = prepareDynamicAction(action)
+    if (copy) delete copy.actions
     return copy
   }), actionState, 0)
   if (!actions) return null
@@ -877,8 +945,8 @@ function workflowCommand(node, input, context) {
   return source.map(function(argument) { return workflowInterpolate(argument, replacements) })
 }
 
-function workflowDirectoryTransition(node, path, context) {
-  if (!node || node.kind !== "directoryPicker" || !node.next) return null
+function workflowPathTransition(node, path, context) {
+  if (!node || ["directoryPicker", "filePicker"].indexOf(node.kind) < 0 || !node.next) return null
   var selectedPath = normalizeFavoritePath(path)
   if (!selectedPath) return null
   var slash = selectedPath.lastIndexOf("/")
@@ -889,6 +957,14 @@ function workflowDirectoryTransition(node, path, context) {
       basename: selectedPath === "/" ? "/" : selectedPath.substring(slash + 1)
     })
   }
+}
+
+function workflowDirectoryTransition(node, path, context) {
+  return node && node.kind === "directoryPicker" ? workflowPathTransition(node, path, context) : null
+}
+
+function workflowFileTransition(node, path, context) {
+  return node && node.kind === "filePicker" ? workflowPathTransition(node, path, context) : null
 }
 
 function workflowInputTransition(node, input, context) {
@@ -1192,9 +1268,8 @@ function normalizeDynamicMenuRows(rows, allowEmpty) {
   for (var i = 0; i < rows.length; i++) {
     var row = rows[i]
     if (!row || typeof row !== "object" || Array.isArray(row)) return null
-    var copy = Object.assign({}, row)
-    copy.kind = copy.confirm ? "confirm" : (copy.input ? "input" : "action")
-    if (copy.input) copy = Object.assign({}, copy, copy.input, { kind: "input", command: copy.input.command || copy.command })
+    var copy = prepareDynamicAction(row)
+    if (!copy) return null
     prepared.push(copy)
   }
   if (allowEmpty && prepared.length === 0) return []
@@ -2112,6 +2187,7 @@ if (typeof module !== "undefined") {
     safeExtensionPattern: safeExtensionPattern,
     openStateReset: openStateReset,
     utf8ByteLength: utf8ByteLength,
+    boundedUtf8Prefix: boundedUtf8Prefix,
     normalizeWorkflow: normalizeWorkflow,
     normalizeDetailDocument: normalizeDetailDocument,
     normalizeDynamicMenuOutput: normalizeDynamicMenuOutput,
@@ -2130,6 +2206,7 @@ if (typeof module !== "undefined") {
     workflowInitialInput: workflowInitialInput,
     workflowCommand: workflowCommand,
     workflowDirectoryTransition: workflowDirectoryTransition,
+    workflowFileTransition: workflowFileTransition,
     workflowInputTransition: workflowInputTransition,
     rebindWorkflow: rebindWorkflow,
     workflowActionIsCurrent: workflowActionIsCurrent,

--- a/MenuModel.js
+++ b/MenuModel.js
@@ -594,6 +594,7 @@ function openStateReset() {
     actionPanelFile: null,
     fileBrowserActive: false,
     directoryPickerActive: false,
+    filePickerActive: false,
     fileBrowserExtension: null,
     fileBrowserPath: "",
     fileEntries: [],

--- a/tests/confirmation-menu-harness.qml
+++ b/tests/confirmation-menu-harness.qml
@@ -1,0 +1,68 @@
+import Quickshell
+import QtQuick
+import ".."
+
+ShellRoot {
+  FloatingWindow {
+    visible: false
+    width: 640
+    height: 480
+
+    ConfirmationMenu {
+      id: menu
+      anchors.fill: parent
+      opened: true
+      actionText: "Run"
+      onCanceled: test.cancelCount += 1
+      onConfirmed: test.confirmCount += 1
+    }
+  }
+
+  QtObject {
+    id: test
+    property int cancelCount: 0
+    property int confirmCount: 0
+  }
+
+  Timer {
+    interval: 10
+    running: true
+    onTriggered: {
+      function key(code) { return { key: code, modifiers: Qt.NoModifier } }
+      function reopen(actionFirst, defaultChoice) {
+        menu.opened = false
+        menu.actionFirst = actionFirst
+        menu.defaultChoice = defaultChoice
+        menu.resultOnly = false
+        menu.opened = true
+      }
+
+      if (menu.selectedIndex !== menu.cancelIndex()) throw new Error("Cancel is not the safe default")
+      menu.handleKey(key(Qt.Key_Down))
+      menu.handleKey(key(Qt.Key_Return))
+      if (test.confirmCount !== 1) throw new Error("Cancel-first action activation failed")
+
+      reopen(true, "cancel")
+      if (menu.selectedIndex !== 1 || menu.cancelIndex() !== 1) throw new Error("Order changed the cancel default")
+      menu.handleKey(key(Qt.Key_Up))
+      menu.handleKey(key(Qt.Key_Return))
+      if (test.confirmCount !== 2) throw new Error("Action-first mapping failed")
+
+      reopen(false, "action")
+      if (menu.selectedIndex !== 1) throw new Error("Action default did not work with cancel-first order")
+      menu.handleKey(key(Qt.Key_Escape))
+      if (test.cancelCount !== 1 || test.confirmCount !== 2) throw new Error("Escape did not always cancel")
+
+      reopen(true, "action")
+      if (menu.selectedIndex !== 0) throw new Error("Action default did not work with action-first order")
+      menu.handleKey(key(Qt.Key_Escape))
+      if (test.cancelCount !== 2) throw new Error("Escape ran the selected action")
+
+      menu.resultOnly = true
+      menu.handleKey(key(Qt.Key_Enter))
+      if (test.confirmCount !== 3 || menu.optionCount() !== 1) throw new Error("Result OK row failed")
+      console.log("HARNESS_OK confirmation menu order default and escape behavior")
+      Qt.quit()
+    }
+  }
+}

--- a/tests/confirmation-menu-integration-test.sh
+++ b/tests/confirmation-menu-integration-test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if ! command -v quickshell >/dev/null 2>&1; then
+  echo "ok - Quickshell confirmation-menu harness skipped (quickshell unavailable)"
+  exit 0
+fi
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cp "$root/ConfirmationMenu.qml" "$root/tests/confirmation-menu-harness.qml" "$tmp/"
+ln -s /usr/share/omarchy/shell/Commons "$tmp/Commons"
+ln -s /usr/share/omarchy/shell/Ui "$tmp/Ui"
+output="$(timeout 8 quickshell --no-color -p "$tmp/confirmation-menu-harness.qml" 2>&1)"
+printf '%s\n' "$output"
+grep -q "HARNESS_OK confirmation menu order default and escape behavior" <<<"$output"
+echo "ok - Confirmation menu handles independent order, default, and Escape"

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -880,7 +880,9 @@ assert(menu.compactActionBarHints(starredActionHints).map(hint => hint.label).jo
 
 const resetOpenState = menu.openStateReset({ workflowActive: true, fileBrowserActive: true })
 assert(resetOpenState.workflowActive === false && resetOpenState.workflowNode === null && resetOpenState.workflowStack.length === 0, 'new opens reset workflow state')
-assert(resetOpenState.fileBrowserActive === false && resetOpenState.directoryPickerActive === false && resetOpenState.fileBrowserExtension === null, 'new opens reset file browser and directory picker state')
+assert(resetOpenState.fileBrowserActive === false && resetOpenState.directoryPickerActive === false
+  && resetOpenState.filePickerActive === false && resetOpenState.fileBrowserExtension === null,
+  'new opens reset file browser and workflow picker state')
 assert(menu.fileEscapeAction({ actionPanelActive: true, hasFilter: true, path: '/home/test/docs', home: '/home/test' }) === 'close-actions',
   'Escape closes Files actions before it changes their saved search')
 assert(menu.fileEscapeAction({ hasFilter: true, path: '/home/test/docs', home: '/home/test' }) === 'clear-search',
@@ -892,8 +894,9 @@ assert(menu.fileEscapeAction({ path: '/home/test', home: '/home/test' }) === 'le
   'Escape leaves Files at home and at the filesystem root')
 assert(menu.fileEscapeAction({ path: '/home', home: '/home/test' }) === 'parent',
   'Escape continues parent navigation above home')
-assert(menu.fileEscapeAction({ path: '/', home: '/home/test', directoryPickerActive: true }) === 'leave-picker',
-  'Escape at the directory-picker root returns to its workflow')
+assert(menu.fileEscapeAction({ path: '/', home: '/home/test', directoryPickerActive: true }) === 'leave-picker'
+  && menu.fileEscapeAction({ path: '/home/test', home: '/home/test', directoryPickerActive: true }) === 'leave-picker',
+  'Escape at the directory-picker home or root returns to its workflow')
 assert(menu.isHomeOrAncestorPath('/home/test', '/home/test')
   && menu.isHomeOrAncestorPath('/home', '/home/test')
   && !menu.isHomeOrAncestorPath('/home/test/docs', '/home/test')

--- a/tests/menu-model-test.js
+++ b/tests/menu-model-test.js
@@ -18,6 +18,17 @@ assert(menu.utf8ByteLength('GitHub') === 6, 'UTF-8 limits count ASCII bytes')
 assert(menu.utf8ByteLength('é') === 2, 'UTF-8 limits count multibyte characters')
 assert(menu.utf8ByteLength('󰊤') === 4, 'UTF-8 limits count surrogate pairs once')
 assert(menu.utf8ByteLength('\ud800') === 3, 'UTF-8 limits count an unpaired surrogate as replacement bytes')
+const stderrLimit = 256 * 1024
+const oneGiantLine = 'x'.repeat(stderrLimit - 4) + '😀' + 'é'.repeat(stderrLimit)
+const boundedGiantLine = menu.boundedUtf8Prefix(oneGiantLine, stderrLimit)
+assert(boundedGiantLine.bytes === stderrLimit && menu.utf8ByteLength(boundedGiantLine.text) === stderrLimit,
+  'one giant multibyte line retains no more than the exact UTF-8 byte limit')
+assert(!boundedGiantLine.complete && boundedGiantLine.text.endsWith('😀')
+  && !/[\ud800-\udbff]$/.test(boundedGiantLine.text),
+'one giant line stops after a complete astral code point without a split surrogate')
+const repairedPrefix = menu.boundedUtf8Prefix('ok\ud800z', 6)
+assert(repairedPrefix.text === 'ok�z' && menu.utf8ByteLength(repairedPrefix.text) === 6,
+  'bounded UTF-8 prefixes replace invalid surrogate input with valid Unicode')
 
 const validMenuSnapshot = menu.parseMenuJsoncSnapshot('{"items":{"root":{"label":"Root"}}}')
 assert(validMenuSnapshot.valid && validMenuSnapshot.items.length === 1, 'valid menu snapshots are identified')
@@ -308,12 +319,22 @@ const dynamicMenu = menu.normalizeDynamicMenuOutput(JSON.stringify({ items: [
   { id: 'open', label: 'Open docs', primaryActionLabel: 'Open', refreshable: true, description: 'Documentation', aliases: ['manual', 'reference'], starred: true, starAction: 'star', command: ['xdg-open', 'https://example.test'], closeOnSuccess: true, actions: [
     { id: 'star', label: 'Unstar', command: ['links', 'star', 'open', 'false'] },
     { id: 'open', label: 'Open', command: ['xdg-open', 'https://example.test'], closeOnSuccess: true },
-    { id: 'delete', label: 'Delete', confirm: 'Delete this link?', confirmLabel: 'Delete', command: ['links', 'delete', 'open'], refreshExtensions: true }
+    { id: 'delete', label: 'Delete', confirm: 'Delete this link?', confirmLabel: 'Delete', confirmActionFirst: true, confirmDefault: 'action', confirmTone: 'danger', confirmIcon: 'delete-icon', command: ['links', 'delete', 'open'], refreshExtensions: true }
   ] },
   { id: 'add', label: 'Add Quicklink', input: { prompt: 'URL', maxLength: 200, command: ['links', 'add', '{input}'] } }
 ] }))
 assert(dynamicMenu && dynamicMenu.items.length === 2, 'bounded dynamic menu output is normalized')
 assert(dynamicMenu.items[0].kind === 'action' && dynamicMenu.items[0].actions[2].kind === 'confirm', 'rows retain direct actions and contextual confirmations')
+const configuredConfirmation = dynamicMenu.items[0].actions[2]
+assert(configuredConfirmation.confirmActionFirst && configuredConfirmation.confirmDefault === 'action'
+  && configuredConfirmation.confirmTone === 'danger' && configuredConfirmation.confirmIcon === 'delete-icon',
+  'confirmations retain independent order, default, tone, and icon fields')
+for (const invalidConfirmation of [
+  { confirmActionFirst: 'yes' }, { confirmDefault: 'first' }, { confirmTone: 'loud' }, { confirmIcon: 42 }
+]) {
+  const raw = { items: [{ id: 'bad-confirm', label: 'Bad', confirm: 'Sure?', command: ['bad'], ...invalidConfirmation }] }
+  assert(menu.normalizeDynamicMenuOutput(JSON.stringify(raw)) === null, 'invalid confirmation settings reject the row')
+}
 assert(dynamicMenu.items[0].closeOnSuccess, 'launch rows can request launcher closure after successful dispatch')
 assert(dynamicMenu.items[0].starred, 'dynamic rows retain explicit starred state')
 assert(dynamicMenu.items[0].starAction === 'star', 'dynamic rows can identify a direct Ctrl+S star action')
@@ -480,6 +501,34 @@ const capturedMenu = menu.normalizeDynamicMenuOutput([{ id: 'add', label: 'Add',
 const capturedTransition = menu.workflowInputTransition(capturedMenu.items[0], 'https://example.test', {})
 assert(capturedTransition.context.target === 'https://example.test' && capturedTransition.node.id === 'name', 'input capture passes a named literal value to the next host input without persistent draft state')
 assert(menu.normalizeDynamicMenuOutput([{ id: 'bad-capture', label: 'Bad', input: { prompt: 'Bad', capture: '__proto__', command: ['true'] } }]) === null, 'input capture names reject unsafe structural keys')
+const pickerMenu = menu.normalizeDynamicMenuOutput([{ id: 'send', label: 'Send file', context: { peerId: 'machine-7' }, filePicker: {
+  next: { id: 'send-confirm', kind: 'confirm', label: 'Send file', confirm: 'Send {basename}?', command: ['helper', 'send', '{peerId}', '{path}'] }
+} }])
+assert(pickerMenu && pickerMenu.items[0].kind === 'filePicker' && pickerMenu.items[0].context.peerId === 'machine-7',
+'dynamic rows normalize the host filePicker object and retain row context')
+assert(menu.normalizeDynamicMenuOutput([{ id: 'bad-picker', label: 'Bad', filePicker: {} }]) === null,
+'filePicker rows require a next node')
+assert(menu.normalizeDynamicMenuOutput([{ id: 'bad-picker-extra', label: 'Bad', filePicker: { next: { id: 'done', kind: 'action', label: 'Done', command: ['true'] }, root: '/tmp' } }]) === null,
+'filePicker objects reject unsupported fields')
+assert(menu.normalizeDynamicMenuOutput([{ id: 'ambiguous-picker', label: 'Bad', command: ['true'], filePicker: { next: { id: 'done', kind: 'action', label: 'Done', command: ['true'] } } }]) === null,
+'filePicker rows reject conflicting primary actions')
+const pickerConflict = { id: 'pick', label: 'Pick', filePicker: { next: { id: 'done', kind: 'action', label: 'Done', command: ['true'] } }, input: {} }
+assert(menu.normalizeDynamicMenuOutput([{ id: 'row', label: 'Row', command: ['true'], actions: [pickerConflict] }]) === null,
+'contextual filePicker actions reject conflicting action forms')
+assert(menu.normalizeDetailDocument({ title: 'Doc', actions: [pickerConflict] }) === null,
+'document filePicker actions reject conflicting action forms')
+const documentPicker = menu.normalizeDetailDocument({ title: 'Doc', actions: [{ id: 'pick', label: 'Pick', filePicker: { next: { id: 'done', kind: 'action', label: 'Done', command: ['true'] } } }] })
+assert(documentPicker && documentPicker.actions[0].kind === 'filePicker', 'document actions support strict filePicker navigation')
+const resultTextAction = menu.normalizeDetailDocument({ title: 'Doc', actions: [{ id: 'save', label: 'Save', command: ['true'], confirm: 'Save?', confirmTitle: 'Confirm {name}', successMessage: 'Saved {name}', successTitle: 'Done {name}', failureTitle: 'Failed {name}' }] })
+assert(resultTextAction && resultTextAction.actions[0].confirmTitle === 'Confirm {name}'
+  && resultTextAction.actions[0].successMessage === 'Saved {name}'
+  && resultTextAction.actions[0].successTitle === 'Done {name}'
+  && resultTextAction.actions[0].failureTitle === 'Failed {name}',
+'document actions retain confirmation and result text for runtime interpolation')
+for (const [field, limit] of [['confirmTitle', 128], ['successMessage', 512], ['successTitle', 128], ['failureTitle', 128]]) {
+  const tooLong = { title: 'Doc', actions: [{ id: 'bad', label: 'Bad', command: ['true'], [field]: 'x'.repeat(limit + 1) }] }
+  assert(menu.normalizeDetailDocument(tooLong) === null, `${field} rejects text above its exact limit`)
+}
 assert(menu.normalizeDynamicMenuOutput('{bad') === null, 'malformed dynamic menu output is rejected')
 assert(menu.normalizeDynamicMenuOutput({ items: Array.from({ length: 101 }, (_, i) => ({ id: String(i), label: String(i), command: ['true'] })) }) === null, 'dynamic menu row counts are bounded')
 assert(menu.normalizeDynamicMenuOutput([{ id: 'bad', label: 'Bad', command: 'true' }]) === null, 'dynamic menu commands must be argument arrays')
@@ -590,6 +639,25 @@ assert(projectsNode.label === 'Projects' && projectsNode.items.length === 2, 'wo
 const directoryTransition = menu.workflowDirectoryTransition(projectsNode.items[1], '/tmp/Saved Project/', {})
 assert(directoryTransition.node.id === 'name' && directoryTransition.context.path === '/tmp/Saved Project' && directoryTransition.context.basename === 'Saved Project', 'directory selection transitions to naming with a basename default context')
 assert(menu.workflowInterpolate(directoryTransition.node.defaultValue, directoryTransition.context) === 'Saved Project', 'project naming defaults to the selected directory basename')
+const fileWorkflow = menu.normalizeWorkflow({ items: [{
+  id: 'choose', kind: 'filePicker', label: 'Choose file', context: { peerId: 'machine-7' }, next: {
+    id: 'send-confirm', kind: 'confirm', label: 'Send file', confirm: 'Send {basename}?',
+    command: ['helper', 'send', '{peerId}', '{path}']
+  }
+}] })
+const fileContext = Object.assign({}, {}, fileWorkflow.items[0].context)
+const fileTransition = menu.workflowFileTransition(fileWorkflow.items[0], '/tmp/report $(literal).txt', fileContext)
+assert(fileTransition && fileTransition.context.peerId === 'machine-7'
+  && fileTransition.context.path === '/tmp/report $(literal).txt'
+  && fileTransition.context.basename === 'report $(literal).txt',
+'file selection retains machine context and supplies literal path and basename values')
+assert(menu.workflowCommand(fileTransition.node, '', fileTransition.context).join('\0')
+  === ['helper', 'send', 'machine-7', '/tmp/report $(literal).txt'].join('\0'),
+'file selection substitutes path and machine context as complete literal command arguments')
+assert(menu.workflowDirectoryTransition(fileWorkflow.items[0], '/tmp/report.txt', {}) === null,
+'directory transitions reject file-picker nodes')
+assert(menu.workflowFileTransition(projectsNode.items[1], '/tmp/project', {}) === null,
+'file transitions reject directory-picker nodes')
 assert(menu.workflowInitialInput(directoryTransition.node, directoryTransition.context) === 'Saved Project', 'workflow defaults are prepared through the bounded initial-input path')
 const sessionNode = projectsNode.items[0].items[0]
 assert(menu.workflowCommand(sessionNode, '', { path: '/tmp/Saved Project' }).join('\0') === ['xdg-terminal-exec', '--dir=/tmp/Saved Project', '--', 'codex'].join('\0'), 'empty prompts launch blank interactive Codex without an empty argument')

--- a/tests/qml-extension-path-test.js
+++ b/tests/qml-extension-path-test.js
@@ -8,6 +8,7 @@ function assert(condition, message) {
 
 const qml = fs.readFileSync(path.join(__dirname, '..', 'Menu.qml'), 'utf8')
 const favoritesQml = fs.readFileSync(path.join(__dirname, '..', 'LauncherFavorites.qml'), 'utf8')
+const confirmationQml = fs.readFileSync(path.join(__dirname, '..', 'ConfirmationMenu.qml'), 'utf8')
 
 const pluginPathExpression = qml.match(/readonly property string pluginPath: (.+)/)[1]
 for (const directory of ['/home/test/plugins/omalaunch', '/tmp/launcher with spaces/#100%']) {
@@ -90,16 +91,21 @@ assert(qml.includes('root.invalidateExtensionQuery("launcher closed")')
   && qml.includes('root.invalidateExtensionQuery("new launcher session")')
   && qml.includes('root.scheduleExtensionQuery()'),
 'close/open and catalog/query context changes invalidate live-query generations')
-assert(qml.includes('if (root.directoryPickerActive) root.workflowBack()'),
-'directory picker Backspace at filesystem root returns through workflow history')
+assert(qml.includes('if (root.workflowPickerActive) root.workflowBack()'),
+'workflow pickers return through workflow history at the filesystem root')
 assert(qml.includes('event.key === Qt.Key_H && (event.modifiers & Qt.ControlModifier)')
   && qml.includes('root.toggleHiddenFiles()')
   && qml.includes('root.fileBrowserShowHidden ? ["--hidden"] : []'),
 'Files Ctrl+H rebuilds browsing and search with hidden entries toggled')
-const directoryPickerBody = qml.slice(qml.indexOf('function enterDirectoryPicker('), qml.indexOf('function selectWorkflowDirectory('))
-assert(directoryPickerBody.includes('root.fileBrowserShowHidden = false')
+const pickerBody = qml.slice(qml.indexOf('function enterWorkflowPicker('), qml.indexOf('function selectWorkflowPath('))
+assert(pickerBody.includes('root.fileBrowserShowHidden = false')
+  && pickerBody.includes('root.filePickerActive = kind === "filePicker"')
   && resetBody.includes('root.fileBrowserShowHidden = false'),
-'new launcher and directory-picker sessions cannot inherit hidden-file mode')
+'new launcher, directory-picker, and file-picker sessions cannot inherit hidden-file mode')
+assert(qml.includes('else if (root.filePickerActive) {\n        root.selectWorkflowPath(row.action)')
+  && qml.includes('if (!root.fileBrowserActive || root.workflowPickerActive')
+  && qml.includes('if (root.workflowPickerActive) return'),
+'file-picker files select into the workflow and picker mode blocks file actions, copy, and stars')
 
 const dynamicProviderBody = qml.slice(qml.indexOf('id: dynamicMenuProc'), qml.indexOf('id: workflowActionTimeout'))
 assert(qml.includes('else if (activation === "menu") root.enterDynamicMenu(extension)')
@@ -258,6 +264,26 @@ assert(qml.includes('MenuModel.footerActionIdForShortcut(key, modifiers)')
   && qml.includes('if (root.workflowActive) root.toggleSelectedWorkflowStar()')
   && qml.includes('root.dispatchWorkflowNode(action, "", false, true)'),
 'workflow rows with a declared star action support Ctrl+S through the background action lifecycle')
+assert(qml.includes('property var workflowPendingSuccess: null')
+  && qml.includes('root.workflowPendingSuccess = continuation')
+  && qml.includes('if (workflowActionProc.successMessage) {')
+  && qml.includes('return\n      }\n      root.applyWorkflowSuccess(continuation)')
+  && qml.includes('onConfirmed: root.dismissWorkflowResult()')
+  && qml.includes('root.workflowPendingSuccess = null'),
+'success results delay their exact continuation until OK and invalidation clears stale pending work')
+assert(qml.includes('stderr: SplitParser {')
+  && qml.includes('var chunk = MenuModel.boundedUtf8Prefix(data, remaining)')
+  && qml.includes('workflowActionProc.signal(15)')
+  && qml.includes('root.boundedDiagnostic(workflowActionProc.stderrText || "Action failed", 512)')
+  && !qml.includes('var next = workflowActionProc.stderrText + data + "\\n"')
+  && !qml.includes('workflowActionProc.stderrText.substring(0, 512)')
+  && !qml.includes('stderr: StdioCollector { waitForEnd: true; onStreamFinished: workflowActionProc.stderrText = text }'),
+'workflow action stderr bounds each chunk before concatenation and stops oversized output')
+assert(confirmationQml.includes('property real maximumHeight')
+  && confirmationQml.includes('Flickable {')
+  && confirmationQml.includes('clip: true')
+  && confirmationQml.includes('ensureChoiceVisible()'),
+'confirmation content is height bounded, scrollable, and keeps the keyboard choice visible')
 assert(qml.includes('else if (root.selectedDynamicStarAction) root.toggleSelectedDynamicStar()')
   && qml.includes('root.dispatchBackgroundAction(extension, action, "")')
   && qml.includes('id: backgroundActionProc')
@@ -310,12 +336,11 @@ assert(qml.includes('documentProc.usageItemId = ""')
 assert(qml.includes('function dispatchWorkflowNode(node, input, returnToRoot, backgroundRequested)')
   && qml.includes('workflowActionProc.refreshDynamicMenu = root.workflowExtension.mode === "menu"')
   && qml.includes('workflowActionProc.closeAfter = node.closeOnSuccess')
-  && qml.includes('if (workflowActionProc.refreshExtensions) root.loadExtensions(true)'),
+  && qml.includes('if (continuation.refreshExtensions) root.loadExtensions(true)'),
 'dynamic row mutations reuse tracked workflow actions and refresh successful state')
 const workflowExit = qml.slice(qml.indexOf('id: workflowActionProc'), qml.indexOf('id: backgroundActionTimeout'))
 assert(workflowExit.includes('if (exitCode !== 0)')
-  && workflowExit.includes('if (usageItemId) usage.record(usageItemId)')
-  && workflowExit.indexOf('if (exitCode !== 0)') < workflowExit.indexOf('usage.record(usageItemId)')
+  && qml.includes('if (continuation.usageItemId) usage.record(continuation.usageItemId)')
   && workflowExit.includes('MenuModel.workflowActionIsCurrent'),
 'dynamic usage is published only after a successful current foreground action')
 const backgroundExit = qml.slice(qml.indexOf('id: backgroundActionProc'), qml.indexOf('id: resultProc'))
@@ -439,10 +464,22 @@ assert(qml.includes('font.pixelSize: Math.max(1, Math.round(Style.font.heading *
   && qml.includes('font.pixelSize: Math.max(1, Math.round(Style.font.title * root.menuItemScale))')
   && qml.includes('spacing: Math.max(Style.space(4), Math.round(Style.space(7) * root.menuItemScale))'),
 'empty-result icon, message, and spacing scale with the configured item font size')
-assert(qml.includes('readonly property color dialogBackground: Qt.rgba(background.r, background.g, background.b, 1)')
-  && (qml.match(/background: root\.dialogBackground/g) || []).length === 3,
-'confirmation cards use one theme-compatible opaque surface')
-assert(qml.includes('z: (root.workflowConfirmOpen || root.deleteConfirmOpen || root.dependencyConfirmOpen) ? 20 : 0')
-  && (qml.match(/onOpenedChanged: if \(opened\) \{ selectedIndex = 1; keyCatcher\.forceActiveFocus\(\) \}/g) || []).length === 3
-  && qml.includes('workflowConfirm.handleKey(event)'),
-'confirmation dialogs retain focus, reset the safe button, and route keyboard input')
+assert(qml.includes('visible: !root.confirmationContentActive')
+  && qml.includes('readonly property bool imagePreviewActive: !root.confirmationContentActive')
+  && (qml.match(/anchors\.leftMargin: card\.contentLeftInset/g) || []).length >= 5
+  && !confirmationQml.includes('scrim')
+  && !confirmationQml.includes('BorderSurface {\n    id: surface'),
+'confirmation content replaces the normal host content without a card, scrim, or preview')
+assert(qml.includes('z: (root.workflowResultOpen || root.workflowConfirmOpen || root.deleteConfirmOpen || root.dependencyConfirmOpen) ? 20 : 0')
+  && (qml.match(/onOpenedChanged: if \(opened\) keyCatcher\.forceActiveFocus\(\)/g) || []).length === 4
+  && qml.includes('workflowResult.handleKey(event)')
+  && qml.includes('workflowConfirm.handleKey(event)')
+  && confirmationQml.includes('if (opened) { selectedIndex = defaultIndex(); Qt.callLater(ensureChoiceVisible) }')
+  && confirmationQml.includes('if (event.key === Qt.Key_Escape) canceled()')
+  && confirmationQml.includes('return true'),
+'confirmation menus retain focus, apply their configured default, always cancel on Escape, and swallow keyboard input')
+assert((qml.match(/ConfirmationMenu \{/g) || []).length === 4
+  && !qml.includes('ConfirmDialog {')
+  && confirmationQml.includes('model: control.optionCount()')
+  && confirmationQml.includes('selectedIndex === cancelIndex()'),
+'all confirmations use semantic vertical choices and results use one OK row')

--- a/tests/qml-extension-path-test.js
+++ b/tests/qml-extension-path-test.js
@@ -91,8 +91,9 @@ assert(qml.includes('root.invalidateExtensionQuery("launcher closed")')
   && qml.includes('root.invalidateExtensionQuery("new launcher session")')
   && qml.includes('root.scheduleExtensionQuery()'),
 'close/open and catalog/query context changes invalidate live-query generations')
-assert(qml.includes('if (root.workflowPickerActive) root.workflowBack()'),
-'workflow pickers return through workflow history at the filesystem root')
+assert(qml.includes('if (root.workflowPickerActive) root.workflowBack()')
+  && qml.includes('directoryPickerActive: root.workflowPickerActive'),
+'file and directory pickers return through workflow history at home and the filesystem root')
 assert(qml.includes('event.key === Qt.Key_H && (event.modifiers & Qt.ControlModifier)')
   && qml.includes('root.toggleHiddenFiles()')
   && qml.includes('root.fileBrowserShowHidden ? ["--hidden"] : []'),


### PR DESCRIPTION
## Motivation

Extensions such as Tailscale need a host-owned way to select one file, confirm the exact operation, and show its result. Extensions must not ship QML or implement their own confirmation interface.

## Changes

- add `filePicker` workflow nodes and dynamic-menu rows
- preserve row context and provide literal `{path}` and `{basename}` values to the next stage
- block file open, copy, star, and Action Panel operations while a workflow picker is active
- render confirmations as inline menu content
- keep Cancel as the safe default unless the extension explicitly selects the action
- make Escape always cancel confirmations
- add configurable action order, default choice, tone, icon, and title
- show bounded success and failure results after tracked workflow actions
- delay successful close, refresh, or next-stage transitions until the result is dismissed
- bound workflow stderr retained for failure messages

## Extension contract

New fields:

- `filePicker.next`
- `confirmTitle`
- `confirmActionFirst`
- `confirmDefault`
- `confirmTone`
- `confirmIcon`
- `successMessage`
- `successTitle`
- `failureTitle`

Commands remain direct argument arrays. Selected paths and inherited context are substituted as complete literal arguments.

## Testing

- full repository CI command set
- `node tests/menu-model-test.js`
- `node tests/qml-extension-path-test.js`
- `bash tests/confirmation-menu-integration-test.sh`
- `bash tests/live-query-process-integration-test.sh`
- `bash tests/manifest-test.sh`
- `git diff --check`

## Manual QA

- selected a file through a dynamic-menu file picker
- confirmed directory navigation and file selection
- checked action-first and cancel-first confirmation layouts
- checked accent and danger action tones
- completed a Tailscale Taildrop send
- checked inline success and failure results

## Release dependency

The Tailscale extension release depends on this host contract. Omalaunch must release this change before the extension file-send flow is published.
