### PR TITLE
Dismiss the menu when clicking on another monitor

### DIFF
--- a/Menu.qml
+++ b/Menu.qml
@@ -4482,7 +4482,7 @@ Item {
     color: "transparent"
     WlrLayershell.namespace: "omarchy-menu"
     WlrLayershell.layer: WlrLayer.Overlay
-    WlrLayershell.keyboardFocus: WlrKeyboardFocus.Exclusive
+    WlrLayershell.keyboardFocus: WlrKeyboardFocus.OnDemand
     exclusionMode: ExclusionMode.Ignore
 
     // Keep the top edge fixed while result and submenu heights change.
@@ -4496,6 +4496,16 @@ Item {
     MouseArea {
       anchors.fill: parent
       onClicked: root.cancel()
+    }
+
+    // Exclusive keyboard focus makes Hyprland hold a seat grab for this surface,
+    // which silently discards pointer events on every other monitor -- the scrim
+    // above only covers the opening one. With OnDemand focus this grab routes
+    // input compositor-wide instead, so clicking away works from any monitor.
+    HyprlandFocusGrab {
+      active: panel.visible
+      windows: [panel]
+      onCleared: root.cancel()
     }
 
     BorderSurface {


### PR DESCRIPTION
## Problem

On a multi-monitor setup, clicking away to dismiss the menu only works if you click on the monitor the menu opened on. Clicking anywhere on any other monitor does nothing and the menu stays open.

## Cause

The menu's `PanelWindow` requests exclusive keyboard focus:

```qml
WlrLayershell.keyboardFocus: WlrKeyboardFocus.Exclusive
```

That makes Hyprland hold a seat grab for that surface. Pointer events outside the grabbing surface's geometry are discarded rather than routed onward, and a layer surface lives on exactly one output — so every click on any other monitor is dropped before anything can react to it.

This also explains why the existing scrim `MouseArea` works on the opening monitor: that click lands *inside* the grabbing surface.

The symptom is invisible on a single-monitor setup, where the grabbing surface covers the whole screen.

## Fix

Use `OnDemand` keyboard focus and dismiss via `HyprlandFocusGrab`, which is how Omarchy's own `Ui/PopupCard.qml` handles outside-click dismissal. The grab applies compositor-wide, so a click on any monitor clears it.

```qml
HyprlandFocusGrab {
  active: panel.visible
  windows: [panel]
  onCleared: root.cancel()
}
```

## Verification

Tested on Hyprland with two monitors (eDP-1 + HDMI-A-1, both scale 2), Quickshell 0.3.1, Omarchy `dev`:

- Clicking on the other monitor now dismisses the menu. Clicking the scrim on the opening monitor still dismisses as before.
- Keyboard input still reaches the menu without exclusive focus — sent keystrokes with `wtype` and confirmed `filterText` tracked `t` → `te` → `ter` → `term`.
- Repo test suite passes (`tests/manifest-test.sh` plus every `tests/*-test.js`, including `opening-screen-test.js`).

An intermediate attempt that added a catch-all surface on each other monitor is worth recording as evidence: that surface rendered and dimmed correctly but received **zero** pointer events, not even motion. A surface that paints yet gets no motion rules out input-region problems and points squarely at the seat grab.

## Caveat worth your judgement

`Exclusive` may have been deliberate, to guarantee the menu takes keyboard focus. With `OnDemand` the focus grab is what delivers it. I verified typing when opening over a normal window, but I did **not** test opening over a fullscreen window, or while another exclusive layer surface (lock screen, another launcher) holds focus. If `OnDemand` proves too weak there, the alternative is to keep `Exclusive` and give the menu a surface per monitor — heavier, but no change to the focus model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
