### PR TITLE
Release v0.5.1

### DIFF
--- a/APP-LIBRARY-COMPATIBILITY.md
+++ b/APP-LIBRARY-COMPATIBILITY.md
@@ -1,10 +1,10 @@
 # Temporary app-library fallback
 
-Tracking issue: [#68](https://github.com/DanielLemky/omalaunch/issues/68).
+Tracking issues: [#68](https://github.com/DanielLemky/omalaunch/issues/68) and [#75](https://github.com/DanielLemky/omalaunch/issues/75).
 
 Upstream correction: [Omarchy PR #11075](https://github.com/omacom/omarchy/pull/11075).
 
-`LauncherAppLibrary.qml` is a temporary compatibility component. It uses the host's shared library when available and loads an independent installed app service only when the attached shell supplies no library. A fixed host does not load the fallback. No version check or configuration switch is required.
+`LauncherAppLibrary.qml` is a temporary compatibility component. It uses the host's shared library when available and loads an independent installed app service when no shared library is available and the installed service path is valid. The fallback remains available if the host destroys the injected shell API while the menu stays loaded. A shared library takes priority and releases the fallback. Menu destruction also releases the fallback. No version check or configuration switch is required.
 
 ## Removal condition
 

--- a/LauncherAppLibrary.qml
+++ b/LauncherAppLibrary.qml
@@ -10,11 +10,9 @@ Item {
   id: root
 
   property var sharedLibrary: null
-  property bool fallbackEnabled: false
   property url fallbackSource: ""
   property string omarchyPath: ""
-  readonly property var library: root.sharedLibrary
-    || (root.fallbackEnabled ? fallbackLoader.item : null)
+  readonly property var library: root.sharedLibrary || fallbackLoader.item
   readonly property int fallbackStatus: fallbackLoader.status
   property bool componentReady: false
   property string loadedOmarchyPath: ""
@@ -37,7 +35,7 @@ Item {
 
   function syncFallback() {
     if (!root.componentReady) return
-    var wanted = root.fallbackEnabled && !root.sharedLibrary
+    var wanted = !root.sharedLibrary
       && String(root.fallbackSource).length > 0
     if (wanted && fallbackLoader.active
         && String(fallbackLoader.source) === String(root.fallbackSource)
@@ -51,7 +49,6 @@ Item {
   }
 
   onSharedLibraryChanged: root.syncFallback()
-  onFallbackEnabledChanged: root.syncFallback()
   onFallbackSourceChanged: root.syncFallback()
   onOmarchyPathChanged: root.syncFallback()
 

--- a/Menu.qml
+++ b/Menu.qml
@@ -265,7 +265,8 @@ Item {
   LauncherAppLibrary {
     id: appLibraryAccess
     sharedLibrary: root.sharedAppLibrary
-    fallbackEnabled: root.shell !== null
+    // Some hosts destroy the injected shell API while the menu remains loaded.
+    fallbackEnabled: true
     omarchyPath: root.omarchyPath
     fallbackSource: root.omarchyPath.charAt(0) === "/"
       ? Util.fileUrl(root.omarchyPath + "/shell/services/AppLibrary.qml") : ""

--- a/Menu.qml
+++ b/Menu.qml
@@ -265,8 +265,6 @@ Item {
   LauncherAppLibrary {
     id: appLibraryAccess
     sharedLibrary: root.sharedAppLibrary
-    // Some hosts destroy the injected shell API while the menu remains loaded.
-    fallbackEnabled: true
     omarchyPath: root.omarchyPath
     fallbackSource: root.omarchyPath.charAt(0) === "/"
       ? Util.fileUrl(root.omarchyPath + "/shell/services/AppLibrary.qml") : ""

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "quantumfire.omalaunch",
   "name": "Omalaunch",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": "Daniel Lemky",
   "license": "MIT",
   "description": "Extensible command launcher for Omarchy",

--- a/tests/app-library-fallback-contract-test.js
+++ b/tests/app-library-fallback-contract-test.js
@@ -9,7 +9,8 @@ assert(menu.includes('readonly property var sharedAppLibrary: root.shell ? root.
 assert(menu.includes('readonly property var appLibrary: appLibraryAccess.library'))
 const integration = menu.match(/  LauncherAppLibrary \{[\s\S]*?\n  \}/)[0]
 assert(integration.includes('sharedLibrary: root.sharedAppLibrary'))
-assert(integration.includes('fallbackEnabled: root.shell !== null'))
+assert(integration.includes('fallbackEnabled: true'),
+  'fallback availability must survive destruction of the injected shell API')
 assert(integration.includes('root.omarchyPath.charAt(0) === "/"'))
 assert(integration.includes('Util.fileUrl(root.omarchyPath + "/shell/services/AppLibrary.qml")'))
 assert(!integration.includes('providersLoaded'), 'in-place var map mutations must not gate the loader')

--- a/tests/app-library-fallback-contract-test.js
+++ b/tests/app-library-fallback-contract-test.js
@@ -9,14 +9,14 @@ assert(menu.includes('readonly property var sharedAppLibrary: root.shell ? root.
 assert(menu.includes('readonly property var appLibrary: appLibraryAccess.library'))
 const integration = menu.match(/  LauncherAppLibrary \{[\s\S]*?\n  \}/)[0]
 assert(integration.includes('sharedLibrary: root.sharedAppLibrary'))
-assert(integration.includes('fallbackEnabled: true'),
-  'fallback availability must survive destruction of the injected shell API')
+assert(!menu.includes('fallbackEnabled') && !access.includes('fallbackEnabled'),
+  'fallback selection must not have a separate enable switch')
 assert(integration.includes('root.omarchyPath.charAt(0) === "/"'))
 assert(integration.includes('Util.fileUrl(root.omarchyPath + "/shell/services/AppLibrary.qml")'))
 assert(!integration.includes('providersLoaded'), 'in-place var map mutations must not gate the loader')
-assert(access.includes('readonly property var library: root.sharedLibrary\n    ||'),
+assert(access.includes('readonly property var library: root.sharedLibrary ||'),
   'the shared library must take priority')
-assert(access.includes('var wanted = root.fallbackEnabled && !root.sharedLibrary'),
+assert(access.includes('var wanted = !root.sharedLibrary'),
   'fallback activation must not depend on the effective library')
 assert(access.includes('fallbackLoader.setSource(root.fallbackSource, { omarchyPath: root.omarchyPath })'),
   'service scans must use the injected installation path from construction')

--- a/tests/app-library-fallback-harness.qml
+++ b/tests/app-library-fallback-harness.qml
@@ -5,6 +5,13 @@ import "app-library-fallback-state.js" as State
 ShellRoot {
   id: root
   property var access: null
+  property QtObject shell: null
+  property var retainedFallback: null
+
+  Component {
+    id: shellComponent
+    QtObject { property var appLibrary: null }
+  }
   property var lastRows: []
   property int stage: 0
   property double stageStarted: Date.now()
@@ -35,6 +42,8 @@ ShellRoot {
   Component {
     id: accessComponent
     LauncherAppLibrary {
+      // The runner inserts the actual Menu.qml binding here.
+      fallbackEnabled: /* MENU_FALLBACK_ENABLED */ false
       omarchyPath: "/fixture/omarchy"
       fallbackSource: Qt.resolvedUrl("app-library-fallback-fixture.qml")
       onLibraryChanged: root.reconcile()
@@ -46,11 +55,8 @@ ShellRoot {
   }
 
   Component.onCompleted: {
-    root.access = accessComponent.createObject(root)
-    root.check(root.access.library === null, "detached library must be null")
-    root.check(root.access.fallbackStatus === Loader.Null, "detached fallback must be inactive")
-    root.access.sharedLibrary = shared
-    root.access.fallbackEnabled = true
+    root.access = accessComponent.createObject(root, { sharedLibrary: shared })
+    root.shell = shellComponent.createObject(root)
   }
 
   Timer {
@@ -79,12 +85,28 @@ ShellRoot {
           root.check(State.initializedPath === "/fixture/omarchy", "path must be set before service startup")
           root.check(root.lastRows.length === 1 && root.lastRows[0].entry.id === "fallback", "late library arrival must reconcile rows")
           root.check(root.access.library.iconSource("app") === "fixture:app", "icon method must come from selected library")
+          root.retainedFallback = root.access.library
+          root.shell.destroy()
+          root.stage = 11
+          root.stageStarted = Date.now()
+          break
+        case 11:
+          if (elapsed < 100) return
+          root.check(root.shell === null, "destroyed shell must clear the QML object reference")
+          root.check(root.ready() && root.access.library === root.retainedFallback,
+            "shell destruction must retain the ready fallback")
+          root.check(State.created === 1 && State.destroyed === 0,
+            "shell destruction must not replace or release the fallback")
+          root.check(root.lastRows.length === 1 && root.lastRows[0].entry.id === "fallback",
+            "shell destruction must retain application rows")
+          if (root.failed) return
           root.access.library.changeRows()
           root.check(root.lastRows[0].entry.id === "changed", "active app changes must reconcile rows")
           root.access.library.launch("app", "App")
           root.access.sharedLibrary = shared
           root.check(root.access.library === shared, "shared library must take priority on handoff")
-          root.next()
+          root.stage = 2
+          root.stageStarted = Date.now()
           break
         case 2:
           if (elapsed < 100) return
@@ -104,19 +126,19 @@ ShellRoot {
           if (elapsed < 100) return
           root.check(State.osdShows === 1, "launch fixture must show feedback")
           root.access.fallbackEnabled = false
-          root.check(root.access.library === null, "detachment must clear the effective library")
-          root.check(root.lastRows.length === 0, "detachment must clear stale rows")
+          root.check(root.access.library === null, "explicit disable must clear the effective library")
+          root.check(root.lastRows.length === 0, "explicit disable must clear stale rows")
           root.next()
           break
         case 5:
           if (elapsed < 30) return
-          root.check(State.destroyed === 2 && State.osdCloses === 1, "detachment must close an open OSD")
+          root.check(State.destroyed === 2 && State.osdCloses === 1, "explicit disable must close an open OSD")
           root.access.fallbackEnabled = true
           root.next()
           break
         case 6:
           if (!root.ready()) return
-          root.check(State.created === 3, "reattachment must load fallback")
+          root.check(State.created === 3, "explicit enable must load fallback")
           root.access.fallbackSource = Qt.resolvedUrl("missing-app-library.qml")
           root.next()
           break

--- a/tests/app-library-fallback-harness.qml
+++ b/tests/app-library-fallback-harness.qml
@@ -42,8 +42,7 @@ ShellRoot {
   Component {
     id: accessComponent
     LauncherAppLibrary {
-      // The runner inserts the actual Menu.qml binding here.
-      fallbackEnabled: /* MENU_FALLBACK_ENABLED */ false
+      sharedLibrary: root.shell ? root.shell.appLibrary : null
       omarchyPath: "/fixture/omarchy"
       fallbackSource: Qt.resolvedUrl("app-library-fallback-fixture.qml")
       onLibraryChanged: root.reconcile()
@@ -55,8 +54,8 @@ ShellRoot {
   }
 
   Component.onCompleted: {
-    root.access = accessComponent.createObject(root, { sharedLibrary: shared })
-    root.shell = shellComponent.createObject(root)
+    root.shell = shellComponent.createObject(root, { appLibrary: shared })
+    root.access = accessComponent.createObject(root)
   }
 
   Timer {
@@ -76,7 +75,7 @@ ShellRoot {
           root.access.fallbackSource = Qt.resolvedUrl("missing-while-shared.qml")
           root.check(root.access.fallbackStatus === Loader.Null, "a shared host must not attempt fallback sources")
           root.access.fallbackSource = Qt.resolvedUrl("app-library-fallback-fixture.qml")
-          root.access.sharedLibrary = null
+          root.shell.appLibrary = null
           root.next()
           break
         case 1:
@@ -103,7 +102,7 @@ ShellRoot {
           root.access.library.changeRows()
           root.check(root.lastRows[0].entry.id === "changed", "active app changes must reconcile rows")
           root.access.library.launch("app", "App")
-          root.access.sharedLibrary = shared
+          root.shell = shellComponent.createObject(root, { appLibrary: shared })
           root.check(root.access.library === shared, "shared library must take priority on handoff")
           root.stage = 2
           root.stageStarted = Date.now()
@@ -113,7 +112,7 @@ ShellRoot {
           root.check(State.destroyed === 1 && State.cleanups === 1, "handoff must clean up before destruction")
           root.check(State.osdShows === 0, "teardown before launch delay must cancel feedback")
           root.check(root.lastRows.length === 1 && root.lastRows[0].entry.id === "shared", "no fallback rows may survive handoff")
-          root.access.sharedLibrary = null
+          root.shell.appLibrary = null
           root.next()
           break
         case 3:
@@ -125,20 +124,20 @@ ShellRoot {
         case 4:
           if (elapsed < 100) return
           root.check(State.osdShows === 1, "launch fixture must show feedback")
-          root.access.fallbackEnabled = false
-          root.check(root.access.library === null, "explicit disable must clear the effective library")
-          root.check(root.lastRows.length === 0, "explicit disable must clear stale rows")
+          root.access.fallbackSource = ""
+          root.check(root.access.library === null, "missing source must clear the effective library")
+          root.check(root.lastRows.length === 0, "missing source must clear stale rows")
           root.next()
           break
         case 5:
           if (elapsed < 30) return
-          root.check(State.destroyed === 2 && State.osdCloses === 1, "explicit disable must close an open OSD")
-          root.access.fallbackEnabled = true
+          root.check(State.destroyed === 2 && State.osdCloses === 1, "missing source must close an open OSD")
+          root.access.fallbackSource = Qt.resolvedUrl("app-library-fallback-fixture.qml")
           root.next()
           break
         case 6:
           if (!root.ready()) return
-          root.check(State.created === 3, "explicit enable must load fallback")
+          root.check(State.created === 3, "restored source must load fallback")
           root.access.fallbackSource = Qt.resolvedUrl("missing-app-library.qml")
           root.next()
           break
@@ -148,12 +147,10 @@ ShellRoot {
           root.check(root.access.library === null && root.lastRows.length === 0, "load errors must not retain stale rows")
           root.access.syncFallback()
           root.access.syncFallback()
-          root.access.sharedLibrary = shared
+          root.shell.appLibrary = shared
           root.check(root.access.library === shared, "shared capability must recover from fallback error")
-          root.access.fallbackEnabled = false
-          root.access.sharedLibrary = null
           root.access.fallbackSource = Qt.resolvedUrl("app-library-fallback-fixture.qml")
-          root.access.fallbackEnabled = true
+          root.shell.appLibrary = null
           root.next()
           break
         case 8:

--- a/tests/app-library-fallback-integration-test.sh
+++ b/tests/app-library-fallback-integration-test.sh
@@ -10,6 +10,17 @@ fi
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 cp "$root/LauncherAppLibrary.qml" "$root"/tests/app-library-fallback-{fixture.qml,state.js,harness.qml} "$tmp/"
+python3 - "$root/Menu.qml" "$tmp/app-library-fallback-harness.qml" <<'PY'
+import pathlib
+import re
+import sys
+
+menu = pathlib.Path(sys.argv[1]).read_text()
+block = re.search(r'  LauncherAppLibrary \{.*?\n  \}', menu, re.S).group()
+binding = re.search(r'^    fallbackEnabled: (.+)$', block, re.M).group(1)
+harness = pathlib.Path(sys.argv[2])
+harness.write_text(harness.read_text().replace('/* MENU_FALLBACK_ENABLED */ false', binding))
+PY
 output="$(QT_QPA_PLATFORM=offscreen timeout 10 quickshell --no-color -p "$tmp/app-library-fallback-harness.qml" 2>&1)"
 printf '%s\n' "$output"
 if grep -F 'HARNESS_FAIL' <<<"$output" >/dev/null; then exit 1; fi

--- a/tests/app-library-fallback-integration-test.sh
+++ b/tests/app-library-fallback-integration-test.sh
@@ -10,17 +10,6 @@ fi
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 cp "$root/LauncherAppLibrary.qml" "$root"/tests/app-library-fallback-{fixture.qml,state.js,harness.qml} "$tmp/"
-python3 - "$root/Menu.qml" "$tmp/app-library-fallback-harness.qml" <<'PY'
-import pathlib
-import re
-import sys
-
-menu = pathlib.Path(sys.argv[1]).read_text()
-block = re.search(r'  LauncherAppLibrary \{.*?\n  \}', menu, re.S).group()
-binding = re.search(r'^    fallbackEnabled: (.+)$', block, re.M).group(1)
-harness = pathlib.Path(sys.argv[2])
-harness.write_text(harness.read_text().replace('/* MENU_FALLBACK_ENABLED */ false', binding))
-PY
 output="$(QT_QPA_PLATFORM=offscreen timeout 10 quickshell --no-color -p "$tmp/app-library-fallback-harness.qml" 2>&1)"
 printf '%s\n' "$output"
 if grep -F 'HARNESS_FAIL' <<<"$output" >/dev/null; then exit 1; fi


### PR DESCRIPTION
## Correction

Omalaunch now keeps its application-library fallback available if Omarchy destroys the injected shell API while the menu remains loaded. This addresses the empty Apps list and missing application search results reported in #75.

The unused fallback enable switch has been removed. The host's shared library still takes priority. The fallback loads only when no shared library is available and a service source is set. Menu destruction still releases the fallback and its launch feedback.

## Verification

- All local tests passed, including the shell-object destruction regression test.
- Desktop checks passed on Intel with Omarchy 4.0.3-1 and M1 with Omarchy 4.0.1-2: Apps, Apps search, root search, and reopening after a plugin rescan.
- No new dependencies or configuration changes are required.

## Update

```sh
omarchy plugin update quantumfire.omalaunch
omarchy restart shell
```

Restart the shell so the updated QML replaces the cached menu. Issue #75 remains open pending confirmation from the reporter.
