### PR TITLE
Restore application results when the host app library is missing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,12 @@ jobs:
       - name: Run workflow row detail tests
         run: node tests/workflow-row-detail-test.js
 
+      - name: Run app library fallback contract tests
+        run: node tests/app-library-fallback-contract-test.js
+
+      - name: Run app library fallback lifecycle harness when available
+        run: bash tests/app-library-fallback-integration-test.sh
+
       - name: Run Quickshell live-query process harness when available
         run: bash tests/live-query-process-integration-test.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,12 @@ jobs:
       - name: Run workflow row detail tests
         run: node tests/workflow-row-detail-test.js
 
+      - name: Run app library reconciliation contract tests
+        run: node tests/app-library-reconciliation-contract-test.js
+
+      - name: Run app library reconciliation lifecycle harness when available
+        run: bash tests/app-library-reconciliation-integration-test.sh
+
       - name: Run app library fallback contract tests
         run: node tests/app-library-fallback-contract-test.js
 

--- a/APP-LIBRARY-COMPATIBILITY.md
+++ b/APP-LIBRARY-COMPATIBILITY.md
@@ -1,0 +1,40 @@
+# Temporary app-library fallback
+
+Tracking issue: [#68](https://github.com/DanielLemky/omalaunch/issues/68).
+
+Upstream correction: [Omarchy PR #11075](https://github.com/omacom/omarchy/pull/11075).
+
+`LauncherAppLibrary.qml` is a temporary compatibility component. It uses the host's shared library when available and loads an independent installed app service only when the attached shell supplies no library. A fixed host does not load the fallback. No version check or configuration switch is required.
+
+## Removal condition
+
+Remove the fallback when Omalaunch's minimum supported Omarchy version includes the upstream correction, or an equivalent verified fix. An upstream merge alone is not sufficient while affected Omarchy versions remain supported. Record the first fixed release and the minimum supported version when those are known; do not guess a version now.
+
+Before removal, test the minimum supported host and a current host. Confirm that each supplies the shared app library and that Apps, search, launch, reopening, and plugin rescan work without the fallback.
+
+## Removal checklist
+
+1. In `Menu.qml`, remove the `sharedAppLibrary` property and the `LauncherAppLibrary` instance. Restore the direct binding:
+
+   ```qml
+   readonly property var appLibrary: root.shell ? root.shell.appLibrary : null
+   ```
+
+2. Delete `LauncherAppLibrary.qml`.
+3. Delete only the fallback-specific tests and fixtures:
+   - `tests/app-library-fallback-contract-test.js`
+   - `tests/app-library-fallback-integration-test.sh`
+   - `tests/app-library-fallback-harness.qml`
+   - `tests/app-library-fallback-fixture.qml`
+   - `tests/app-library-fallback-state.js`
+4. Remove the two fallback test steps from `.github/workflows/test.yml`.
+5. Remove the application-library compatibility subsection from `README.md` and delete this note.
+6. Run the permanent reconciliation tests, the remaining test suite, and the host checks above.
+
+## Keep after removal
+
+- The timer-based `onAppLibraryChanged` reconciliation and `appRowsMergeDebounce` in `Menu.qml`. They prevent delayed work from running after menu destruction, regardless of the selected library.
+- All `tests/app-library-reconciliation-*` files and their CI steps. These tests depend on `Menu.qml`, not on the fallback component or its fixtures.
+- The separate icon-refresh compatibility fix and its tests, once integrated. Raw and proxy app-library APIs differ even without this workaround.
+
+The runtime fallback code and its tests can therefore be deleted without deleting the permanent reload protection.

--- a/LauncherAppLibrary.qml
+++ b/LauncherAppLibrary.qml
@@ -1,0 +1,73 @@
+import QtQuick
+
+// Temporary compatibility path for hosts that omit the menu app-library API.
+// The fallback is an independent instance of the installed Omarchy service,
+// not a reference to the host's private object tree.
+Item {
+  id: root
+
+  property var sharedLibrary: null
+  property bool fallbackEnabled: false
+  property url fallbackSource: ""
+  property string omarchyPath: ""
+  readonly property var library: root.sharedLibrary
+    || (root.fallbackEnabled ? fallbackLoader.item : null)
+  readonly property int fallbackStatus: fallbackLoader.status
+  property bool componentReady: false
+  property string loadedOmarchyPath: ""
+
+  function releaseFallback() {
+    var owned = fallbackLoader.item
+    // The service can leave a duration-0 launch OSD open. Stop its launch
+    // timers and close only its own feedback before the Loader destroys it.
+    if (owned && typeof owned.closeLaunchFeedback === "function") {
+      try {
+        owned.closeLaunchFeedback(owned.launchSerial)
+      } catch (error) {
+        console.warn("Omalaunch: fallback launch feedback cleanup failed:", error)
+      }
+    }
+    fallbackLoader.active = false
+    fallbackLoader.source = ""
+    root.loadedOmarchyPath = ""
+  }
+
+  function syncFallback() {
+    if (!root.componentReady) return
+    var wanted = root.fallbackEnabled && !root.sharedLibrary
+      && String(root.fallbackSource).length > 0
+    if (wanted && fallbackLoader.active
+        && String(fallbackLoader.source) === String(root.fallbackSource)
+        && root.loadedOmarchyPath === root.omarchyPath) return
+    root.releaseFallback()
+    if (!wanted) return
+    root.loadedOmarchyPath = root.omarchyPath
+    // Set properties before Component.onCompleted starts the service scans.
+    fallbackLoader.setSource(root.fallbackSource, { omarchyPath: root.omarchyPath })
+    fallbackLoader.active = true
+  }
+
+  onSharedLibraryChanged: root.syncFallback()
+  onFallbackEnabledChanged: root.syncFallback()
+  onFallbackSourceChanged: root.syncFallback()
+  onOmarchyPathChanged: root.syncFallback()
+
+  Loader {
+    id: fallbackLoader
+    active: false
+    asynchronous: true
+    onStatusChanged: {
+      if (status === Loader.Error)
+        console.warn("Omalaunch: fallback app library could not load:", source)
+    }
+  }
+
+  Component.onCompleted: {
+    root.componentReady = true
+    root.syncFallback()
+  }
+  Component.onDestruction: {
+    root.componentReady = false
+    root.releaseFallback()
+  }
+}

--- a/LauncherAppLibrary.qml
+++ b/LauncherAppLibrary.qml
@@ -1,6 +1,9 @@
 import QtQuick
 
 // Temporary compatibility path for hosts that omit the menu app-library API.
+// Upstream fix: https://github.com/omacom/omarchy/pull/11075
+// Remove when our minimum supported Omarchy version includes that fix.
+// See APP-LIBRARY-COMPATIBILITY.md for the removal checklist.
 // The fallback is an independent instance of the installed Omarchy service,
 // not a reference to the host's private object tree.
 Item {

--- a/Menu.qml
+++ b/Menu.qml
@@ -271,8 +271,8 @@ Item {
   onAppLibraryChanged: {
     root.appIconIndexUpdatedAt = 0
     root.appIconRefreshPending = false
-    // A provider request can race shell injection or fallback loading. Use
-    // the owned timer so queued reconciliation cannot outlive this menu on
+    // A provider request can race app-library attachment. Use the owned
+    // timer so queued reconciliation cannot outlive this menu on
     // plugin reload. An empty replacement also clears stale detached rows.
     if (root.providersLoaded["apps"] && appRowsMergeDebounce)
       appRowsMergeDebounce.restart()

--- a/Menu.qml
+++ b/Menu.qml
@@ -251,9 +251,20 @@ Item {
   readonly property int previewPaneWidth: Math.round((root.cardWidth
     - card.contentLeftInset - card.contentRightInset - root.contentSpacing) / 2)
 
-  // Shared application engine (entries, hidden filters, icons, launch,
-  // removal), owned by the shell and also used by the standalone launcher.
-  readonly property var appLibrary: root.shell ? root.shell.appLibrary : null
+  // Prefer the host's shared application engine. Omarchy 4.0.3 can inject a
+  // null menu capability; use an independently owned copy of its installed
+  // app service only in that case, without accessing the host's private state.
+  readonly property var sharedAppLibrary: root.shell ? root.shell.appLibrary : null
+  readonly property var appLibrary: appLibraryAccess.library
+
+  LauncherAppLibrary {
+    id: appLibraryAccess
+    sharedLibrary: root.sharedAppLibrary
+    fallbackEnabled: root.shell !== null
+    omarchyPath: root.omarchyPath
+    fallbackSource: root.omarchyPath.charAt(0) === "/"
+      ? Util.fileUrl(root.omarchyPath + "/shell/services/AppLibrary.qml") : ""
+  }
   readonly property int appIconRefreshTtlMs: 30 * 1000
   property double appIconIndexUpdatedAt: 0
   property bool appIconRefreshPending: false

--- a/Menu.qml
+++ b/Menu.qml
@@ -271,16 +271,11 @@ Item {
   onAppLibraryChanged: {
     root.appIconIndexUpdatedAt = 0
     root.appIconRefreshPending = false
-    // A provider request can race shell injection. Reconcile loaded app rows
-    // after attachment or detachment; mergeAppRows() also clears stale rows
-    // when no library is attached.
-    if (root.providersLoaded["apps"]) {
-      var revision = root.providerRevision
-      Qt.callLater(function() {
-        if (revision === root.providerRevision && root.providersLoaded["apps"])
-          root.mergeAppRows()
-      })
-    }
+    // A provider request can race shell injection or fallback loading. Use
+    // the owned timer so queued reconciliation cannot outlive this menu on
+    // plugin reload. An empty replacement also clears stale detached rows.
+    if (root.providersLoaded["apps"] && appRowsMergeDebounce)
+      appRowsMergeDebounce.restart()
   }
   property bool deleteConfirmOpen: false
   property bool dependencyConfirmOpen: false

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ If it is missing, the launcher’s starting view shows **Enable Calculator & Cur
 
 Omalaunch never installs system packages silently. Package installation is offered only for dependencies allow-listed by Omalaunch itself; external extensions cannot supply installation commands.
 
+### Application library compatibility
+
+Omalaunch uses Omarchy's shared application library when it is available. If the shell omits that library, as can occur on Omarchy 4.0.3, Omalaunch uses a separate instance of the installed application service. This preserves Omarchy's application filtering, icons, and launch behavior without changing system files. The separate instance is released when the shared library becomes available. If the installed service is missing or cannot load, application results remain unavailable; other menu commands still work.
+
 ## Usage
 
 Start typing to search commands and applications. Use the arrow keys or Tab and Shift+Tab to move, Enter to activate, and Escape to go back or close the launcher.

--- a/tests/app-library-fallback-contract-test.js
+++ b/tests/app-library-fallback-contract-test.js
@@ -1,0 +1,24 @@
+const fs = require('fs')
+const path = require('path')
+const assert = require('assert')
+
+const menu = fs.readFileSync(path.join(__dirname, '../Menu.qml'), 'utf8')
+const access = fs.readFileSync(path.join(__dirname, '../LauncherAppLibrary.qml'), 'utf8')
+
+assert(menu.includes('readonly property var sharedAppLibrary: root.shell ? root.shell.appLibrary : null'))
+assert(menu.includes('readonly property var appLibrary: appLibraryAccess.library'))
+const integration = menu.match(/  LauncherAppLibrary \{[\s\S]*?\n  \}/)[0]
+assert(integration.includes('sharedLibrary: root.sharedAppLibrary'))
+assert(integration.includes('fallbackEnabled: root.shell !== null'))
+assert(integration.includes('root.omarchyPath.charAt(0) === "/"'))
+assert(integration.includes('Util.fileUrl(root.omarchyPath + "/shell/services/AppLibrary.qml")'))
+assert(!integration.includes('providersLoaded'), 'in-place var map mutations must not gate the loader')
+assert(access.includes('readonly property var library: root.sharedLibrary\n    ||'),
+  'the shared library must take priority')
+assert(access.includes('var wanted = root.fallbackEnabled && !root.sharedLibrary'),
+  'fallback activation must not depend on the effective library')
+assert(access.includes('fallbackLoader.setSource(root.fallbackSource, { omarchyPath: root.omarchyPath })'),
+  'service scans must use the injected installation path from construction')
+const reconcile = menu.slice(menu.indexOf('  onAppLibraryChanged:'), menu.indexOf('  onAppLibraryChanged:') + 800)
+assert(reconcile.includes('root.mergeAppRows()'), 'library changes must reconcile existing application rows')
+console.log('App library fallback contract tests passed')

--- a/tests/app-library-fallback-contract-test.js
+++ b/tests/app-library-fallback-contract-test.js
@@ -19,6 +19,9 @@ assert(access.includes('var wanted = root.fallbackEnabled && !root.sharedLibrary
   'fallback activation must not depend on the effective library')
 assert(access.includes('fallbackLoader.setSource(root.fallbackSource, { omarchyPath: root.omarchyPath })'),
   'service scans must use the injected installation path from construction')
-const reconcile = menu.slice(menu.indexOf('  onAppLibraryChanged:'), menu.indexOf('  onAppLibraryChanged:') + 800)
-assert(reconcile.includes('root.mergeAppRows()'), 'library changes must reconcile existing application rows')
+const reconcile = menu.slice(menu.indexOf('  onAppLibraryChanged:'), menu.indexOf('  property bool deleteConfirmOpen:'))
+assert(reconcile.includes('appRowsMergeDebounce.restart()'), 'library changes must schedule the owned reconciliation timer')
+assert(!reconcile.includes('Qt.callLater'), 'library teardown must not queue callbacks that outlive the menu')
+assert(menu.includes('onTriggered: if (root.providersLoaded["apps"]) root.mergeAppRows()'),
+  'the owned timer must reconcile only the current loaded provider')
 console.log('App library fallback contract tests passed')

--- a/tests/app-library-fallback-contract-test.js
+++ b/tests/app-library-fallback-contract-test.js
@@ -19,9 +19,4 @@ assert(access.includes('var wanted = root.fallbackEnabled && !root.sharedLibrary
   'fallback activation must not depend on the effective library')
 assert(access.includes('fallbackLoader.setSource(root.fallbackSource, { omarchyPath: root.omarchyPath })'),
   'service scans must use the injected installation path from construction')
-const reconcile = menu.slice(menu.indexOf('  onAppLibraryChanged:'), menu.indexOf('  property bool deleteConfirmOpen:'))
-assert(reconcile.includes('appRowsMergeDebounce.restart()'), 'library changes must schedule the owned reconciliation timer')
-assert(!reconcile.includes('Qt.callLater'), 'library teardown must not queue callbacks that outlive the menu')
-assert(menu.includes('onTriggered: if (root.providersLoaded["apps"]) root.mergeAppRows()'),
-  'the owned timer must reconcile only the current loaded provider')
 console.log('App library fallback contract tests passed')

--- a/tests/app-library-fallback-fixture.qml
+++ b/tests/app-library-fallback-fixture.qml
@@ -1,0 +1,49 @@
+import QtQuick
+import "app-library-fallback-state.js" as State
+
+Item {
+  id: root
+  property string omarchyPath: "unset"
+  property var rows: [{ entry: { id: "fallback", name: "Fallback app" } }]
+  property int launchSerial: 0
+  property bool launchPending: false
+  property bool launchOsdOpen: false
+  signal appsChanged()
+
+  function sortedEntries(query) { return root.rows }
+  function iconSource(icon) { return "fixture:" + icon }
+  function changeRows() {
+    root.rows = [{ entry: { id: "changed", name: "Changed app" } }]
+    root.appsChanged()
+  }
+  function launch(id, name) {
+    root.launchSerial++
+    root.launchPending = true
+    delay.restart()
+  }
+  function closeLaunchFeedback(serial) {
+    if (serial !== root.launchSerial) return
+    State.cleanups++
+    delay.stop()
+    root.launchPending = false
+    if (root.launchOsdOpen) State.osdCloses++
+    root.launchOsdOpen = false
+  }
+
+  Timer {
+    id: delay
+    interval: 40
+    onTriggered: {
+      root.launchOsdOpen = true
+      State.osdShows++
+    }
+  }
+  Component.onCompleted: {
+    State.created++
+    State.initializedPath = root.omarchyPath
+  }
+  Component.onDestruction: {
+    State.destroyed++
+    if (root.launchPending || root.launchOsdOpen) State.unsafeDestructions++
+  }
+}

--- a/tests/app-library-fallback-harness.qml
+++ b/tests/app-library-fallback-harness.qml
@@ -5,6 +5,7 @@ import "app-library-fallback-state.js" as State
 ShellRoot {
   id: root
   property var access: null
+  property var reconciliationFixture: null
   property var lastRows: []
   property int stage: 0
   property double stageStarted: Date.now()
@@ -39,6 +40,10 @@ ShellRoot {
       fallbackSource: Qt.resolvedUrl("app-library-fallback-fixture.qml")
       onLibraryChanged: root.reconcile()
     }
+  }
+  Component {
+    id: reconciliationComponent
+    AppLibraryReconciliationFixture { }
   }
   Connections {
     target: root.access ? root.access.library : null
@@ -151,6 +156,27 @@ ShellRoot {
           root.check(State.destroyed === 4 && State.osdCloses === 2, "wrapper destruction must close owned feedback")
           root.check(State.unsafeDestructions === 0, "all owned launch state must be stopped before destruction")
           root.check(State.cleanups === 4, "each owned instance must be cleaned up exactly once")
+          root.reconciliationFixture = reconciliationComponent.createObject(root)
+          root.reconciliationFixture.appLibrary = ({ first: true })
+          root.reconciliationFixture.appLibrary = ({ second: true })
+          root.next()
+          break
+        case 11:
+          if (elapsed < 200) return
+          root.check(State.reconciliations === 1, "library handoff must coalesce reconciliation")
+          root.reconciliationFixture.appLibrary = null
+          root.next()
+          break
+        case 12:
+          if (elapsed < 200) return
+          root.check(State.reconciliations === 2 && State.lastLibraryWasNull, "live detachment must reconcile an empty library")
+          root.reconciliationFixture.appLibrary = ({ pending: true })
+          root.reconciliationFixture.destroy()
+          root.next()
+          break
+        case 13:
+          if (elapsed < 200) return
+          root.check(State.reconciliations === 2, "queued reconciliation must not outlive the menu")
           if (!root.failed) console.log("HARNESS_OK app library fallback lifecycle")
           Qt.quit()
           break

--- a/tests/app-library-fallback-harness.qml
+++ b/tests/app-library-fallback-harness.qml
@@ -5,7 +5,6 @@ import "app-library-fallback-state.js" as State
 ShellRoot {
   id: root
   property var access: null
-  property var reconciliationFixture: null
   property var lastRows: []
   property int stage: 0
   property double stageStarted: Date.now()
@@ -40,10 +39,6 @@ ShellRoot {
       fallbackSource: Qt.resolvedUrl("app-library-fallback-fixture.qml")
       onLibraryChanged: root.reconcile()
     }
-  }
-  Component {
-    id: reconciliationComponent
-    AppLibraryReconciliationFixture { }
   }
   Connections {
     target: root.access ? root.access.library : null
@@ -156,27 +151,6 @@ ShellRoot {
           root.check(State.destroyed === 4 && State.osdCloses === 2, "wrapper destruction must close owned feedback")
           root.check(State.unsafeDestructions === 0, "all owned launch state must be stopped before destruction")
           root.check(State.cleanups === 4, "each owned instance must be cleaned up exactly once")
-          root.reconciliationFixture = reconciliationComponent.createObject(root)
-          root.reconciliationFixture.appLibrary = ({ first: true })
-          root.reconciliationFixture.appLibrary = ({ second: true })
-          root.next()
-          break
-        case 11:
-          if (elapsed < 200) return
-          root.check(State.reconciliations === 1, "library handoff must coalesce reconciliation")
-          root.reconciliationFixture.appLibrary = null
-          root.next()
-          break
-        case 12:
-          if (elapsed < 200) return
-          root.check(State.reconciliations === 2 && State.lastLibraryWasNull, "live detachment must reconcile an empty library")
-          root.reconciliationFixture.appLibrary = ({ pending: true })
-          root.reconciliationFixture.destroy()
-          root.next()
-          break
-        case 13:
-          if (elapsed < 200) return
-          root.check(State.reconciliations === 2, "queued reconciliation must not outlive the menu")
           if (!root.failed) console.log("HARNESS_OK app library fallback lifecycle")
           Qt.quit()
           break

--- a/tests/app-library-fallback-harness.qml
+++ b/tests/app-library-fallback-harness.qml
@@ -1,0 +1,160 @@
+import QtQuick
+import Quickshell
+import "app-library-fallback-state.js" as State
+
+ShellRoot {
+  id: root
+  property var access: null
+  property var lastRows: []
+  property int stage: 0
+  property double stageStarted: Date.now()
+  property bool failed: false
+
+  function check(value, message) {
+    if (value) return
+    root.failed = true
+    console.error("HARNESS_FAIL", message)
+    Qt.quit()
+  }
+  function reconcile() {
+    root.lastRows = root.access && root.access.library
+      ? root.access.library.sortedEntries("") : []
+  }
+  function next() {
+    root.stage++
+    root.stageStarted = Date.now()
+  }
+  function ready() { return root.access && root.access.fallbackStatus === Loader.Ready }
+
+  QtObject {
+    id: shared
+    signal appsChanged()
+    function sortedEntries(query) { return [{ entry: { id: "shared" } }] }
+  }
+
+  Component {
+    id: accessComponent
+    LauncherAppLibrary {
+      omarchyPath: "/fixture/omarchy"
+      fallbackSource: Qt.resolvedUrl("app-library-fallback-fixture.qml")
+      onLibraryChanged: root.reconcile()
+    }
+  }
+  Connections {
+    target: root.access ? root.access.library : null
+    function onAppsChanged() { root.reconcile() }
+  }
+
+  Component.onCompleted: {
+    root.access = accessComponent.createObject(root)
+    root.check(root.access.library === null, "detached library must be null")
+    root.check(root.access.fallbackStatus === Loader.Null, "detached fallback must be inactive")
+    root.access.sharedLibrary = shared
+    root.access.fallbackEnabled = true
+  }
+
+  Timer {
+    interval: 10
+    repeat: true
+    running: true
+    onTriggered: {
+      if (root.failed) return
+      var elapsed = Date.now() - root.stageStarted
+      root.check(elapsed < 3000, "timeout at stage " + root.stage)
+      if (root.failed) return
+      switch (root.stage) {
+        case 0:
+          if (elapsed < 50) return
+          root.check(State.created === 0, "shared host must never instantiate fallback")
+          root.check(root.access.library === shared, "shared identity must be retained")
+          root.access.fallbackSource = Qt.resolvedUrl("missing-while-shared.qml")
+          root.check(root.access.fallbackStatus === Loader.Null, "a shared host must not attempt fallback sources")
+          root.access.fallbackSource = Qt.resolvedUrl("app-library-fallback-fixture.qml")
+          root.access.sharedLibrary = null
+          root.next()
+          break
+        case 1:
+          if (!root.ready()) return
+          root.check(State.created === 1, "missing shared capability must create one fallback")
+          root.check(State.initializedPath === "/fixture/omarchy", "path must be set before service startup")
+          root.check(root.lastRows.length === 1 && root.lastRows[0].entry.id === "fallback", "late library arrival must reconcile rows")
+          root.check(root.access.library.iconSource("app") === "fixture:app", "icon method must come from selected library")
+          root.access.library.changeRows()
+          root.check(root.lastRows[0].entry.id === "changed", "active app changes must reconcile rows")
+          root.access.library.launch("app", "App")
+          root.access.sharedLibrary = shared
+          root.check(root.access.library === shared, "shared library must take priority on handoff")
+          root.next()
+          break
+        case 2:
+          if (elapsed < 100) return
+          root.check(State.destroyed === 1 && State.cleanups === 1, "handoff must clean up before destruction")
+          root.check(State.osdShows === 0, "teardown before launch delay must cancel feedback")
+          root.check(root.lastRows.length === 1 && root.lastRows[0].entry.id === "shared", "no fallback rows may survive handoff")
+          root.access.sharedLibrary = null
+          root.next()
+          break
+        case 3:
+          if (!root.ready()) return
+          root.check(State.created === 2, "lost shared capability must recreate fallback")
+          root.access.library.launch("app", "App")
+          root.next()
+          break
+        case 4:
+          if (elapsed < 100) return
+          root.check(State.osdShows === 1, "launch fixture must show feedback")
+          root.access.fallbackEnabled = false
+          root.check(root.access.library === null, "detachment must clear the effective library")
+          root.check(root.lastRows.length === 0, "detachment must clear stale rows")
+          root.next()
+          break
+        case 5:
+          if (elapsed < 30) return
+          root.check(State.destroyed === 2 && State.osdCloses === 1, "detachment must close an open OSD")
+          root.access.fallbackEnabled = true
+          root.next()
+          break
+        case 6:
+          if (!root.ready()) return
+          root.check(State.created === 3, "reattachment must load fallback")
+          root.access.fallbackSource = Qt.resolvedUrl("missing-app-library.qml")
+          root.next()
+          break
+        case 7:
+          if (root.access.fallbackStatus !== Loader.Error || elapsed < 100) return
+          root.check(State.destroyed === 3, "source replacement must clean up the old service")
+          root.check(root.access.library === null && root.lastRows.length === 0, "load errors must not retain stale rows")
+          root.access.syncFallback()
+          root.access.syncFallback()
+          root.access.sharedLibrary = shared
+          root.check(root.access.library === shared, "shared capability must recover from fallback error")
+          root.access.fallbackEnabled = false
+          root.access.sharedLibrary = null
+          root.access.fallbackSource = Qt.resolvedUrl("app-library-fallback-fixture.qml")
+          root.access.fallbackEnabled = true
+          root.next()
+          break
+        case 8:
+          if (!root.ready()) return
+          root.check(State.created === 4, "valid source must recover after error")
+          root.access.library.launch("app", "App")
+          root.next()
+          break
+        case 9:
+          if (elapsed < 100) return
+          root.check(State.osdShows === 2, "second launch must show feedback")
+          root.access.destroy()
+          root.next()
+          break
+        case 10:
+          if (elapsed < 50) return
+          root.check(State.destroyed === 4 && State.osdCloses === 2, "wrapper destruction must close owned feedback")
+          root.check(State.unsafeDestructions === 0, "all owned launch state must be stopped before destruction")
+          root.check(State.cleanups === 4, "each owned instance must be cleaned up exactly once")
+          if (!root.failed) console.log("HARNESS_OK app library fallback lifecycle")
+          Qt.quit()
+          break
+      }
+    }
+  }
+}

--- a/tests/app-library-fallback-integration-test.sh
+++ b/tests/app-library-fallback-integration-test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if ! command -v quickshell >/dev/null 2>&1; then
+  echo "ok - app library fallback harness skipped (quickshell unavailable)"
+  exit 0
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cp "$root/LauncherAppLibrary.qml" "$root"/tests/app-library-fallback-{fixture.qml,state.js,harness.qml} "$tmp/"
+output="$(QT_QPA_PLATFORM=offscreen timeout 10 quickshell --no-color -p "$tmp/app-library-fallback-harness.qml" 2>&1)"
+printf '%s\n' "$output"
+if grep -F 'HARNESS_FAIL' <<<"$output" >/dev/null; then exit 1; fi
+grep -F 'HARNESS_OK app library fallback lifecycle' <<<"$output" >/dev/null
+test "$(grep -c 'Omalaunch: fallback app library could not load:' <<<"$output")" -eq 1
+if grep -E 'TypeError|ReferenceError|Binding loop|cleanup failed' <<<"$output"; then exit 1; fi
+echo "ok - fallback selection, recovery, and launch feedback cleanup"

--- a/tests/app-library-fallback-integration-test.sh
+++ b/tests/app-library-fallback-integration-test.sh
@@ -10,6 +10,31 @@ fi
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 cp "$root/LauncherAppLibrary.qml" "$root"/tests/app-library-fallback-{fixture.qml,state.js,harness.qml} "$tmp/"
+python - "$root/Menu.qml" "$tmp/AppLibraryReconciliationFixture.qml" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1]).read_text()
+start = source.index('  onAppLibraryChanged: {')
+end = source.index('  property bool deleteConfirmOpen:', start)
+timer = re.search(r'  Timer \{\n    id: appRowsMergeDebounce\b.*?\n  \}', source, re.S)
+assert timer is not None
+Path(sys.argv[2]).write_text('''import QtQuick
+import "app-library-fallback-state.js" as State
+Item {
+  id: root
+  property var appLibrary: null
+  property var providersLoaded: ({apps: true})
+  property int providerRevision: 0
+  property double appIconIndexUpdatedAt: 0
+  property bool appIconRefreshPending: false
+  function mergeAppRows() {
+    State.reconciliations++
+    State.lastLibraryWasNull = root.appLibrary === null
+  }
+''' + source[start:end] + timer.group(0) + '\n}\n')
+PY
 output="$(QT_QPA_PLATFORM=offscreen timeout 10 quickshell --no-color -p "$tmp/app-library-fallback-harness.qml" 2>&1)"
 printf '%s\n' "$output"
 if grep -F 'HARNESS_FAIL' <<<"$output" >/dev/null; then exit 1; fi

--- a/tests/app-library-fallback-integration-test.sh
+++ b/tests/app-library-fallback-integration-test.sh
@@ -10,31 +10,6 @@ fi
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 cp "$root/LauncherAppLibrary.qml" "$root"/tests/app-library-fallback-{fixture.qml,state.js,harness.qml} "$tmp/"
-python - "$root/Menu.qml" "$tmp/AppLibraryReconciliationFixture.qml" <<'PY'
-import re
-import sys
-from pathlib import Path
-
-source = Path(sys.argv[1]).read_text()
-start = source.index('  onAppLibraryChanged: {')
-end = source.index('  property bool deleteConfirmOpen:', start)
-timer = re.search(r'  Timer \{\n    id: appRowsMergeDebounce\b.*?\n  \}', source, re.S)
-assert timer is not None
-Path(sys.argv[2]).write_text('''import QtQuick
-import "app-library-fallback-state.js" as State
-Item {
-  id: root
-  property var appLibrary: null
-  property var providersLoaded: ({apps: true})
-  property int providerRevision: 0
-  property double appIconIndexUpdatedAt: 0
-  property bool appIconRefreshPending: false
-  function mergeAppRows() {
-    State.reconciliations++
-    State.lastLibraryWasNull = root.appLibrary === null
-  }
-''' + source[start:end] + timer.group(0) + '\n}\n')
-PY
 output="$(QT_QPA_PLATFORM=offscreen timeout 10 quickshell --no-color -p "$tmp/app-library-fallback-harness.qml" 2>&1)"
 printf '%s\n' "$output"
 if grep -F 'HARNESS_FAIL' <<<"$output" >/dev/null; then exit 1; fi

--- a/tests/app-library-fallback-state.js
+++ b/tests/app-library-fallback-state.js
@@ -1,0 +1,9 @@
+.pragma library
+
+var created = 0
+var destroyed = 0
+var cleanups = 0
+var unsafeDestructions = 0
+var osdShows = 0
+var osdCloses = 0
+var initializedPath = ""

--- a/tests/app-library-fallback-state.js
+++ b/tests/app-library-fallback-state.js
@@ -7,5 +7,3 @@ var unsafeDestructions = 0
 var osdShows = 0
 var osdCloses = 0
 var initializedPath = ""
-var reconciliations = 0
-var lastLibraryWasNull = false

--- a/tests/app-library-fallback-state.js
+++ b/tests/app-library-fallback-state.js
@@ -7,3 +7,5 @@ var unsafeDestructions = 0
 var osdShows = 0
 var osdCloses = 0
 var initializedPath = ""
+var reconciliations = 0
+var lastLibraryWasNull = false

--- a/tests/app-library-reconciliation-contract-test.js
+++ b/tests/app-library-reconciliation-contract-test.js
@@ -1,0 +1,16 @@
+const fs = require('fs')
+const path = require('path')
+const assert = require('assert')
+
+// Permanent regression coverage. This test must not depend on the temporary
+// app-library fallback component or its fixtures.
+const menu = fs.readFileSync(path.join(__dirname, '../Menu.qml'), 'utf8')
+const start = menu.indexOf('  onAppLibraryChanged:')
+const end = menu.indexOf('  property bool deleteConfirmOpen:', start)
+assert(start >= 0 && end > start, 'app-library change handler must be present')
+const reconcile = menu.slice(start, end)
+assert(reconcile.includes('appRowsMergeDebounce.restart()'), 'library changes must schedule the owned reconciliation timer')
+assert(!reconcile.includes('Qt.callLater'), 'library teardown must not queue callbacks that outlive the menu')
+assert(menu.includes('onTriggered: if (root.providersLoaded["apps"]) root.mergeAppRows()'),
+  'the owned timer must reconcile only the current loaded provider')
+console.log('App library reconciliation contract tests passed')

--- a/tests/app-library-reconciliation-harness.qml
+++ b/tests/app-library-reconciliation-harness.qml
@@ -1,0 +1,78 @@
+import QtQuick
+import Quickshell
+
+// Permanent regression coverage for Menu.qml, independent of any fallback.
+ShellRoot {
+  id: root
+  property var fixture: null
+  property int merges: 0
+  property bool lastLibraryWasNull: false
+  property int stage: 0
+  property double stageStarted: Date.now()
+  property bool failed: false
+
+  function check(value, message) {
+    if (value) return
+    root.failed = true
+    console.error("HARNESS_FAIL", message)
+    Qt.quit()
+  }
+  function next() {
+    root.stage++
+    root.stageStarted = Date.now()
+  }
+
+  Item { id: fixtureParent }
+  Component {
+    id: fixtureComponent
+    AppLibraryReconciliationFixture {
+      onMerged: function(emptyLibrary) {
+        root.merges++
+        root.lastLibraryWasNull = emptyLibrary
+      }
+    }
+  }
+
+  Component.onCompleted: {
+    root.fixture = fixtureComponent.createObject(fixtureParent)
+    root.fixture.appLibrary = ({ first: true })
+    root.fixture.appLibrary = ({ second: true })
+  }
+
+  Timer {
+    interval: 10
+    repeat: true
+    running: true
+    onTriggered: {
+      if (root.failed) return
+      var elapsed = Date.now() - root.stageStarted
+      root.check(elapsed < 3000, "timeout at stage " + root.stage)
+      if (root.failed || elapsed < 200) return
+      switch (root.stage) {
+        case 0:
+          root.check(root.merges === 1, "library handoff must coalesce reconciliation")
+          root.fixture.appLibrary = null
+          root.next()
+          break
+        case 1:
+          root.check(root.merges === 2 && root.lastLibraryWasNull, "live detachment must reconcile an empty library")
+          root.fixture.appLibrary = ({ pending: true })
+          root.fixture.providersLoaded = ({})
+          root.next()
+          break
+        case 2:
+          root.check(root.merges === 2, "queued reconciliation must check the current provider state")
+          root.fixture.providersLoaded = ({apps: true})
+          root.fixture.appLibrary = null
+          root.fixture.destroy()
+          root.next()
+          break
+        case 3:
+          root.check(root.merges === 2, "queued reconciliation must not outlive the menu")
+          if (!root.failed) console.log("HARNESS_OK app library reconciliation lifecycle")
+          Qt.quit()
+          break
+      }
+    }
+  }
+}

--- a/tests/app-library-reconciliation-integration-test.sh
+++ b/tests/app-library-reconciliation-integration-test.sh
@@ -10,7 +10,8 @@ fi
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 cp "$root/tests/app-library-reconciliation-harness.qml" "$tmp/"
-# Extract only the permanent handler and timer. No fallback file is needed.
+# Extract the permanent handler, its optional reset helper, and the timer.
+# No fallback file is needed.
 python - "$root/Menu.qml" "$tmp/AppLibraryReconciliationFixture.qml" <<'PY'
 import re
 import sys
@@ -21,6 +22,10 @@ start = source.index('  onAppLibraryChanged: {')
 end = source.index('  property bool deleteConfirmOpen:', start)
 timer = re.search(r'  Timer \{\n    id: appRowsMergeDebounce\b.*?\n  \}', source, re.S)
 assert timer is not None
+# The icon-refresh fix moves the reset into a helper. Use its real code when
+# present, while keeping this test runnable before that separate fix is merged.
+reset = re.search(r'  function resetAppIconRefreshState\(\) \{.*?\n  \}', source, re.S)
+reset_source = reset.group(0) + '\n' if reset else ''
 Path(sys.argv[2]).write_text('''import QtQuick
 Item {
   id: root
@@ -31,7 +36,7 @@ Item {
   property bool appIconRefreshPending: false
   signal merged(bool emptyLibrary)
   function mergeAppRows() { root.merged(root.appLibrary === null) }
-''' + source[start:end] + timer.group(0) + '\n}\n')
+''' + reset_source + source[start:end] + timer.group(0) + '\n}\n')
 PY
 output="$(QT_QPA_PLATFORM=offscreen timeout 10 quickshell --no-color -p "$tmp/app-library-reconciliation-harness.qml" 2>&1)"
 printf '%s\n' "$output"

--- a/tests/app-library-reconciliation-integration-test.sh
+++ b/tests/app-library-reconciliation-integration-test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if ! command -v quickshell >/dev/null 2>&1; then
+  echo "ok - app library reconciliation harness skipped (quickshell unavailable)"
+  exit 0
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+cp "$root/tests/app-library-reconciliation-harness.qml" "$tmp/"
+# Extract only the permanent handler and timer. No fallback file is needed.
+python - "$root/Menu.qml" "$tmp/AppLibraryReconciliationFixture.qml" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1]).read_text()
+start = source.index('  onAppLibraryChanged: {')
+end = source.index('  property bool deleteConfirmOpen:', start)
+timer = re.search(r'  Timer \{\n    id: appRowsMergeDebounce\b.*?\n  \}', source, re.S)
+assert timer is not None
+Path(sys.argv[2]).write_text('''import QtQuick
+Item {
+  id: root
+  property var appLibrary: null
+  property var providersLoaded: ({apps: true})
+  property int providerRevision: 0
+  property double appIconIndexUpdatedAt: 0
+  property bool appIconRefreshPending: false
+  signal merged(bool emptyLibrary)
+  function mergeAppRows() { root.merged(root.appLibrary === null) }
+''' + source[start:end] + timer.group(0) + '\n}\n')
+PY
+output="$(QT_QPA_PLATFORM=offscreen timeout 10 quickshell --no-color -p "$tmp/app-library-reconciliation-harness.qml" 2>&1)"
+printf '%s\n' "$output"
+if grep -F 'HARNESS_FAIL' <<<"$output" >/dev/null; then exit 1; fi
+grep -F 'HARNESS_OK app library reconciliation lifecycle' <<<"$output" >/dev/null
+if grep -E 'TypeError|ReferenceError|Binding loop|invalid context' <<<"$output"; then exit 1; fi
+echo "ok - app library reconciliation stays within the menu lifetime"


### PR DESCRIPTION
Fixes #68.

## Summary

Omarchy 4.0.3 can give third-party menus a null app-library API. This leaves the installed application list and application search empty. The upstream correction is pending at https://github.com/omacom/omarchy/pull/11075.

This PR adds a narrow compatibility fallback:

- Prefer the host's shared app library whenever it is available.
- When the shell is attached but supplies no library, load a separately owned instance of its installed `AppLibrary.qml`.
- Use only the fixed service path under the injected absolute `omarchyPath`. Do not copy application enumeration or access the host's private objects.
- Preserve the installed service's filtering, icons, launch, and removal methods.
- Release the fallback when the shared library becomes available or the menu is destroyed. Stop its launch timers and close its owned launch notice before teardown.
- Keep other menu commands usable if the installed service cannot load, without a retry loop.

The PR also replaces the app-library change handler's delayed callback with the existing menu-owned reconciliation timer. Live reload testing found that the old callback could run after the menu was destroyed.

## Tests

- All `tests/*-test.js`, `tests/*-test.py`, and `tests/*-test.sh` files passed. Python test files were run directly.
- The Python compile check from CI and `git diff --check` passed.
- The new contract and lifecycle tests are wired into CI. The native harness skips explicitly when Quickshell is unavailable.
- The lifecycle harness checks shared-first selection, Loader ownership, source errors and recovery, application-change forwarding, pending and open launch-notice cleanup, and library replacement.
- The reload regression checks production handler/timer code for coalescing, null-library reconciliation, and cancellation on destruction. It fails before the reload correction and passes afterward.
- Independent read-only reviews found no blockers.

## Live verification

On unmodified Omarchy 4.0.3-1 with Quickshell 0.3.1-1:

- Installed applications appeared after startup and plugin rescan.
- Search from Apps and the root menu worked.
- A temporary visible desktop entry appeared with its custom SVG icon. Entries with `NoDisplay=true` and a nonmatching `OnlyShowIn` remained hidden.
- Activating the test entry created its launch marker through the normal desktop-entry launch path.
- Plugin teardown closed an open launch notice.
- Removing the test entries removed their search results without a shell restart.

On Omarchy 4.0.1-2, the selected library remained the host's shared object and the fallback Loader stayed unloaded.

The user has also tried the final test snapshot on both machines and confirmed that both work. The installed test copies are stable snapshots, not links to the development worktree.

## Scope and limits

The fallback depends on the installed Omarchy service file and its API. No Omarchy system files are changed. No user application was uninstalled during testing; the service's removal method is unchanged.

The separate icon-refresh compatibility fix is not included in this PR. This PR does not change the release version or publish a release.
