### PR TITLE
Release v0.5.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "quantumfire.omalaunch",
   "name": "Omalaunch",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "author": "Daniel Lemky",
   "license": "MIT",
   "description": "Extensible command launcher for Omarchy",


### PR DESCRIPTION
Prepare v0.5.0 for extension marketplace access, interactive Git installation, and confirmed plugin-wide removal. Changes only the manifest version. All nine targeted release tests passed.