### PR TITLE
Release v0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Omalaunch never installs system packages silently. Package installation is offer
 
 Omalaunch uses Omarchy's shared application library when it is available. If the shell omits that library, as can occur on Omarchy 4.0.3, Omalaunch uses a separate instance of the installed application service. This preserves Omarchy's application filtering, icons, and launch behavior without changing system files. The separate instance is released when the shared library becomes available. If the installed service is missing or cannot load, application results remain unavailable; other menu commands still work.
 
+Icon refresh supports both the original application service and the newer scoped API. On the scoped API, refresh requests use a 30-second interval without waiting for an unavailable completion signal.
+
 ## Usage
 
 Start typing to search commands and applications. Use the arrow keys or Tab and Shift+Tab to move, Enter to activate, and Escape to go back or close the launcher.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "quantumfire.omalaunch",
   "name": "Omalaunch",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "Daniel Lemky",
   "license": "MIT",
   "description": "Extensible command launcher for Omarchy",


### PR DESCRIPTION
## Release preparation

Prepare patch release **v0.4.1** from the merged application-list and icon-refresh fixes (#69, #70).

- Set `manifest.json` to `0.4.1`.
- Document icon-refresh compatibility in the README, alongside the existing app-library fallback note.
- No runtime code changes in this PR.

## Verification

- All 30 `tests/*-test.js`, `tests/*-test.py`, and `tests/*-test.sh` files passed locally, including the native Quickshell harnesses. Python tests were run directly.
- The Python compile check from CI passed.
- `git diff --check` passed.

This PR prepares the release only. After approval, squash-merge it, create the annotated `v0.4.1` tag from clean current `master`, and publish the GitHub release. Keep the manifest, tag, and release versions identical. Then update a test installation and run the post-release checks in `RELEASING.md`.

## Proposed release notes

### Fixes

- Restore installed application lists and search when Omarchy does not supply the shared app library, as can occur on Omarchy 4.0.3 (#69).
- Stop pending application-list updates when the menu is destroyed, preventing delayed callback errors during plugin reload (#69).
- Fix icon refresh on the newer scoped app-library API. Refresh no longer remains pending while waiting for a signal that the API does not provide (#70).

### Compatibility

The shared app library remains the first choice. When it is unavailable, Omalaunch loads an independent instance of Omarchy's installed application service. This keeps the service's application filtering, icons, and launch behavior without changing system files. If that service cannot load, application results remain unavailable, but other menu commands still work.

No new package dependencies or configuration changes are required.

Omarchy plugin updates follow `master`, not release tags. This release provides a fixed reference point for the tested changes.

**Full changelog:** https://github.com/DanielLemky/omalaunch/compare/v0.4.0...v0.4.1
