### PR TITLE
Support icon refresh through the scoped app-library API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Run app library fallback lifecycle harness when available
         run: bash tests/app-library-fallback-integration-test.sh
 
+      - name: Run app icon refresh compatibility tests
+        run: node tests/app-icon-refresh-compat-test.js
+
       - name: Run Quickshell live-query process harness when available
         run: bash tests/live-query-process-integration-test.sh
 

--- a/Menu.qml
+++ b/Menu.qml
@@ -269,8 +269,7 @@ Item {
   property double appIconIndexUpdatedAt: 0
   property bool appIconRefreshPending: false
   onAppLibraryChanged: {
-    root.appIconIndexUpdatedAt = 0
-    root.appIconRefreshPending = false
+    root.resetAppIconRefreshState()
     // A provider request can race app-library attachment. Use the owned
     // timer so queued reconciliation cannot outlive this menu on
     // plugin reload. An empty replacement also clears stale detached rows.
@@ -534,12 +533,34 @@ Item {
     return false
   }
 
+  function resetAppIconRefreshState() {
+    root.appIconIndexUpdatedAt = 0
+    root.appIconRefreshPending = false
+  }
+
+  function completeAppIconRefresh() {
+    root.appIconIndexUpdatedAt = Date.now()
+    root.appIconRefreshPending = false
+  }
+
+  function appIconRefreshHasCompletionSignal(library) {
+    // The raw AppLibrary exposes iconIndex and its change signal. The detached
+    // PluginAppLibraryApi proxy intentionally exposes neither.
+    return library && library.iconIndex !== undefined
+  }
+
   function refreshAppIconsIfStale() {
-    if (!root.appLibrary || root.appIconRefreshPending) return
+    var library = root.appLibrary
+    if (!library || root.appIconRefreshPending) return
     if (root.appIconIndexUpdatedAt > 0
         && Date.now() - root.appIconIndexUpdatedAt < root.appIconRefreshTtlMs) return
-    root.appIconRefreshPending = true
-    root.appLibrary.refreshIcons()
+    var waitsForCompletion = root.appIconRefreshHasCompletionSignal(library)
+    root.appIconRefreshPending = waitsForCompletion
+    library.refreshIcons()
+    // The proxy cannot report scan completion. Treat dispatch as the freshness
+    // point so repeated menu opens stay bounded by the same TTL.
+    if (!waitsForCompletion && root.appLibrary === library)
+      root.appIconIndexUpdatedAt = Date.now()
   }
 
   function badgeToneColor(tone) {
@@ -4166,11 +4187,12 @@ Item {
 
   Connections {
     target: root.appLibrary
+    // PluginAppLibraryApi does not expose the raw iconIndex property or signal.
+    ignoreUnknownSignals: true
     function onIconIndexChanged() {
       // iconIndex is swapped only when AppLibrary's asynchronous scan exits.
       // Start the freshness window from completion, not from the request.
-      root.appIconIndexUpdatedAt = Date.now()
-      root.appIconRefreshPending = false
+      root.completeAppIconRefresh()
     }
     function onAppsChanged() {
       // AppLibrary owns app-change icon rescans; this signal can also mean only

--- a/tests/app-icon-refresh-compat-test.js
+++ b/tests/app-icon-refresh-compat-test.js
@@ -1,0 +1,76 @@
+const fs = require('fs')
+const path = require('path')
+const vm = require('vm')
+const assert = require('assert')
+
+const qml = fs.readFileSync(path.join(__dirname, '../Menu.qml'), 'utf8')
+const start = qml.indexOf('  function resetAppIconRefreshState() {')
+const end = qml.indexOf('\n  function badgeToneColor(', start)
+assert(start >= 0 && end > start, 'icon refresh functions must be present')
+
+let now = 1000
+const root = {
+  appLibrary: null,
+  appIconRefreshTtlMs: 30000,
+  appIconIndexUpdatedAt: 0,
+  appIconRefreshPending: false
+}
+const context = { root, Date: { now: () => now } }
+vm.createContext(context)
+vm.runInContext(qml.slice(start, end), context)
+root.resetAppIconRefreshState = context.resetAppIconRefreshState
+root.completeAppIconRefresh = context.completeAppIconRefresh
+root.appIconRefreshHasCompletionSignal = context.appIconRefreshHasCompletionSignal
+
+let rawRefreshes = 0
+const rawAppLibrary = { iconIndex: {}, refreshIcons: () => rawRefreshes++ }
+root.appLibrary = rawAppLibrary
+context.refreshAppIconsIfStale()
+assert.strictEqual(rawRefreshes, 1)
+assert.strictEqual(root.appIconRefreshPending, true,
+  'raw AppLibrary waits for iconIndexChanged')
+context.refreshAppIconsIfStale()
+assert.strictEqual(rawRefreshes, 1, 'a pending raw scan is not restarted')
+now = 2000
+context.completeAppIconRefresh()
+assert.strictEqual(root.appIconRefreshPending, false)
+assert.strictEqual(root.appIconIndexUpdatedAt, now)
+now = 31999
+context.refreshAppIconsIfStale()
+assert.strictEqual(rawRefreshes, 1, 'raw refreshes stay bounded by the TTL')
+now = 32000
+context.refreshAppIconsIfStale()
+assert.strictEqual(rawRefreshes, 2)
+
+// App-library replacement runs resetAppIconRefreshState through
+// onAppLibraryChanged. Exercise that reset before attaching the proxy.
+context.resetAppIconRefreshState()
+let proxyRefreshes = 0
+const proxyAppLibrary = { refreshIcons: () => proxyRefreshes++ }
+root.appLibrary = proxyAppLibrary
+now = 50000
+context.refreshAppIconsIfStale()
+assert.strictEqual(proxyRefreshes, 1)
+assert.strictEqual(root.appIconRefreshPending, false,
+  'a proxy without iconIndexChanged must never stay pending')
+assert.strictEqual(root.appIconIndexUpdatedAt, now,
+  'proxy dispatch starts its bounded freshness interval')
+now = 79999
+context.refreshAppIconsIfStale()
+assert.strictEqual(proxyRefreshes, 1)
+now = 80000
+context.refreshAppIconsIfStale()
+assert.strictEqual(proxyRefreshes, 2)
+
+// A second replacement must clear proxy freshness before raw attachment.
+context.resetAppIconRefreshState()
+root.appLibrary = rawAppLibrary
+now = 81000
+context.refreshAppIconsIfStale()
+assert.strictEqual(rawRefreshes, 3, 'reattached raw API refreshes immediately')
+assert.strictEqual(root.appIconRefreshPending, true)
+
+const connections = qml.slice(qml.indexOf('  Connections {\n    target: root.appLibrary'))
+assert(connections.includes('ignoreUnknownSignals: true'),
+  'the optional raw-only signal must not warn on the proxy API')
+console.log('App icon refresh compatibility tests passed')


### PR DESCRIPTION
## Summary

Handle both app-library APIs without leaving icon refresh permanently pending.

The raw Omarchy `AppLibrary` exposes `iconIndex` and its change signal. The newer `PluginAppLibraryApi` proxy exposes `refreshIcons()` but no completion signal. Waiting for that signal on the proxy leaves `appIconRefreshPending` set and prevents later refresh requests.

- Keep asynchronous completion handling for the raw library.
- For the proxy, use refresh dispatch as the start of the existing 30-second freshness interval and do not set a pending wait.
- Ignore unavailable optional signals to remove the proxy's unknown-signal warning.
- Reset refresh state when the library changes. Do not apply a dispatch timestamp to a replacement library.
- Add a regression test and run it in CI.

## Scope

This is separate from the missing application-list workaround in #69. It does not add a fallback library, change application enumeration, or fix a null app-library capability. No release version is changed.

## Verification

- All 26 `tests/*-test.js`, `tests/*-test.py`, and `tests/*-test.sh` files on the original standalone branch passed. After rebasing onto the merged #69, all 30 test files passed again. Python tests were run directly.
- The new test covers raw completion, pending-request suppression, proxy dispatch timing, the 30-second interval, and library replacement.
- All 30 test files passed in a separate integration worktree combining this PR with #69. That check found and corrected a test-fixture omission in #69: the reconciliation fixture now includes the real reset helper when present.
- `git diff --check` passed.
- Independent review found no production blockers. Its CI coverage finding was corrected in the second commit.
- Earlier live testing on Omarchy 4.0.3 with the upstream capability correction confirmed that application icons remained visible and the unknown `iconIndexChanged` warning was removed. Standard installations were restored after that test.

## Merge order

#69 was squash-merged first. This branch is now rebased onto that master commit. The conflict resolutions preserve #69's owned reconciliation timer, use this PR's reset helper, and retain every CI test step. The resulting tree matches the previously tested integration exactly. All 30 tests were rerun successfully after the rebase.

The proxy does not report scan completion, so its timestamp records dispatch, not proof that the icon scan has finished.

